### PR TITLE
refactor(backend): add tracing + spans (phase 6)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.0.105"
+version = "0.0.106"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -177,6 +177,9 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
  "url",
  "uuid",
  "webpki-roots 1.0.4",
@@ -3150,6 +3153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,6 +3405,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5243,6 +5264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6053,6 +6083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6523,6 +6562,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -6740,6 +6809,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -19,6 +19,9 @@ tauri-build = { version = "2.3.1", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-log = "0.2"
 tauri = { version = "2.8.0", features = ["macos-private-api"] }
 tauri-plugin-log = "2"
 thiserror = "2.0.12"

--- a/apps/desktop/src-tauri/src/database/live_monitor.rs
+++ b/apps/desktop/src-tauri/src/database/live_monitor.rs
@@ -8,6 +8,7 @@ use std::{
 use base64::Engine;
 use dashmap::DashMap;
 use futures_util::future::poll_fn;
+use tracing::instrument;
 use rusqlite::types::ValueRef;
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -93,6 +94,7 @@ impl LiveMonitorManager {
         }
     }
 
+    #[instrument(skip(self, change_types), fields(connection_id = %connection_id, table = %table_name, interval_ms))]
     pub fn start_monitor(
         &self,
         connection_id: Uuid,

--- a/apps/desktop/src-tauri/src/database/services/connection.rs
+++ b/apps/desktop/src-tauri/src/database/services/connection.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Context;
 use dashmap::DashMap;
 use mysql_async::prelude::Queryable;
+use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -23,6 +24,7 @@ pub struct ConnectionService<'a> {
 }
 
 impl<'a> ConnectionService<'a> {
+    #[instrument(skip(self, database_info))]
     pub async fn add_connection(
         &self,
         name: String,
@@ -50,6 +52,7 @@ impl<'a> ConnectionService<'a> {
         Ok(info)
     }
 
+    #[instrument(skip(self, database_info), fields(conn_id = %conn_id))]
     pub async fn update_connection(
         &self,
         conn_id: Uuid,
@@ -246,6 +249,7 @@ impl<'a> ConnectionService<'a> {
         Ok(())
     }
 
+    #[instrument(skip(self, monitor, certificates), fields(connection_id = %connection_id))]
     pub async fn connect_to_database(
         &self,
         monitor: &ConnectionMonitor,
@@ -508,6 +512,7 @@ impl<'a> ConnectionService<'a> {
         }
     }
 
+    #[instrument(skip(self), fields(connection_id = %connection_id))]
     pub async fn disconnect_from_database(
         &self,
         connection_id: Uuid,
@@ -668,6 +673,7 @@ impl<'a> ConnectionService<'a> {
 
 // Static method that doesn't need state
 impl ConnectionService<'_> {
+    #[instrument(skip(database_info, certificates))]
     pub async fn test_connection(
         database_info: DatabaseInfo,
         certificates: &Certificates,

--- a/apps/desktop/src-tauri/src/database/services/mutation.rs
+++ b/apps/desktop/src-tauri/src/database/services/mutation.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use anyhow::{Context, anyhow};
 use dashmap::DashMap;
+use tracing::instrument;
 use uuid::Uuid;
 use serde::{Deserialize, Serialize};
 use base64::Engine;
@@ -40,6 +41,7 @@ pub struct MutationService<'a> {
 }
 
 impl<'a> MutationService<'a> {
+    #[instrument(skip(self, primary_key_value, new_value), fields(connection_id = %connection_id, table = %table_name))]
     pub async fn update_cell(
         &self,
         connection_id: Uuid,
@@ -114,6 +116,7 @@ impl<'a> MutationService<'a> {
         })
     }
 
+    #[instrument(skip(self, primary_key_values), fields(connection_id = %connection_id, table = %table_name))]
     pub async fn delete_rows(
         &self,
         connection_id: Uuid,
@@ -237,6 +240,7 @@ impl<'a> MutationService<'a> {
         })
     }
 
+    #[instrument(skip(self, row_data), fields(connection_id = %connection_id, table = %table_name))]
     pub async fn insert_row(
         &self,
         connection_id: Uuid,
@@ -946,6 +950,7 @@ impl<'a> MutationService<'a> {
         }
     }
 
+    #[instrument(skip(self, statements), fields(connection_id = %connection_id, count = statements.len()))]
     pub async fn execute_batch(
         &self,
         connection_id: Uuid,

--- a/apps/desktop/src-tauri/src/database/services/query.rs
+++ b/apps/desktop/src-tauri/src/database/services/query.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 use anyhow::Context;
 use dashmap::DashMap;
+use tracing::instrument;
 use uuid::Uuid;
 use serde_json::value::RawValue;
 
@@ -142,6 +143,7 @@ impl<'a> QueryService<'a> {
         Ok(filtered)
     }
 
+    #[instrument(skip(self, query), fields(connection_id = %connection_id))]
     pub async fn start_query(
         &self,
         connection_id: Uuid,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub mod credentials;
 pub mod database;
 mod error;
 mod init;
+mod observability;
 mod storage;
 mod test_queries;
 pub mod utils;
@@ -63,6 +64,9 @@ impl AppState {
 #[allow(clippy::missing_panics_doc)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Set up `tracing` before anything else so startup events are captured.
+    observability::init();
+
     // Install ring as the default crypto provider for rustls
     rustls::crypto::ring::default_provider()
         .install_default()

--- a/apps/desktop/src-tauri/src/observability.rs
+++ b/apps/desktop/src-tauri/src/observability.rs
@@ -1,0 +1,33 @@
+//! Tracing subscriber bootstrap.
+//!
+//! Initialises a global `tracing` subscriber for the app. The `log` crate is
+//! bridged through `tracing-log` so existing `log::info!`/`log::error!` call
+//! sites emit as `tracing` events without a mass find-replace.
+//!
+//! Filter rules via `RUST_LOG`, e.g. `RUST_LOG=debug,hyper=info bun tauri:dev`.
+//! Default filter is `info` for the `app` crate and `warn` elsewhere.
+
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+/// Must be called exactly once, before `tauri::Builder::default().run()`.
+/// Second call is a no-op (returns `Err` from `set_global_default`).
+pub fn init() {
+    let default_filter = "info,app=debug";
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(default_filter));
+
+    let fmt_layer = fmt::layer()
+        .with_target(true)
+        .with_thread_ids(false)
+        .with_thread_names(false)
+        .with_file(false)
+        .with_line_number(false);
+
+    let registry = tracing_subscriber::registry().with(filter).with(fmt_layer);
+
+    if registry.try_init().is_ok() {
+        // Bridge `log` crate calls into the tracing subscriber. Done after
+        // init so tracing's own logs don't trigger re-entrance.
+        let _ = tracing_log::LogTracer::init();
+    }
+}


### PR DESCRIPTION
## Summary
- Bootstrap `tracing` subscriber in new `observability.rs` — `EnvFilter` from `RUST_LOG`, bridges `log::` crate via `LogTracer` (no find-replace at existing call sites)
- `#[instrument]` on hot-path service methods: connect, disconnect, test_connection, update_cell, delete_rows, insert_row, execute_batch, start_query, start_monitor
- All spans skip sensitive/large params and record key fields (`connection_id`, `table`, `count`)

## Test plan
- [ ] `RUST_LOG=debug bun tauri dev` — verify structured span output in terminal
- [ ] `RUST_LOG=info` (default) — only connection-level events visible, no noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce centralized observability by initializing a global tracing subscriber and instrumenting core database operations with structured spans.

New Features:
- Add an observability module that configures a global tracing subscriber with env-based filtering and log crate bridging.

Enhancements:
- Instrument key database service methods and live monitor operations with tracing spans that capture connection, table, and batch metadata while skipping sensitive payloads.
- Wire observability initialization into the Tauri app startup so application lifecycle events are captured early.

Build:
- Add tracing, tracing-subscriber, and tracing-log dependencies to the desktop Tauri crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging and tracing infrastructure across database services to improve system observability, monitoring, and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->