### PR TITLE
Fix desktop TypeScript test failures

### DIFF
--- a/__tests__/apps/desktop/src/features/database-studio/hooks/use-live-monitor.test.ts
+++ b/__tests__/apps/desktop/src/features/database-studio/hooks/use-live-monitor.test.ts
@@ -1,18 +1,10 @@
-import { renderHook, act, waitFor } from '@testing-library/react'
+import { renderHook, act } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { useLiveMonitor } from '@/features/database-studio/hooks/use-live-monitor'
 
 const mocks = vi.hoisted(function () {
 	return {
-		listen: vi.fn(),
 		startLiveMonitor: vi.fn(),
 		stopLiveMonitor: vi.fn()
-	}
-})
-
-vi.mock('@tauri-apps/api/event', function () {
-	return {
-		listen: mocks.listen
 	}
 })
 
@@ -30,12 +22,7 @@ describe('useLiveMonitor', function () {
 
 	beforeEach(function () {
 		backendListener = null
-		mocks.listen.mockImplementation(function (_eventName, handler) {
-			backendListener = handler
-			return Promise.resolve(function () {
-				backendListener = null
-			})
-		})
+		vi.resetModules()
 		mocks.startLiveMonitor.mockResolvedValue({
 			status: 'ok',
 			data: {
@@ -45,23 +32,43 @@ describe('useLiveMonitor', function () {
 		})
 		mocks.stopLiveMonitor.mockResolvedValue({ status: 'ok', data: null })
 
-		Object.defineProperty(window, '__TAURI__', {
-			value: {},
+		Object.defineProperty(window, '__TAURI_INTERNALS__', {
+			value: {
+				transformCallback(handler: (event: { payload: any }) => void) {
+					backendListener = handler
+					return 1
+				},
+				unregisterCallback: vi.fn(),
+				invoke: vi.fn(async function (command: string) {
+					if (command === 'plugin:event|listen') {
+						return 1
+					}
+					if (command === 'plugin:event|unlisten') {
+						backendListener = null
+						return null
+					}
+					return null
+				})
+			},
 			configurable: true
 		})
-		delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+		Object.defineProperty(window, '__TAURI_EVENT_PLUGIN_INTERNALS__', {
+			value: {
+				unregisterListener: vi.fn()
+			},
+			configurable: true
+		})
 		vi.useFakeTimers()
 	})
 
 	afterEach(function () {
 		vi.runOnlyPendingTimers()
 		vi.useRealTimers()
-		delete (window as unknown as Record<string, unknown>).__TAURI__
-		delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
 		vi.clearAllMocks()
 	})
 
 	it('batches backend change events into a single refresh callback', async function () {
+		const { useLiveMonitor } = await import('@/features/database-studio/hooks/use-live-monitor')
 		const onDataChanged = vi.fn()
 
 		const { result } = renderHook(function () {
@@ -82,9 +89,11 @@ describe('useLiveMonitor', function () {
 			})
 		})
 
-		await waitFor(function () {
-			expect(mocks.startLiveMonitor).toHaveBeenCalledTimes(1)
+		await act(async function () {
+			await Promise.resolve()
 		})
+
+		expect(mocks.startLiveMonitor).toHaveBeenCalledTimes(1)
 
 		await act(async function () {
 			backendListener?.({

--- a/__tests__/apps/desktop/src/features/sql-console/components/sql-results.test.tsx
+++ b/__tests__/apps/desktop/src/features/sql-console/components/sql-results.test.tsx
@@ -61,7 +61,14 @@ describe('SqlResults', function () {
 
 		fireEvent.doubleClick(screen.getByText('Bob'))
 
-		const input = screen.getByDisplayValue('Bob')
+		const input = screen
+			.getAllByDisplayValue('Bob')
+			.find((element) => element.getAttribute('placeholder') !== 'Filter results...')
+
+		expect(input).toBeTruthy()
+		if (!input) {
+			throw new Error('Expected inline editor input to be rendered')
+		}
 		fireEvent.change(input, { target: { value: 'Bobby' } })
 		fireEvent.keyDown(input, { key: 'Enter' })
 

--- a/apps/desktop/src/features/connections/validation.ts
+++ b/apps/desktop/src/features/connections/validation.ts
@@ -21,18 +21,26 @@ export const libsqlConnectionSchema = baseConnectionSchema.extend({
 	authToken: z.string().optional(),
 })
 
-export const connectionStringSchema = baseConnectionSchema.extend({
-	type: z.enum(['postgres', 'mysql']),
+export const postgresConnectionStringSchema = baseConnectionSchema.extend({
+	type: z.literal('postgres'),
 	url: z
 		.string()
 		.min(1, 'Connection string is required')
 		.refine(
-			(val) =>
-				val.startsWith('postgres://') ||
-				val.startsWith('postgresql://') ||
-				val.startsWith('mysql://'),
+			(val) => val.startsWith('postgres://') || val.startsWith('postgresql://'),
 			'Invalid connection string format'
 		),
+})
+
+export const mysqlConnectionStringSchema = baseConnectionSchema.extend({
+	type: z.literal('mysql'),
+	url: z
+		.string()
+		.min(1, 'Connection string is required')
+		.refine(
+			(val) => val.startsWith('mysql://'),
+			'Invalid connection string format'
+		)
 })
 
 export const connectionFieldsSchema = baseConnectionSchema.extend({
@@ -94,7 +102,11 @@ export function validateConnection(
 			libsqlConnectionSchema.parse(formData)
 		} else if (type === 'postgres' || type === 'mysql') {
 			if (useConnectionString) {
-				connectionStringSchema.parse(formData)
+				if (type === 'postgres') {
+					postgresConnectionStringSchema.parse(formData)
+				} else {
+					mysqlConnectionStringSchema.parse(formData)
+				}
 			} else {
 				connectionFieldsSchema.parse(formData)
 			}


### PR DESCRIPTION
## Summary
- tighten MySQL connection-string validation so MySQL rejects PostgreSQL URLs
- update the live monitor hook test to mock the current Tauri event runtime correctly
- make the SQL results test target the inline editor instead of the filter field

## Verification
- bun run test:desktop -- __tests__/apps/desktop/src/features/connections/mysql-validation.test.ts __tests__/apps/desktop/src/features/database-studio/hooks/use-live-monitor.test.ts __tests__/apps/desktop/src/features/sql-console/components/sql-results.test.tsx
- bun run test:desktop

## Summary by Sourcery

Fix desktop test failures around MySQL connection string validation, live monitor event handling, and SQL results inline editing.

Bug Fixes:
- Ensure MySQL connection string validation rejects non-MySQL URLs such as PostgreSQL connection strings.
- Update the live monitor hook test to correctly mock the current Tauri event runtime and asynchronous behavior.
- Adjust the SQL results component test to target the inline cell editor instead of the filter input when editing values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for database connection strings.

* **Refactor**
  * Improved internal test reliability for live monitoring functionality.
  * Refined test assertions for SQL result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->