### PR TITLE
fix(release): restore cross-platform release flow and prep v0.0.94

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release-linux:
     permissions:
       contents: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +28,15 @@ jobs:
       - name: install dependencies (ubuntu)
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            patchelf
 
       - name: install frontend dependencies
         run: bun install
@@ -119,11 +127,6 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         with:
           projectPath: ./apps/desktop
           tagName: ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.0.94 - CI/Release Infrastructure Recovery
+
+**Date:** 2026-02-09
+
+**What happened between `v0.0.93` (`d596a4c`) and `master` (`df1d696`)**
+
+- `4ded3ed`: Updated README for `v0.0.93` release links and install docs.
+- `73fafbc`: Fixed CI failures in tests and Rust compile flow.
+- `6654232`: Unblocked Rust tests in GitHub Actions.
+- `20e0161`: Added PostgreSQL `initdb` path setup for `pgtemp` in CI.
+- `df1d696`: Final pipeline stabilization merged via PR #32.
+
+**Release pipeline fixes in `v0.0.94`**
+
+- Linux release runner moved to `ubuntu-latest` and updated Tauri v2 system dependencies (`webkit2gtk-4.1`, `javascriptcoregtk-4.1`, `libsoup-3.0`).
+- macOS release job now builds unsigned artifacts in CI by removing failing Apple signing environment wiring.
+- Windows packaging now links SQLite reliably by enabling `rusqlite` `bundled` feature to avoid missing `sqlite3.lib`.
+- Version metadata aligned to `0.0.94` for npm + Tauri config + in-app changelog.
+
 ## 0.0.92 - Docker Manager & UI Overhaul
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 Dora is natively available for **Linux**, **macOS**, and **Windows**. Pre-compiled binaries are available through the [releases](https://github.com/remcostoeten/dora/releases) page.
 
-### Latest Release: v0.0.93
+### Latest Release: v0.0.94
 
 **Features:** Drizzle-aware typo detection, light/dark theme toggle, SQL snippet saving, custom keyboard shortcuts, performance optimizations, and more.
 
@@ -38,28 +38,26 @@ Dora is natively available for **Linux**, **macOS**, and **Windows**. Pre-compil
 - **Linux**
   - `.deb` - Debian/Ubuntu (recommended for apt-based systems)
   - `.AppImage` - Universal Linux executable (works on most distributions)
-  - `.rpm` - Red Hat/Fedora/CentOS (for rpm-based systems)
 
 - **macOS**
   - `.dmg` - macOS installer (Intel & Apple Silicon support)
 
 - **Windows**
   - `.exe` - Windows installer (recommended)
-  - `.msi` - Alternative Windows installer option
 
-👉 **[Download Latest Release](https://github.com/remcostoeten/dora/releases/tag/v0.0.93)**
+👉 **[Download Latest Release](https://github.com/remcostoeten/dora/releases/tag/v0.0.94)**
 
 ### Installation by Platform
 
 #### Linux (Debian/Ubuntu)
 ```bash
 # Using .deb package
-sudo dpkg -i dora_0.0.93_amd64.deb
+sudo dpkg -i dora_0.0.94_amd64.deb
 dora
 
 # Or using AppImage
-chmod +x dora_0.0.93_x64.AppImage
-./dora_0.0.93_x64.AppImage
+chmod +x dora_0.0.94_x64.AppImage
+./dora_0.0.94_x64.AppImage
 ```
 
 #### macOS

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,27 @@
+# Release Notes - v0.0.94
+
+**Date:** 2026-02-09
+**Tag:** `v0.0.94`
+**Range:** `v0.0.93..master` (`d596a4c..df1d696`)
+
+## Summary
+
+This release focuses on CI and release pipeline reliability so all platform artifacts are generated again.
+
+## Changes since `v0.0.93`
+
+- Stabilized Rust test execution in CI.
+- Added `pgtemp` PostgreSQL `initdb` PATH wiring for GitHub runners.
+- Updated Linux release dependencies for Tauri v2.
+- Fixed Windows release linking by enabling bundled SQLite in `rusqlite`.
+- Adjusted macOS release configuration to avoid signing-env failure for unsigned CI builds.
+
+## Expected assets
+
+- Linux: `.deb`, `.AppImage`
+- macOS: `.dmg`
+- Windows: `.exe`
+
 # Release Notes - v0.0.9
 
 **Date:** 2026-01-15

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dora/desktop",
-	"version": "0.0.93",
+	"version": "0.0.94",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3038,6 +3038,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ rustls-native-certs = "0.8.1"
 webpki-roots = "1.0.2"
 tokio-postgres-rustls = "0.13.0"
 dirs = "6.0.0"
-rusqlite = { version = "0.37.0", features = ["column_decltype"] }
+rusqlite = { version = "0.37.0", features = ["column_decltype", "bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3.31"
 rustls-pemfile = "2.2.0"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ rustls-native-certs = "0.8.1"
 webpki-roots = "1.0.2"
 tokio-postgres-rustls = "0.13.0"
 dirs = "6.0.0"
-rusqlite = { version = "0.37.0", features = ["column_decltype", "bundled"] }
+rusqlite = { version = "0.37.0", features = ["column_decltype"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3.31"
 rustls-pemfile = "2.2.0"
@@ -71,6 +71,9 @@ rand = "0.9"
 bcrypt = "0.15"
 reqwest = { version = "0.12", features = ["json"] }
 tauri-plugin-shell = "2.3.4"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+rusqlite = { version = "0.37.0", features = ["column_decltype", "bundled"] }
 
 [profile.release]
 panic = "abort"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
 	"productName": "Dora",
-	"version": "0.0.93",
+	"version": "0.0.94",
 	"identifier": "com.Dora.dev",
 	"build": {
 		"frontendDist": "../dist",

--- a/apps/desktop/src/features/sidebar/changelog-data.ts
+++ b/apps/desktop/src/features/sidebar/changelog-data.ts
@@ -8,9 +8,26 @@ export type ChangelogEntry = {
 	details?: string[]
 }
 
-export const CURRENT_VERSION = '0.0.93'
+export const CURRENT_VERSION = '0.0.94'
 
 export const CHANGELOG: ChangelogEntry[] = [
+	{
+		version: '0.0.94',
+		date: '2026-02-09',
+		commit: 'df1d696',
+		title: 'CI, Test Stability & Cross-Platform Release Recovery',
+		description:
+			'Stabilized CI pipelines, fixed Rust test failures in GitHub Actions, and repaired cross-platform release workflow for Linux/macOS/Windows artifacts',
+		type: 'fix',
+		details: [
+			'Fixed CI Rust test failures caused by libsql threading behavior in tests',
+			'Added PostgreSQL initdb PATH setup for pgtemp in CI',
+			'Resolved rust/TypeScript compile and lint blockers in pipelines',
+			'Updated release Linux dependencies for Tauri v2 (webkit 4.1/libsoup 3.0)',
+			'Removed failing macOS signing env wiring for unsigned CI builds',
+			'Enabled bundled SQLite linking for Windows release builds'
+		]
+	},
 	{
 		version: '0.0.93',
 		date: '2026-02-06',

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,33 @@
+# Version 0.0.94
+
+**Date:** 2026-02-09
+**Tag:** `v0.0.94`
+**Range:** `d596a4c..df1d696` + release infrastructure fixes in this release prep
+
+## Why this release exists
+
+`v0.0.93` was tagged on 2026-02-06 but did not produce a GitHub release because all release workflow jobs failed (Linux dependency mismatch, Windows sqlite link failure, macOS signing import failure). `v0.0.94` restores a reliable cross-platform release flow.
+
+## Commits since `v0.0.93`
+
+- `4ded3ed` docs: update README with `v0.0.93` download links
+- `73fafbc` fix(ci): resolve failing tests and rust compile issues
+- `6654232` fix(ci): unblock rust tests in GitHub Actions
+- `20e0161` fix(ci): add postgres initdb bin path for pgtemp tests
+- `df1d696` fix(ci): resolve pipeline failures (#32)
+
+## Infrastructure fixes for release generation
+
+- Linux release dependencies updated for Tauri v2 (`libwebkit2gtk-4.1-dev`, `libsoup-3.0-dev`, `libjavascriptcoregtk-4.1-dev`, etc.).
+- Windows SQLite linkage stabilized by enabling `rusqlite` `bundled`.
+- macOS release flow adjusted to produce unsigned CI artifacts without failing keychain import.
+
+## Expected assets
+
+- Linux: `.deb`, `.AppImage`
+- macOS: `.dmg`
+- Windows: `.exe` (NSIS)
+
 # Version 0.0.92
 
 ## Features


### PR DESCRIPTION
## Summary
- fix Linux release dependencies for Tauri v2 on GitHub runners
- fix Windows release linking by enabling bundled SQLite in rusqlite
- remove failing macOS signing env wiring for unsigned CI artifact generation
- bump desktop version metadata to 0.0.94
- document changes since v0.0.93 in changelog/release notes

## Verification
- bun run test:desktop (pass)
- bun run lint (pass with existing warnings)
- bun run build (pass)
- cargo dependency graph confirms rusqlite bundled/libsqlite3-sys bundled enabled

## Notes
- local cargo test --lib is not runnable in this environment due missing system pkg-config/GTK stack, but CI/release workflows install required packages

## Summary by Sourcery

Recover cross-platform desktop release generation for v0.0.94 and align versioning and documentation with the new release.

Bug Fixes:
- Restore Linux desktop release builds by updating GitHub runner image and Tauri v2 system dependencies.
- Fix Windows desktop release builds by switching rusqlite to use bundled SQLite for reliable linking.
- Unblock macOS desktop release artifacts by removing failing signing-related environment configuration in the CI workflow.

Enhancements:
- Stabilize CI pipelines and Rust tests, including PostgreSQL pgtemp initdb PATH wiring on GitHub runners.
- Update in-app changelog sidebar data to include the 0.0.94 entry summarizing CI, test, and release recovery work.

Build:
- Bump desktop app version metadata to 0.0.94 across package.json, Tauri config, and docs.

CI:
- Adjust GitHub Actions release workflow for Linux, macOS, and Windows to generate expected artifacts consistently.

Documentation:
- Add 0.0.94 sections to CHANGELOG and release notes, and update README to reference the new release tag, assets, and install commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to v0.0.94
  * Updated documentation and changelog
  * Enhanced CI/release infrastructure for improved build stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->