### PR TITLE
Add Vercel Speed Insights to desktop app layout

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -41,6 +41,7 @@
 		"@tauri-apps/plugin-dialog": "^2.6.0",
 		"@tauri-apps/plugin-fs": "^2.4.5",
 		"@tauri-apps/plugin-shell": "^2.3.4",
+		"@vercel/speed-insights": "^1.2.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"date-fns": "^3.6.0",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { SpeedInsights } from '@vercel/speed-insights/react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { DemoBanner } from '@/components/demo-banner'
 import { Toaster as Sonner } from '@/components/ui/sonner'
@@ -33,6 +34,7 @@ function App() {
 					<PendingEditsProvider>
 						<DataProvider>
 							<QueryHistoryProvider>
+								<SpeedInsights />
 								<RecordingOverlay />
 								<div className='flex flex-col h-screen'>
 									<DemoBanner />


### PR DESCRIPTION
### Motivation
- Integrate Vercel Speed Insights into the desktop application to enable performance telemetry and local profiling in the app layout.
- Keep the change minimal and focused on wiring the insights component into the root layout so it can collect metrics across routes.

### Description
- Add the `@vercel/speed-insights` dependency to `apps/desktop/package.json`.
- Import `SpeedInsights` from `@vercel/speed-insights/react` in `apps/desktop/src/App.tsx`.
- Render `<SpeedInsights />` inside the root layout (before the `RecordingOverlay`) so it initializes for the whole app.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698892eaf1ac8327bea501630ad74638)

## Summary by Sourcery

Integrate Vercel Speed Insights into the desktop app layout to enable performance telemetry across the application.

Enhancements:
- Render the SpeedInsights component in the root desktop app layout so performance metrics are collected application-wide.

Build:
- Add @vercel/speed-insights dependency to the desktop app package configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated performance monitoring and insights to track application performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->