### PR TITLE
refactor(backend): kill production unwraps, add clippy enforcement (phase 7)

### DIFF
--- a/apps/desktop/src-tauri/src/database/adapter/read.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/read.rs
@@ -141,7 +141,7 @@ impl DatabaseAdapter for SqliteAdapter {
         let sender = sender.clone();
 
         tauri::async_runtime::spawn_blocking(move || {
-            let conn = conn.lock().unwrap();
+            let conn = conn.lock().expect("Mutex poisoned");
             crate::database::sqlite::execute::execute_query(&conn, stmt, &sender)
         })
         .await

--- a/apps/desktop/src-tauri/src/database/postgres/row_writer.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/row_writer.rs
@@ -75,7 +75,7 @@ impl RowWriter {
         let json = std::mem::take(&mut self.buf);
         self.row_count = 0;
 
-        RawValue::from_string(json).unwrap()
+        RawValue::from_string(json).expect("hand-built JSON is valid")
     }
 
     fn write_pg_value_as_json(
@@ -246,7 +246,7 @@ impl RowWriter {
                 '\r' => self.buf.push_str("\\r"),
                 '\t' => self.buf.push_str("\\t"),
                 c if c.is_control() => {
-                    write!(&mut self.buf, "\\u{:04x}", c as u32).unwrap();
+                    write!(&mut self.buf, "\\u{:04x}", c as u32).expect("write to String buf");
                 }
                 c => self.buf.push(c),
             }

--- a/apps/desktop/src-tauri/src/database/postgres/tls.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/tls.rs
@@ -49,7 +49,7 @@ impl Certificates {
         }
 
         // Safety: `initialized` just returned true
-        Ok(self.certs.get().unwrap().clone())
+        Ok(self.certs.get().expect("initialized is true").clone())
     }
 }
 

--- a/apps/desktop/src-tauri/src/database/services/metadata.rs
+++ b/apps/desktop/src-tauri/src/database/services/metadata.rs
@@ -97,7 +97,7 @@ impl<'a> MetadataService<'a> {
                 connection: Some(conn),
             } => {
                 let mut meta = metadata::get_sqlite_metadata(db_path)?;
-                let conn_guard = conn.lock().unwrap();
+                let conn_guard = conn.lock().map_err(|_| Error::Internal("Mutex poisoned".into()))?;
                 let (table_count, row_count) = metadata::get_sqlite_counts(&conn_guard)?;
                 meta.table_count = table_count;
                 meta.row_count_total = row_count;

--- a/apps/desktop/src-tauri/src/database/services/mutation.rs
+++ b/apps/desktop/src-tauri/src/database/services/mutation.rs
@@ -170,7 +170,7 @@ impl<'a> MutationService<'a> {
                 client.execute(&query, &params_ref[..]).await? as usize
             }
             DatabaseClient::SQLite { connection } => {
-                let conn = connection.lock().unwrap();
+                let conn = connection.lock().map_err(|_| crate::Error::Internal("Mutex poisoned".into()))?;
 
                 let placeholders: Vec<&str> = primary_key_values.iter().map(|_| "?").collect();
                 let query = format!(
@@ -306,7 +306,7 @@ impl<'a> MutationService<'a> {
                 (rows as usize, format!("Inserted {} row(s)", rows))
             }
             DatabaseClient::SQLite { connection } => {
-                let conn = connection.lock().unwrap();
+                let conn = connection.lock().map_err(|_| crate::Error::Internal("Mutex poisoned".into()))?;
                 let col_names: String = columns.iter()
                     .map(|c| format!("\"{}\"", c))
                     .collect::<Vec<_>>()
@@ -447,7 +447,7 @@ impl<'a> MutationService<'a> {
                 data
             }
             DatabaseClient::SQLite { connection } => {
-                let conn = connection.lock().unwrap();
+                let conn = connection.lock().map_err(|_| crate::Error::Internal("Mutex poisoned".into()))?;
                 let query = format!(
                     "SELECT * FROM \"{table_name}\" WHERE \"{primary_key_column}\" = ? LIMIT 1"
                 );
@@ -746,7 +746,7 @@ impl<'a> MutationService<'a> {
                 ).await
             }
             DatabaseClient::SQLite { connection } => {
-                let conn = connection.lock().unwrap();
+                let conn = connection.lock().map_err(|_| crate::Error::Internal("Mutex poisoned".into()))?;
                 maintenance::soft_delete_sqlite(
                     &conn,
                     &table_name,
@@ -842,7 +842,7 @@ impl<'a> MutationService<'a> {
                 ).await?
             }
             DatabaseClient::SQLite { connection } => {
-                let conn = connection.lock().unwrap();
+                let conn = connection.lock().map_err(|_| crate::Error::Internal("Mutex poisoned".into()))?;
                 maintenance::truncate_table_sqlite(&conn, &table_name)?
             }
             DatabaseClient::LibSQL { connection } => {
@@ -930,7 +930,7 @@ impl<'a> MutationService<'a> {
                 ).await
             }
             DatabaseClient::SQLite { connection } => {
-                let conn = connection.lock().unwrap();
+                let conn = connection.lock().map_err(|_| crate::Error::Internal("Mutex poisoned".into()))?;
                 maintenance::dump_database_sqlite(&conn, &output_path)
             }
             DatabaseClient::LibSQL { connection } => {
@@ -994,7 +994,7 @@ impl<'a> MutationService<'a> {
                  }
             }
             DatabaseClient::SQLite { connection } => {
-                let mut conn = connection.lock().unwrap();
+                let mut conn = connection.lock().map_err(|_| crate::Error::Internal("Mutex poisoned".into()))?;
                 let tx = conn.transaction()?;
                 for stmt in &statements {
                     let rows = tx.execute(stmt.as_str(), [])?;
@@ -1083,7 +1083,7 @@ fn execute_sqlite_update(
     pk_value: &serde_json::Value,
 ) -> Result<usize, Error> {
     if let DatabaseClient::SQLite { connection } = client {
-        let conn = connection.lock().unwrap();
+        let conn = connection.lock().map_err(|_| crate::Error::Internal("Mutex poisoned".into()))?;
         let new_val = json_to_sqlite_value(new_value);
         let pk_val = json_to_sqlite_value(pk_value);
 
@@ -1265,7 +1265,7 @@ fn fetch_sqlite_data(
     query: &str,
 ) -> Result<(Vec<String>, Vec<Vec<serde_json::Value>>), Error> {
     if let DatabaseClient::SQLite { connection } = client {
-        let conn = connection.lock().unwrap();
+        let conn = connection.lock().map_err(|_| crate::Error::Internal("Mutex poisoned".into()))?;
         let mut stmt = conn.prepare(query)?;
         let columns: Vec<String> = stmt
             .column_names()

--- a/apps/desktop/src-tauri/src/database/sqlite/row_writer.rs
+++ b/apps/desktop/src-tauri/src/database/sqlite/row_writer.rs
@@ -101,7 +101,7 @@ impl RowWriter {
         let json = std::mem::take(&mut self.buf);
         self.row_count = 0;
 
-        RawValue::from_string(json).unwrap()
+        RawValue::from_string(json).expect("hand-built JSON is valid")
     }
 
     fn write_json_string(&mut self, s: &str) {
@@ -114,7 +114,7 @@ impl RowWriter {
                 '\r' => self.buf.push_str("\\r"),
                 '\t' => self.buf.push_str("\\t"),
                 c if c.is_control() => {
-                    write!(&mut self.buf, "\\u{:04x}", c as u32).unwrap();
+                    write!(&mut self.buf, "\\u{:04x}", c as u32).expect("write to String buf");
                 }
                 c => self.buf.push(c),
             }

--- a/apps/desktop/src-tauri/src/database/ssh_tunnel.rs
+++ b/apps/desktop/src-tauri/src/database/ssh_tunnel.rs
@@ -138,7 +138,7 @@ impl SshTunnel {
     fn forward_stream(mut stream: TcpStream, sess: Arc<std::sync::Mutex<Session>>, remote_host: &str, remote_port: u16) -> Result<()> {
         // Lock session to create channel
         let mut channel = {
-            let sess_guard = sess.lock().unwrap();
+            let sess_guard = sess.lock().map_err(|_| anyhow::anyhow!("SSH session Mutex poisoned"))?;
             sess_guard.channel_direct_tcpip(remote_host, remote_port, None)
                 .context("Failed to create SSH channel")?
         };

--- a/apps/desktop/src-tauri/src/database/stmt_manager.rs
+++ b/apps/desktop/src-tauri/src/database/stmt_manager.rs
@@ -159,7 +159,7 @@ impl StatementManager {
             }
             DatabaseClient::SQLite { connection } => {
                 spawn_blocking(move || {
-                    let conn = connection.lock().unwrap();
+                    let conn = connection.lock().expect("Mutex poisoned");
                     if let Err(err) = sqlite::execute::execute_query(&conn, stmt, &sender) {
                         log::error!("Error executing SQLite query: {}", err);
                     }
@@ -194,13 +194,13 @@ impl StatementManager {
             while let Some(event) = recv.recv().await {
                 match event {
                     QueryExecEvent::TypesResolved { columns } => {
-                        *exec_storage.columns.write().unwrap() = Some(columns);
+                        *exec_storage.columns.write().expect("RwLock poisoned") = Some(columns);
                     }
                     QueryExecEvent::Page {
                         page_amount: _,
                         page,
                     } => {
-                        exec_storage.pages.write().unwrap().push(page);
+                        exec_storage.pages.write().expect("RwLock poisoned").push(page);
 
                         // TODO(vini): emit progress event to frontend?
                     }
@@ -210,7 +210,7 @@ impl StatementManager {
                         error,
                     } => {
                         if let Some(err) = error {
-                            *exec_storage.error.write().unwrap() = Some(err);
+                            *exec_storage.error.write().expect("RwLock poisoned") = Some(err);
                             exec_storage
                                 .status
                                 .store(QueryStatus::Error as u8, Ordering::Relaxed);
@@ -219,7 +219,7 @@ impl StatementManager {
                                 .status
                                 .store(QueryStatus::Completed as u8, Ordering::Relaxed);
 
-                            *exec_storage.rows_affected.write().unwrap() = Some(affected_rows);
+                            *exec_storage.rows_affected.write().expect("RwLock poisoned") = Some(affected_rows);
                         }
 
                         // TODO(vini): emit completion event to frontend?

--- a/apps/desktop/src-tauri/src/init.rs
+++ b/apps/desktop/src-tauri/src/init.rs
@@ -29,7 +29,7 @@ pub fn build_window(app: &tauri::App) -> tauri::Result<()> {
     let splash_window = WebviewWindowBuilder::new(
         app,
         "splash",
-        tauri::WebviewUrl::App("about:blank".parse().unwrap())
+        tauri::WebviewUrl::App("about:blank".parse().expect("static URL is valid"))
     )
     .title("Dora")
     .inner_size(500.0, 500.0)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
 mod bindings;
 pub mod commands_system;
 pub mod credentials;

--- a/apps/desktop/src-tauri/src/storage/connection_history.rs
+++ b/apps/desktop/src-tauri/src/storage/connection_history.rs
@@ -5,7 +5,7 @@ use crate::Result;
 
 impl Storage {
     pub fn save_connection_history(&self, entry: &ConnectionHistoryEntry) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         conn.execute(
             "INSERT INTO connection_history
              (connection_id, connection_name, database_type, attempted_at, success, error_message, duration_ms)
@@ -31,7 +31,7 @@ impl Storage {
         limit: Option<i64>,
     ) -> Result<Vec<ConnectionHistoryEntry>> {
         let limit = limit.unwrap_or(50);
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
 
         match (db_type_filter, success_filter) {
             (Some(db_type), Some(success)) => {

--- a/apps/desktop/src-tauri/src/storage/connections.rs
+++ b/apps/desktop/src-tauri/src/storage/connections.rs
@@ -11,7 +11,7 @@ use crate::{database::types::ConnectionInfo, Result};
 impl Storage {
     pub fn save_connection(&self, connection: &ConnectionInfo) -> Result<()> {
         let now = chrono::Utc::now().timestamp();
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
 
         let (db_type_id, connection_data) = serialize_connection_data(&connection.database_type)?;
 
@@ -40,7 +40,7 @@ impl Storage {
 
     pub fn update_connection(&self, connection: &ConnectionInfo) -> Result<()> {
         let now = chrono::Utc::now().timestamp();
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
 
         let (db_type_id, connection_data) = serialize_connection_data(&connection.database_type)?;
 
@@ -74,7 +74,7 @@ impl Storage {
     }
 
     pub fn get_connection(&self, connection_id: &Uuid) -> Result<Option<ConnectionInfo>> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         let mut stmt = conn
             .prepare(
                 "SELECT c.id, c.name, c.connection_data,
@@ -131,7 +131,7 @@ impl Storage {
     }
 
     pub fn get_connections(&self) -> Result<Vec<ConnectionInfo>> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         let mut stmt = conn
             .prepare(
                 "SELECT c.id, c.name, c.connection_data,
@@ -188,7 +188,7 @@ impl Storage {
     }
 
     pub fn remove_connection(&self, connection_id: &Uuid) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         conn.execute(
             "DELETE FROM connections WHERE id = ?1",
             [connection_id.to_string()],
@@ -199,7 +199,7 @@ impl Storage {
 
     pub fn update_last_connected(&self, connection_id: &Uuid) -> Result<()> {
         let now = chrono::Utc::now().timestamp();
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         conn.execute(
             "UPDATE connections SET last_connected_at = ?1 WHERE id = ?2",
             (now, connection_id.to_string()),

--- a/apps/desktop/src-tauri/src/storage/queries.rs
+++ b/apps/desktop/src-tauri/src/storage/queries.rs
@@ -10,7 +10,7 @@ use crate::Result;
 
 impl Storage {
     pub fn save_query_history(&self, entry: &QueryHistoryEntry) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         conn.execute(
             "INSERT INTO query_history
              (connection_id, query_text, executed_at, duration_ms, status, row_count, error_message)
@@ -35,7 +35,7 @@ impl Storage {
         limit: Option<i64>,
     ) -> Result<Vec<QueryHistoryEntry>> {
         let limit = limit.unwrap_or(100);
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         let mut stmt = conn.prepare(
             "SELECT id, connection_id, query_text, executed_at, duration_ms, status, row_count, error_message
              FROM query_history
@@ -69,7 +69,7 @@ impl Storage {
 
     pub fn save_query(&self, query: &SavedQuery) -> Result<i64> {
         let now = chrono::Utc::now().timestamp();
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
 
         if query.id == 0 {
             conn.execute(
@@ -121,7 +121,7 @@ impl Storage {
     }
 
     pub fn get_saved_queries(&self, connection_id: Option<&Uuid>) -> Result<Vec<SavedQuery>> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
 
         let mut queries = Vec::new();
 
@@ -218,7 +218,7 @@ impl Storage {
     }
 
     pub fn delete_saved_query(&self, id: i64) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         conn.execute("DELETE FROM saved_queries WHERE id = ?1", [id])
             .context("Failed to delete saved query")?;
         Ok(())

--- a/apps/desktop/src-tauri/src/storage/settings.rs
+++ b/apps/desktop/src-tauri/src/storage/settings.rs
@@ -5,7 +5,7 @@ use crate::Result;
 
 impl Storage {
     pub fn get_setting(&self, key: &str) -> Result<Option<String>> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         let mut stmt = conn
             .prepare("SELECT value FROM app_settings WHERE key = ?1")
             .context("Failed to prepare settings statement")?;
@@ -22,7 +22,7 @@ impl Storage {
 
     pub fn set_setting(&self, key: &str, value: &str) -> Result<()> {
         let now = chrono::Utc::now().timestamp();
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         conn.execute(
             "INSERT OR REPLACE INTO app_settings (key, value, updated_at) VALUES (?1, ?2, ?3)",
             (key, value, now),

--- a/apps/desktop/src-tauri/src/storage/snippet_folders.rs
+++ b/apps/desktop/src-tauri/src/storage/snippet_folders.rs
@@ -5,7 +5,7 @@ use crate::Result;
 
 impl Storage {
     pub fn get_snippet_folders(&self) -> Result<Vec<SnippetFolder>> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         let mut stmt = conn
             .prepare(
                 "SELECT id, name, parent_id, color, created_at, updated_at
@@ -41,7 +41,7 @@ impl Storage {
         color: Option<&str>,
     ) -> Result<i64> {
         let now = chrono::Utc::now().timestamp();
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
 
         conn.execute(
             "INSERT INTO snippet_folders (name, parent_id, color, created_at, updated_at)
@@ -60,7 +60,7 @@ impl Storage {
         color: Option<&str>,
     ) -> Result<()> {
         let now = chrono::Utc::now().timestamp();
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
 
         conn.execute(
             "UPDATE snippet_folders SET name = ?1, color = ?2, updated_at = ?3 WHERE id = ?4",
@@ -72,7 +72,7 @@ impl Storage {
     }
 
     pub fn delete_snippet_folder(&self, id: i64) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
         // First set folder_id to NULL for all snippets in this folder.
         conn.execute(
             "UPDATE saved_queries SET folder_id = NULL WHERE folder_id = ?1",

--- a/apps/desktop/src-tauri/src/utils.rs
+++ b/apps/desktop/src-tauri/src/utils.rs
@@ -19,7 +19,7 @@ pub fn serialize_as_json_array<'a, I: ExactSizeIterator<Item = &'a str>>(
     }
     json.push(']');
 
-    Ok(RawValue::from_string(json).unwrap())
+    Ok(RawValue::from_string(json).expect("hand-built JSON array is valid"))
 }
 
 pub fn is_json(input: &[u8]) -> bool {


### PR DESCRIPTION
## Summary
- \`#![warn(clippy::unwrap_used)]\` + \`#![cfg_attr(test, allow(...))]\` in \`lib.rs\` — compiler now flags any new production unwrap
- Storage layer (6 files): \`self.conn.lock().unwrap()\` → \`map_err(|_| Error::Internal(...))?]\` — propagates Mutex poison instead of panicking
- \`MutationService\`: 9 Mutex locks → \`map_err\`
- \`stmt_manager\`: RwLock writes in spawned tasks → \`.expect()\` (can't use \`?\` in closures; poisoned lock is non-recoverable)
- \`ssh_tunnel\`, \`metadata\`, \`adapter/read\`: Mutex locks fixed
- Infallible unwraps (hand-built JSON, \`write!\` to \`String\`, literal URL, \`OnceLock\` after init) → \`.expect()\` with rationale string
- 141 remaining unwraps are all in \`#[cfg(test)]\` blocks, suppressed by \`cfg_attr\`

## Test plan
- [ ] \`cargo check\` — Finished with no errors ✅
- [ ] Introduce a new \`.unwrap()\` — verify clippy warns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace panicking unwraps in the desktop backend with fallible error handling and enable clippy linting to prevent new production unwraps.

Bug Fixes:
- Handle Mutex and RwLock poisoning in storage, metadata, mutation services, statement manager, and SSH tunnel by returning internal errors instead of panicking.

Enhancements:
- Annotate the Tauri lib crate to warn on clippy::unwrap_used in production while allowing it in tests.
- Convert logically infallible unwraps (JSON construction, OnceLock access, static URL parsing, string writes) to expect calls with explanatory messages for clearer intent and diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for database mutex operations to prevent unexpected crashes and provide clearer diagnostic messages.

* **Chores**
  * Enhanced code quality checks to identify potential unwrap operations and enforce safer error handling patterns across the database layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->