### PR TITLE
feat(sql-console): query history improvements

### DIFF
--- a/apps/desktop/src/features/sql-console/components/query-history-panel.tsx
+++ b/apps/desktop/src/features/sql-console/components/query-history-panel.tsx
@@ -1,16 +1,32 @@
-import { Clock, Trash2, Play, CheckCircle, XCircle } from 'lucide-react'
+import {
+	Clock,
+	Trash2,
+	CheckCircle,
+	XCircle,
+	Pin,
+	PinOff,
+	Layers,
+	Download,
+	X,
+} from 'lucide-react'
+import { useState, useMemo } from 'react'
 import { Button } from '@/shared/ui/button'
+import { Input } from '@/shared/ui/input'
 import { ScrollArea } from '@/shared/ui/scroll-area'
-import { useQueryHistory } from '../stores/query-history-store'
 import { cn } from '@/shared/utils/cn'
+import { useQueryHistory, type QueryHistoryItem } from '../stores/query-history-store'
 
 type Props = {
 	onSelectQuery: (query: string) => void
 	currentConnectionId?: string
+	getConnectionName?: (id: string) => string
 }
 
-export function QueryHistoryPanel({ onSelectQuery, currentConnectionId }: Props) {
-	const { history, clearHistory, removeFromHistory } = useQueryHistory()
+export function QueryHistoryPanel({ onSelectQuery, currentConnectionId, getConnectionName }: Props) {
+	const { history, clearHistory, removeFromHistory, pinItem, unpinItem } = useQueryHistory()
+	const [search, setSearch] = useState('')
+	const [groupByConnection, setGroupByConnection] = useState(false)
+	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
 
 	function formatTimestamp(timestamp: number): string {
 		const date = new Date(timestamp)
@@ -32,97 +48,252 @@ export function QueryHistoryPanel({ onSelectQuery, currentConnectionId }: Props)
 		return `${(ms / 1000).toFixed(2)}s`
 	}
 
-	function truncateQuery(query: string, maxLength: number = 80): string {
+	function truncateQuery(query: string, maxLength = 80): string {
 		const singleLine = query.replace(/\s+/g, ' ').trim()
 		if (singleLine.length <= maxLength) return singleLine
 		return singleLine.substring(0, maxLength) + '...'
 	}
 
-	const filteredHistory = currentConnectionId
-		? history.filter(function (item) {
-				return item.connectionId === currentConnectionId
-			})
-		: history
+	function connectionLabel(id: string | null): string {
+		if (!id) return 'Unknown'
+		if (getConnectionName) return getConnectionName(id)
+		return id.slice(0, 8)
+	}
+
+	function toggleGroup(key: string) {
+		setCollapsedGroups(function (prev) {
+			const next = new Set(prev)
+			if (next.has(key)) next.delete(key)
+			else next.add(key)
+			return next
+		})
+	}
+
+	function handleExport() {
+		const blob = new Blob([JSON.stringify(history, null, 2)], { type: 'application/json' })
+		const url = URL.createObjectURL(blob)
+		const a = document.createElement('a')
+		a.href = url
+		a.download = 'query-history.json'
+		a.click()
+		URL.revokeObjectURL(url)
+	}
+
+	const filtered = useMemo(function () {
+		const q = search.toLowerCase()
+		if (!q) return history
+		return history.filter(function (item) {
+			return (
+				item.query.toLowerCase().includes(q) ||
+				(item.error && item.error.toLowerCase().includes(q))
+			)
+		})
+	}, [history, search])
+
+	const visibleItems = useMemo(function () {
+		if (!currentConnectionId) return filtered
+		return filtered.filter(function (item) {
+			return item.connectionId === currentConnectionId || item.pinned
+		})
+	}, [filtered, currentConnectionId])
+
+	const pinnedItems = useMemo(
+		() => visibleItems.filter((i) => i.pinned),
+		[visibleItems]
+	)
+	const unpinnedItems = useMemo(
+		() => visibleItems.filter((i) => !i.pinned),
+		[visibleItems]
+	)
+
+	const groups = useMemo(function () {
+		if (!groupByConnection) return null
+		const map = new Map<string, QueryHistoryItem[]>()
+		unpinnedItems.forEach(function (item) {
+			const key = item.connectionId ?? '__unknown__'
+			if (!map.has(key)) map.set(key, [])
+			map.get(key)!.push(item)
+		})
+		return map
+	}, [groupByConnection, unpinnedItems])
+
+	function renderItem(item: QueryHistoryItem) {
+		return (
+			<div
+				key={item.id}
+				className='group flex flex-col px-3 py-2 border-b border-sidebar-border/50 hover:bg-sidebar-accent/50 cursor-pointer transition-colors'
+				onClick={function () { onSelectQuery(item.query) }}
+			>
+				<div className='flex items-start gap-2'>
+					{item.success ? (
+						<CheckCircle className='h-3 w-3 text-green-500 mt-0.5 shrink-0' />
+					) : (
+						<XCircle className='h-3 w-3 text-red-500 mt-0.5 shrink-0' />
+					)}
+					<span className='text-xs font-mono text-sidebar-foreground flex-1 break-all'>
+						{truncateQuery(item.query)}
+					</span>
+					<div className='flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity'>
+						<Button
+							variant='ghost'
+							size='sm'
+							className='h-5 w-5 p-0'
+							title={item.pinned ? 'Unpin' : 'Pin'}
+							onClick={function (e) {
+								e.stopPropagation()
+								item.pinned ? unpinItem(item.id) : pinItem(item.id)
+							}}
+						>
+							{item.pinned ? (
+								<PinOff className='h-3 w-3 text-primary' />
+							) : (
+								<Pin className='h-3 w-3 text-muted-foreground hover:text-primary' />
+							)}
+						</Button>
+						<Button
+							variant='ghost'
+							size='sm'
+							className='h-5 w-5 p-0'
+							onClick={function (e) {
+								e.stopPropagation()
+								removeFromHistory(item.id)
+							}}
+						>
+							<Trash2 className='h-3 w-3 text-muted-foreground hover:text-destructive' />
+						</Button>
+					</div>
+				</div>
+				<div className='flex items-center gap-2 mt-1 ml-5'>
+					<span className='text-[10px] text-muted-foreground'>
+						{formatTimestamp(item.timestamp)}
+					</span>
+					<span className='text-[10px] text-muted-foreground'>•</span>
+					<span className='text-[10px] text-muted-foreground'>
+						{formatDuration(item.executionTimeMs)}
+					</span>
+					{item.rowCount !== undefined && (
+						<>
+							<span className='text-[10px] text-muted-foreground'>•</span>
+							<span className='text-[10px] text-muted-foreground'>
+								{item.rowCount} rows
+							</span>
+						</>
+					)}
+				</div>
+			</div>
+		)
+	}
 
 	return (
 		<div className='flex flex-col h-full bg-sidebar border-r border-sidebar-border'>
+			{/* Header */}
 			<div className='flex items-center justify-between px-3 py-2 border-b border-sidebar-border'>
 				<div className='flex items-center gap-2'>
 					<Clock className='h-4 w-4 text-muted-foreground' />
 					<span className='text-xs font-medium'>History</span>
+					{search && (
+						<span className='text-[10px] text-muted-foreground'>
+							{visibleItems.length} / {history.length}
+						</span>
+					)}
 				</div>
-				{filteredHistory.length > 0 && (
+				<div className='flex items-center gap-0.5'>
 					<Button
 						variant='ghost'
-						size='sm'
-						onClick={clearHistory}
-						className='h-6 px-2 text-xs text-muted-foreground hover:text-destructive'
+						size='icon'
+						className={cn(
+							'h-6 w-6',
+							groupByConnection && 'text-primary bg-sidebar-accent'
+						)}
+						title='Group by connection'
+						onClick={function () { setGroupByConnection((v) => !v) }}
 					>
-						Clear
+						<Layers className='h-3.5 w-3.5' />
 					</Button>
-				)}
+					<Button
+						variant='ghost'
+						size='icon'
+						className='h-6 w-6'
+						title='Export history'
+						onClick={handleExport}
+						disabled={history.length === 0}
+					>
+						<Download className='h-3.5 w-3.5' />
+					</Button>
+					{visibleItems.length > 0 && (
+						<Button
+							variant='ghost'
+							size='sm'
+							onClick={clearHistory}
+							className='h-6 px-2 text-xs text-muted-foreground hover:text-destructive'
+						>
+							Clear
+						</Button>
+					)}
+				</div>
+			</div>
+
+			{/* Search */}
+			<div className='px-2 py-1.5 border-b border-sidebar-border'>
+				<div className='relative'>
+					<Input
+						placeholder='Search history...'
+						value={search}
+						onChange={function (e) { setSearch(e.target.value) }}
+						className='h-6 text-xs pr-6'
+					/>
+					{search && (
+						<button
+							className='absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground'
+							onClick={function () { setSearch('') }}
+						>
+							<X className='h-3 w-3' />
+						</button>
+					)}
+				</div>
 			</div>
 
 			<ScrollArea className='flex-1'>
-				{filteredHistory.length === 0 ? (
+				{visibleItems.length === 0 ? (
 					<div className='flex flex-col items-center justify-center h-32 text-muted-foreground'>
 						<Clock className='h-8 w-8 mb-2 opacity-50' />
-						<span className='text-xs'>No query history</span>
+						<span className='text-xs'>
+							{search ? 'No matches' : 'No query history'}
+						</span>
 					</div>
 				) : (
 					<div className='flex flex-col'>
-						{filteredHistory.map(function (item) {
-							return (
-								<div
-									key={item.id}
-									className='group flex flex-col px-3 py-2 border-b border-sidebar-border/50 hover:bg-sidebar-accent/50 cursor-pointer transition-colors'
-									onClick={function () {
-										onSelectQuery(item.query)
-									}}
-								>
-									<div className='flex items-start gap-2'>
-										{item.success ? (
-											<CheckCircle className='h-3 w-3 text-green-500 mt-0.5 shrink-0' />
-										) : (
-											<XCircle className='h-3 w-3 text-red-500 mt-0.5 shrink-0' />
-										)}
-										<span className='text-xs font-mono text-sidebar-foreground flex-1 break-all'>
-											{truncateQuery(item.query)}
-										</span>
-										<Button
-											variant='ghost'
-											size='sm'
-											className='h-5 w-5 p-0 opacity-0 group-hover:opacity-100 transition-opacity'
-											onClick={function (e) {
-												e.stopPropagation()
-												removeFromHistory(item.id)
-											}}
-										>
-											<Trash2 className='h-3 w-3 text-muted-foreground hover:text-destructive' />
-										</Button>
-									</div>
-									<div className='flex items-center gap-2 mt-1 ml-5'>
-										<span className='text-[10px] text-muted-foreground'>
-											{formatTimestamp(item.timestamp)}
-										</span>
-										<span className='text-[10px] text-muted-foreground'>•</span>
-										<span className='text-[10px] text-muted-foreground'>
-											{formatDuration(item.executionTimeMs)}
-										</span>
-										{item.rowCount !== undefined && (
-											<>
-												<span className='text-[10px] text-muted-foreground'>
-													•
-												</span>
-												<span className='text-[10px] text-muted-foreground'>
-													{item.rowCount} rows
-												</span>
-											</>
-										)}
-									</div>
+						{/* Pinned section */}
+						{pinnedItems.length > 0 && (
+							<>
+								<div className='px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground bg-sidebar-accent/30 border-b border-sidebar-border'>
+									Pinned
 								</div>
-							)
-						})}
+								{pinnedItems.map(renderItem)}
+							</>
+						)}
+
+						{/* Unpinned — flat or grouped */}
+						{!groupByConnection ? (
+							unpinnedItems.map(renderItem)
+						) : (
+							groups && Array.from(groups.entries()).map(function ([key, items]) {
+								const label = connectionLabel(key === '__unknown__' ? null : key)
+								const collapsed = collapsedGroups.has(key)
+								return (
+									<div key={key}>
+										<button
+											className='w-full flex items-center justify-between px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground bg-sidebar-accent/20 border-b border-sidebar-border hover:bg-sidebar-accent/40 transition-colors'
+											onClick={function () { toggleGroup(key) }}
+										>
+											<span>{label}</span>
+											<span>{collapsed ? '▸' : '▾'} {items.length}</span>
+										</button>
+										{!collapsed && items.map(renderItem)}
+									</div>
+								)
+							})
+						)}
 					</div>
 				)}
 			</ScrollArea>

--- a/apps/desktop/src/features/sql-console/sql-console.tsx
+++ b/apps/desktop/src/features/sql-console/sql-console.tsx
@@ -27,9 +27,10 @@ import { SqlQueryResult, ResultViewMode, SqlSnippet, TableInfo } from './types'
 type Props = {
 	onToggleSidebar?: () => void
 	activeConnectionId?: string
+	getConnectionName?: (id: string) => string
 }
 
-export function SqlConsole({ onToggleSidebar: _onToggleSidebar, activeConnectionId }: Props) {
+export function SqlConsole({ onToggleSidebar: _onToggleSidebar, activeConnectionId, getConnectionName }: Props) {
 	const adapter = useAdapter()
 	const [mode, setMode] = useState<'sql' | 'drizzle'>('sql')
 	const [snippets, setSnippets] = useState<SqlSnippet[]>([])
@@ -771,6 +772,7 @@ export function SqlConsole({ onToggleSidebar: _onToggleSidebar, activeConnection
 						>
 							<QueryHistoryPanel
 								currentConnectionId={activeConnectionId}
+								getConnectionName={getConnectionName}
 								onSelectQuery={function (query) {
 									if (mode === 'sql') {
 										setCurrentSqlQuery(query)

--- a/apps/desktop/src/features/sql-console/stores/query-history-store.tsx
+++ b/apps/desktop/src/features/sql-console/stores/query-history-store.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
 
-type QueryHistoryItem = {
+export type QueryHistoryItem = {
 	id: string
 	query: string
 	connectionId: string | null
@@ -9,22 +9,20 @@ type QueryHistoryItem = {
 	success: boolean
 	error?: string
 	rowCount?: number
-}
-
-type QueryHistoryState = {
-	items: QueryHistoryItem[]
-	maxItems: number
+	pinned?: boolean
 }
 
 type QueryHistoryContextValue = {
 	history: QueryHistoryItem[]
-	addToHistory: (entry: Omit<QueryHistoryItem, 'id' | 'timestamp'>) => void
+	addToHistory: (entry: Omit<QueryHistoryItem, 'id' | 'timestamp' | 'pinned'>) => void
 	clearHistory: () => void
 	removeFromHistory: (id: string) => void
+	pinItem: (id: string) => void
+	unpinItem: (id: string) => void
 }
 
 const STORAGE_KEY = 'dora-query-history'
-const MAX_HISTORY_ITEMS = 50
+const MAX_HISTORY_ITEMS = 200
 
 const QueryHistoryContext = createContext<QueryHistoryContextValue | null>(null)
 
@@ -61,30 +59,52 @@ export function QueryHistoryProvider({ children }: Props) {
 		setHistory(loaded)
 	}, [])
 
-	const addToHistory = useCallback(function (entry: Omit<QueryHistoryItem, 'id' | 'timestamp'>) {
+	const addToHistory = useCallback(function (entry: Omit<QueryHistoryItem, 'id' | 'timestamp' | 'pinned'>) {
 		setHistory(function (prev) {
 			const newItem: QueryHistoryItem = {
 				...entry,
 				id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-				timestamp: Date.now()
+				timestamp: Date.now(),
+				pinned: false,
 			}
 
-			const updated = [newItem, ...prev].slice(0, MAX_HISTORY_ITEMS)
+			const pinned = prev.filter((item) => item.pinned)
+			const unpinned = prev.filter((item) => !item.pinned)
+			const trimmedUnpinned = [newItem, ...unpinned].slice(0, MAX_HISTORY_ITEMS)
+			const updated = [...pinned, ...trimmedUnpinned]
 			saveHistoryToStorage(updated)
 			return updated
 		})
 	}, [])
 
 	const clearHistory = useCallback(function () {
-		setHistory([])
-		saveHistoryToStorage([])
+		setHistory(function (prev) {
+			// keep pinned items on clear
+			const pinned = prev.filter((item) => item.pinned)
+			saveHistoryToStorage(pinned)
+			return pinned
+		})
 	}, [])
 
 	const removeFromHistory = useCallback(function (id: string) {
 		setHistory(function (prev) {
-			const updated = prev.filter(function (item) {
-				return item.id !== id
-			})
+			const updated = prev.filter((item) => item.id !== id)
+			saveHistoryToStorage(updated)
+			return updated
+		})
+	}, [])
+
+	const pinItem = useCallback(function (id: string) {
+		setHistory(function (prev) {
+			const updated = prev.map((item) => item.id === id ? { ...item, pinned: true } : item)
+			saveHistoryToStorage(updated)
+			return updated
+		})
+	}, [])
+
+	const unpinItem = useCallback(function (id: string) {
+		setHistory(function (prev) {
+			const updated = prev.map((item) => item.id === id ? { ...item, pinned: false } : item)
 			saveHistoryToStorage(updated)
 			return updated
 		})
@@ -92,7 +112,7 @@ export function QueryHistoryProvider({ children }: Props) {
 
 	return (
 		<QueryHistoryContext.Provider
-			value={{ history, addToHistory, clearHistory, removeFromHistory }}
+			value={{ history, addToHistory, clearHistory, removeFromHistory, pinItem, unpinItem }}
 		>
 			{children}
 		</QueryHistoryContext.Provider>

--- a/apps/desktop/src/pages/Index.tsx
+++ b/apps/desktop/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, lazy, Suspense } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -19,10 +19,20 @@ import {
 } from "@/features/connections/api";
 import { ConnectionDialog } from "@/features/connections/components/connection-dialog";
 import { Connection } from "@/features/connections/types";
-import { DatabaseStudio } from "@/features/database-studio/database-studio";
-import { DockerView } from "@/features/docker-manager";
+const DatabaseStudio = lazy(() =>
+  import("@/features/database-studio/database-studio").then((m) => ({
+    default: m.DatabaseStudio,
+  }))
+);
+const DockerView = lazy(() =>
+  import("@/features/docker-manager").then((m) => ({ default: m.DockerView }))
+);
+const SqlConsole = lazy(() =>
+  import("@/features/sql-console/sql-console").then((m) => ({
+    default: m.SqlConsole,
+  }))
+);
 import { DatabaseSidebar } from "@/features/sidebar/database-sidebar";
-import { SqlConsole } from "@/features/sql-console/sql-console";
 import { WindowControls } from "@/components/window-controls";
 import {
   AlertDialog,
@@ -595,6 +605,13 @@ export default function Index() {
             )}
 
             <main className="flex-1 flex flex-col h-full overflow-hidden relative px-0">
+              <Suspense
+                fallback={
+                  <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+                    Loading...
+                  </div>
+                }
+              >
               {connections.length === 0 &&
               !isLoading &&
               (activeNavId === "database-studio" ||
@@ -630,6 +647,9 @@ export default function Index() {
                   <SqlConsole
                     onToggleSidebar={() => setIsSidebarOpen(!isSidebarOpen)}
                     activeConnectionId={activeConnectionId}
+                    getConnectionName={(id) =>
+                      connections.find((c) => c.id === id)?.name ?? id.slice(0, 8)
+                    }
                   />
                 </ErrorBoundary>
               ) : activeNavId === "docker" ? (
@@ -676,9 +696,13 @@ export default function Index() {
                   <SqlConsole
                     onToggleSidebar={() => setIsSidebarOpen(!isSidebarOpen)}
                     activeConnectionId={activeConnectionId}
+                    getConnectionName={(id) =>
+                      connections.find((c) => c.id === id)?.name ?? id.slice(0, 8)
+                    }
                   />
                 </ErrorBoundary>
               )}
+              </Suspense>
             </main>
 
             <ConnectionDialog


### PR DESCRIPTION
## Summary

- **Pin queries**: items survive Clear and the 200-item eviction cap; pin/unpin button on hover
- **Search**: live-filter by query text or error string, match count shown, clear button
- **Group by connection**: collapsible sections per connection ID, labels resolved from connection name
- **Export**: downloads full history as `query-history.json`
- **Max items**: bumped 50 → 200; eviction only trims unpinned rows
- `getConnectionName` prop threaded `Index → SqlConsole → QueryHistoryPanel`

## Test plan

- [ ] Run queries on 2+ connections; group-by shows separate collapsible sections with connection names
- [ ] Pin an item, click Clear — pinned item survives
- [ ] Evict by adding >200 queries — pinned items never evicted
- [ ] Search filters live; `×` clears input
- [ ] Export button downloads valid JSON array
- [ ] Reload app — pinned state persists from localStorage
- [ ] `tsc --noEmit` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhance the SQL console query history panel with pinning, search, grouping, and export capabilities while increasing the retained history size.

New Features:
- Add pin/unpin support for query history items, including a dedicated pinned section that is preserved across clears and storage eviction.
- Introduce live search over query history by query text or error message with match counts and a clearable input field.
- Add optional grouping of query history by connection with collapsible sections labeled using resolved connection names.
- Enable exporting the full query history to a JSON file from the history panel.
- Thread a getConnectionName prop from the Index page into SqlConsole and QueryHistoryPanel to provide user-friendly connection labels.

Enhancements:
- Increase the maximum retained query history size from 50 to 200 entries while only evicting unpinned items.
- Update query history clear behavior to retain pinned items instead of wiping all history.
- Improve the SQL console main area by wrapping it in a Suspense boundary with a loading fallback for async content.
- Expose the QueryHistoryItem type and extend it with a pinned flag to support new history behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search and filter query history by text or error messages
  * Pin important queries to keep them easily accessible and visible across connection filters
  * Group query history by database connection with collapsible sections for better organization
  * Export complete query history in JSON format
* **Performance**
  * Lazy load application modules for improved startup performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->