### PR TITLE
feat(ai): schema-grounded AI ⌘I with Groq rotating-key provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,16 @@
 # Gemini API Key (Required for release:gen)
 GEMINI_API_KEY=your-api-key
 
+# Groq API keys — used by the AI SQL command palette (⌘I / mod+i).
+# You can set up to 10 keys; the backend rotates across them on 429 / 401.
+# Free-tier keys: https://console.groq.com/keys
+GROQ_API_KEY_1=your-groq-key-here
+# GROQ_API_KEY_2=
+# GROQ_API_KEY_3=
+
+# Optional: override the default Groq model (default: llama-3.3-70b-versatile)
+# GROQ_MODEL=llama-3.3-70b-versatile
+
 # Recording/demo controls (disabled by default)
 VITE_RECORDING_MODE=false
 VITE_DEMO_AUTOPILOT=false

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -147,6 +147,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "dirs",
+ "dotenvy",
  "fake",
  "futures-util",
  "hex",
@@ -1372,6 +1373,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast-rs"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -81,7 +81,7 @@ sqlparser = { version = "0.52", features = ["serde"] }
 fake = { version = "3", features = ["derive"] }
 rand = "0.9"
 bcrypt = "0.15"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 tauri-plugin-shell = "2.3.4"
 
 [profile.release]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -83,6 +83,7 @@ rand = "0.9"
 bcrypt = "0.15"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 tauri-plugin-shell = "2.3.4"
+dotenvy = "0.15"
 
 [profile.release]
 panic = "abort"

--- a/apps/desktop/src-tauri/src/bindings.rs
+++ b/apps/desktop/src-tauri/src/bindings.rs
@@ -73,11 +73,13 @@ pub fn generate_bindings() -> Builder<tauri::Wry> {
         db_commands::export_schema_sql,
         db_commands::export_schema_drizzle,
         db_commands::ai_complete,
+        db_commands::ai_complete_stream,
         db_commands::ai_set_provider,
         db_commands::ai_get_provider,
         db_commands::ai_set_gemini_key,
         db_commands::ai_configure_ollama,
-        db_commands::ai_list_ollama_models
+        db_commands::ai_list_ollama_models,
+        db_commands::ai_groq_status
     ])
 }
 

--- a/apps/desktop/src-tauri/src/database/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/database/commands/ai.rs
@@ -2,12 +2,72 @@ use tauri::State;
 use uuid::Uuid;
 
 use crate::{
-    database::services::ai::{
-        AIProvider, AIRequest, AIResponse, AIService, OllamaClient, SchemaContext, TableContext,
+    database::{
+        services::ai::{
+            AIProvider, AIRequest, AIResponse, AIService, AiStreamEvent, ColumnContext,
+            ForeignKeyContext, GroqClient, GroqStatus, OllamaClient, SchemaContext, TableContext,
+        },
+        types::DatabaseSchema,
     },
     error::Error,
     AppState,
 };
+
+fn build_schema_context(schema: &DatabaseSchema, engine: &str) -> SchemaContext {
+    let tables = schema
+        .tables
+        .iter()
+        .map(|t| TableContext {
+            name: t.name.clone(),
+            schema: t.schema.clone(),
+            columns: t
+                .columns
+                .iter()
+                .map(|c| ColumnContext {
+                    name: c.name.clone(),
+                    data_type: c.data_type.clone(),
+                    is_nullable: c.is_nullable,
+                    is_primary_key: c.is_primary_key,
+                    is_auto_increment: c.is_auto_increment,
+                })
+                .collect(),
+            primary_keys: t.primary_key_columns.clone(),
+            foreign_keys: t
+                .columns
+                .iter()
+                .filter_map(|c| {
+                    c.foreign_key.as_ref().map(|fk| ForeignKeyContext {
+                        column: c.name.clone(),
+                        referenced_table: fk.referenced_table.clone(),
+                        referenced_column: fk.referenced_column.clone(),
+                        referenced_schema: fk.referenced_schema.clone(),
+                    })
+                })
+                .collect(),
+            row_count_estimate: t.row_count_estimate,
+        })
+        .collect();
+
+    SchemaContext {
+        engine: engine.to_string(),
+        tables,
+    }
+}
+
+fn engine_for_connection(state: &AppState, conn_id: Uuid) -> String {
+    use crate::database::types::Database;
+    state
+        .connections
+        .get(&conn_id)
+        .map(|entry| match entry.value().database {
+            Database::Postgres { .. } => "postgres",
+            Database::MySQL { .. } => "mysql",
+            Database::SQLite { .. } => "sqlite",
+            Database::LibSQL { .. } => "libsql",
+        })
+        .unwrap_or("sql")
+        .to_string()
+}
 
 #[tauri::command]
 #[specta::specta]
@@ -18,15 +78,9 @@ pub async fn ai_complete(
     state: State<'_, AppState>,
 ) -> Result<AIResponse, Error> {
     let context = if let Some(conn_id) = connection_id {
-        state.schemas.get(&conn_id).map(|schema| SchemaContext {
-            tables: schema
-                .tables
-                .iter()
-                .map(|t| TableContext {
-                    name: t.name.clone(),
-                    columns: t.columns.iter().map(|c| c.name.clone()).collect(),
-                })
-                .collect(),
+        state.schemas.get(&conn_id).map(|schema| {
+            let engine = engine_for_connection(&state, conn_id);
+            build_schema_context(&schema, &engine)
         })
     } else {
         None
@@ -47,8 +101,60 @@ pub async fn ai_complete(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn ai_complete_stream(
+    prompt: String,
+    connection_id: Option<Uuid>,
+    max_tokens: Option<u32>,
+    on_event: tauri::ipc::Channel<AiStreamEvent>,
+    state: State<'_, AppState>,
+) -> Result<(), Error> {
+    let context = if let Some(conn_id) = connection_id {
+        state.schemas.get(&conn_id).map(|schema| {
+            let engine = engine_for_connection(&state, conn_id);
+            build_schema_context(&schema, &engine)
+        })
+    } else {
+        None
+    };
+
+    let request = AIRequest {
+        prompt,
+        context,
+        connection_id,
+        max_tokens,
+    };
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<AiStreamEvent>();
+
+    // Forward internal channel to Tauri IPC channel
+    let forward_handle = tokio::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            let _ = on_event.send(event);
+        }
+    });
+
+    let svc = AIService {
+        storage: &state.storage,
+    };
+    let result = svc.complete_stream(request, tx).await;
+
+    // Wait for forwarder to drain
+    let _ = forward_handle.await;
+
+    if let Err(ref e) = result {
+        // Best-effort: errors are surfaced through the command return value,
+        // not through the channel (which has already been dropped).
+        tracing::warn!("ai_complete_stream error: {}", e);
+    }
+
+    result
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn ai_set_provider(provider: String, state: State<'_, AppState>) -> Result<(), Error> {
     let ai_provider = match provider.to_lowercase().as_str() {
+        "groq" => AIProvider::Groq,
         "gemini" => AIProvider::Gemini,
         "ollama" => AIProvider::Ollama,
         _ => return Err(Error::Any(anyhow::anyhow!("Invalid provider: {}", provider))),
@@ -68,6 +174,7 @@ pub async fn ai_get_provider(state: State<'_, AppState>) -> Result<String, Error
     };
     let provider = svc.get_provider()?;
     Ok(match provider {
+        AIProvider::Groq => "groq".to_string(),
         AIProvider::Gemini => "gemini".to_string(),
         AIProvider::Ollama => "ollama".to_string(),
     })
@@ -106,4 +213,21 @@ pub async fn ai_list_ollama_models(state: State<'_, AppState>) -> Result<Vec<Str
 
     let client = OllamaClient::new(endpoint, String::new());
     client.list_models().await
+}
+
+/// Check whether Groq provider is usable (env keys present).
+/// Returns key count detected. Never exposes the key values.
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_groq_status() -> Result<GroqStatus, Error> {
+    match GroqClient::from_env() {
+        Ok(client) => Ok(GroqStatus {
+            available: true,
+            key_count: client.key_count(),
+        }),
+        Err(_) => Ok(GroqStatus {
+            available: false,
+            key_count: 0,
+        }),
+    }
 }

--- a/apps/desktop/src-tauri/src/database/services/ai/gemini.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/gemini.rs
@@ -70,25 +70,8 @@ impl GeminiClient {
     }
 
     fn build_prompt(&self, request: &AIRequest) -> String {
-        let mut prompt = String::new();
-        
-        // System context
-        prompt.push_str("You are an expert SQL assistant. Help the user write, debug, and understand SQL queries.\n\n");
-        
-        // Schema context if provided
-        if let Some(ctx) = &request.context {
-            prompt.push_str("## Available Tables:\n");
-            for table in &ctx.tables {
-                prompt.push_str(&format!("- **{}**: {}\n", table.name, table.columns.join(", ")));
-            }
-            prompt.push('\n');
-        }
-        
-        // User prompt
-        prompt.push_str("## User Request:\n");
-        prompt.push_str(&request.prompt);
-        
-        prompt
+        let (system, user) = super::prompts::build(request);
+        format!("{}\n\n## User request\n{}", system, user)
     }
 
     pub async fn complete(&self, request: AIRequest) -> Result<AIResponse, Error> {

--- a/apps/desktop/src-tauri/src/database/services/ai/groq.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/groq.rs
@@ -1,0 +1,322 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::{AIRequest, AIResponse, AiStreamEvent};
+use crate::error::Error;
+
+const GROQ_API_URL: &str = "https://api.groq.com/openai/v1/chat/completions";
+const DEFAULT_MODEL: &str = "llama-3.3-70b-versatile";
+
+#[derive(Debug, Serialize)]
+struct GroqMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Serialize)]
+struct GroqRequest {
+    model: String,
+    messages: Vec<GroqMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response_format: Option<ResponseFormat>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResponseFormat {
+    #[serde(rename = "type")]
+    kind: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GroqResponse {
+    choices: Vec<GroqChoice>,
+    usage: Option<GroqUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GroqChoice {
+    message: GroqResponseMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct GroqResponseMessage {
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GroqUsage {
+    total_tokens: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GroqStreamChunk {
+    choices: Vec<GroqStreamChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GroqStreamChoice {
+    delta: GroqStreamDelta,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct GroqStreamDelta {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+pub struct GroqClient {
+    keys: Vec<String>,
+    counter: AtomicUsize,
+    model: String,
+    client: reqwest::Client,
+}
+
+impl GroqClient {
+    pub fn from_env() -> Result<Self, Error> {
+        let mut keys = Vec::new();
+
+        if let Ok(k) = std::env::var("GROQ_API_KEY") {
+            if !k.is_empty() {
+                keys.push(k);
+            }
+        }
+
+        for i in 1..=10 {
+            if let Ok(k) = std::env::var(format!("GROQ_API_KEY_{}", i)) {
+                if !k.is_empty() {
+                    keys.push(k);
+                }
+            }
+        }
+
+        if keys.is_empty() {
+            return Err(Error::InvalidInput(
+                "No GROQ_API_KEY or GROQ_API_KEY_1..10 env vars found".into(),
+            ));
+        }
+
+        Ok(Self {
+            keys,
+            counter: AtomicUsize::new(0),
+            model: std::env::var("GROQ_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string()),
+            client: reqwest::Client::new(),
+        })
+    }
+
+    pub fn key_count(&self) -> usize {
+        self.keys.len()
+    }
+
+    fn next_key(&self) -> &str {
+        let idx = self.counter.fetch_add(1, Ordering::Relaxed);
+        &self.keys[idx % self.keys.len()]
+    }
+
+    fn build_request(&self, system: String, user: String, max_tokens: Option<u32>, stream: bool) -> GroqRequest {
+        GroqRequest {
+            model: self.model.clone(),
+            messages: vec![
+                GroqMessage {
+                    role: "system".into(),
+                    content: system,
+                },
+                GroqMessage {
+                    role: "user".into(),
+                    content: user,
+                },
+            ],
+            max_tokens,
+            stream,
+            temperature: Some(0.2),
+            response_format: if stream {
+                None
+            } else {
+                Some(ResponseFormat {
+                    kind: "json_object".into(),
+                })
+            },
+        }
+    }
+
+    /// Non-streaming completion with key rotation on 429.
+    pub async fn complete(&self, request: AIRequest) -> Result<AIResponse, Error> {
+        let (system, user) = super::prompts::build(&request);
+        let body = self.build_request(system, user, request.max_tokens, false);
+
+        let max_retries = self.keys.len();
+        let mut last_err: Option<Error> = None;
+
+        for _ in 0..max_retries {
+            let key = self.next_key().to_string();
+            let response = self
+                .client
+                .post(GROQ_API_URL)
+                .bearer_auth(&key)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| Error::Any(anyhow::anyhow!("Groq request failed: {}", e)))?;
+
+            let status = response.status();
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS
+                || status == reqwest::StatusCode::UNAUTHORIZED
+            {
+                let body_text = response.text().await.unwrap_or_default();
+                last_err = Some(Error::Any(anyhow::anyhow!(
+                    "Groq key exhausted (status {}): {}",
+                    status,
+                    body_text
+                )));
+                continue;
+            }
+
+            if !status.is_success() {
+                let body_text = response.text().await.unwrap_or_default();
+                return Err(Error::Any(anyhow::anyhow!(
+                    "Groq API error ({}): {}",
+                    status,
+                    body_text
+                )));
+            }
+
+            let parsed: GroqResponse = response.json().await.map_err(|e| {
+                Error::Any(anyhow::anyhow!("Failed to parse Groq response: {}", e))
+            })?;
+
+            let content = parsed
+                .choices
+                .into_iter()
+                .next()
+                .and_then(|c| c.message.content)
+                .unwrap_or_default();
+
+            let tokens_used = parsed.usage.and_then(|u| u.total_tokens);
+
+            return Ok(AIResponse {
+                content,
+                suggested_queries: None,
+                tokens_used,
+                provider: "groq".to_string(),
+            });
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            Error::Any(anyhow::anyhow!("All Groq keys exhausted"))
+        }))
+    }
+
+    /// Streaming completion. Emits AiStreamEvent via sender.
+    pub async fn complete_stream(
+        &self,
+        request: AIRequest,
+        sender: UnboundedSender<AiStreamEvent>,
+    ) -> Result<(), Error> {
+        let (system, user) = super::prompts::build(&request);
+        let body = self.build_request(system, user, request.max_tokens, true);
+
+        let max_retries = self.keys.len();
+        let mut last_err: Option<Error> = None;
+
+        for _ in 0..max_retries {
+            let key = self.next_key().to_string();
+            let response = self
+                .client
+                .post(GROQ_API_URL)
+                .bearer_auth(&key)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| Error::Any(anyhow::anyhow!("Groq request failed: {}", e)))?;
+
+            let status = response.status();
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS
+                || status == reqwest::StatusCode::UNAUTHORIZED
+            {
+                let body_text = response.text().await.unwrap_or_default();
+                last_err = Some(Error::Any(anyhow::anyhow!(
+                    "Groq key exhausted (status {}): {}",
+                    status,
+                    body_text
+                )));
+                continue;
+            }
+
+            if !status.is_success() {
+                let body_text = response.text().await.unwrap_or_default();
+                return Err(Error::Any(anyhow::anyhow!(
+                    "Groq API error ({}): {}",
+                    status,
+                    body_text
+                )));
+            }
+
+            let mut stream = response.bytes_stream();
+            let mut buffer = String::new();
+            let mut full_content = String::new();
+
+            while let Some(chunk_result) = stream.next().await {
+                let chunk = chunk_result.map_err(|e| {
+                    Error::Any(anyhow::anyhow!("Groq stream error: {}", e))
+                })?;
+                buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+                while let Some(newline_idx) = buffer.find('\n') {
+                    let line = buffer[..newline_idx].trim().to_string();
+                    buffer = buffer[newline_idx + 1..].to_string();
+
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let data = if let Some(rest) = line.strip_prefix("data: ") {
+                        rest
+                    } else {
+                        continue;
+                    };
+
+                    if data == "[DONE]" {
+                        let _ = sender.send(AiStreamEvent::Final {
+                            content: full_content.clone(),
+                        });
+                        return Ok(());
+                    }
+
+                    match serde_json::from_str::<GroqStreamChunk>(data) {
+                        Ok(parsed) => {
+                            if let Some(delta_text) = parsed
+                                .choices
+                                .into_iter()
+                                .next()
+                                .and_then(|c| c.delta.content)
+                            {
+                                full_content.push_str(&delta_text);
+                                let _ = sender.send(AiStreamEvent::Token {
+                                    text: delta_text,
+                                });
+                            }
+                        }
+                        Err(_) => {
+                            // Skip malformed chunks quietly
+                        }
+                    }
+                }
+            }
+
+            let _ = sender.send(AiStreamEvent::Final {
+                content: full_content,
+            });
+            return Ok(());
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            Error::Any(anyhow::anyhow!("All Groq keys exhausted"))
+        }))
+    }
+}

--- a/apps/desktop/src-tauri/src/database/services/ai/mod.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/mod.rs
@@ -1,5 +1,7 @@
 mod gemini;
+mod groq;
 mod ollama;
+mod prompts;
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -8,29 +10,54 @@ use crate::error::Error;
 use crate::storage::Storage;
 
 pub use gemini::GeminiClient;
+pub use groq::GroqClient;
 pub use ollama::OllamaClient;
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub enum AIProvider {
+    Groq,
     Gemini,
     Ollama,
 }
 
 impl Default for AIProvider {
     fn default() -> Self {
-        Self::Ollama // Default to local/free
+        // Groq free tier with rotating keys is the preferred default.
+        Self::Groq
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct SchemaContext {
+    pub engine: String,
     pub tables: Vec<TableContext>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct TableContext {
     pub name: String,
-    pub columns: Vec<String>,
+    pub schema: String,
+    pub columns: Vec<ColumnContext>,
+    pub primary_keys: Vec<String>,
+    pub foreign_keys: Vec<ForeignKeyContext>,
+    pub row_count_estimate: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct ColumnContext {
+    pub name: String,
+    pub data_type: String,
+    pub is_nullable: bool,
+    pub is_primary_key: bool,
+    pub is_auto_increment: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct ForeignKeyContext {
+    pub column: String,
+    pub referenced_table: String,
+    pub referenced_column: String,
+    pub referenced_schema: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
@@ -49,23 +76,37 @@ pub struct AIResponse {
     pub provider: String,
 }
 
+#[derive(Debug, Clone, Serialize, specta::Type)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AiStreamEvent {
+    Token { text: String },
+    Final { content: String },
+    Error { message: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct GroqStatus {
+    pub available: bool,
+    pub key_count: usize,
+}
+
 pub struct AIService<'a> {
     pub storage: &'a Storage,
 }
 
 impl<'a> AIService<'a> {
-    /// Get the currently configured AI provider
     pub fn get_provider(&self) -> Result<AIProvider, Error> {
         match self.storage.get_setting("ai_provider")? {
+            Some(p) if p == "groq" => Ok(AIProvider::Groq),
             Some(p) if p == "gemini" => Ok(AIProvider::Gemini),
             Some(p) if p == "ollama" => Ok(AIProvider::Ollama),
             _ => Ok(AIProvider::default()),
         }
     }
 
-    /// Set the AI provider
     pub fn set_provider(&self, provider: AIProvider) -> Result<(), Error> {
         let value = match provider {
+            AIProvider::Groq => "groq",
             AIProvider::Gemini => "gemini",
             AIProvider::Ollama => "ollama",
         };
@@ -73,26 +114,62 @@ impl<'a> AIService<'a> {
         Ok(())
     }
 
-    /// Complete a prompt using the configured provider
     pub async fn complete(&self, request: AIRequest) -> Result<AIResponse, Error> {
         let provider = self.get_provider()?;
-        
+
         match provider {
+            AIProvider::Groq => {
+                let client = GroqClient::from_env()?;
+                client.complete(request).await
+            }
             AIProvider::Gemini => {
-                let api_key = self.storage.get_setting("gemini_api_key")?
-                    .ok_or_else(|| Error::Any(anyhow::anyhow!("Gemini API key not configured")))?;
-                
+                let api_key = self
+                    .storage
+                    .get_setting("gemini_api_key")?
+                    .ok_or_else(|| {
+                        Error::Any(anyhow::anyhow!("Gemini API key not configured"))
+                    })?;
+
                 let client = GeminiClient::new(api_key);
                 client.complete(request).await
             }
             AIProvider::Ollama => {
-                let endpoint = self.storage.get_setting("ollama_endpoint")?
+                let endpoint = self
+                    .storage
+                    .get_setting("ollama_endpoint")?
                     .unwrap_or_else(|| "http://localhost:11434".to_string());
-                let model = self.storage.get_setting("ollama_model")?
+                let model = self
+                    .storage
+                    .get_setting("ollama_model")?
                     .unwrap_or_else(|| "llama3.2".to_string());
-                
+
                 let client = OllamaClient::new(endpoint, model);
                 client.complete(request).await
+            }
+        }
+    }
+
+    /// Streaming completion. Currently only Groq supports streaming natively;
+    /// Gemini/Ollama fall back to non-streaming and emit the full result as
+    /// a single Final event.
+    pub async fn complete_stream(
+        &self,
+        request: AIRequest,
+        sender: tokio::sync::mpsc::UnboundedSender<AiStreamEvent>,
+    ) -> Result<(), Error> {
+        let provider = self.get_provider()?;
+
+        match provider {
+            AIProvider::Groq => {
+                let client = GroqClient::from_env()?;
+                client.complete_stream(request, sender).await
+            }
+            _ => {
+                let response = self.complete(request).await?;
+                let _ = sender.send(AiStreamEvent::Final {
+                    content: response.content,
+                });
+                Ok(())
             }
         }
     }

--- a/apps/desktop/src-tauri/src/database/services/ai/ollama.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/ollama.rs
@@ -53,25 +53,8 @@ impl OllamaClient {
     }
 
     fn build_prompt(&self, request: &AIRequest) -> String {
-        let mut prompt = String::new();
-        
-        // System context
-        prompt.push_str("You are an expert SQL assistant. Help the user write, debug, and understand SQL queries.\n\n");
-        
-        // Schema context if provided
-        if let Some(ctx) = &request.context {
-            prompt.push_str("## Available Tables:\n");
-            for table in &ctx.tables {
-                prompt.push_str(&format!("- **{}**: {}\n", table.name, table.columns.join(", ")));
-            }
-            prompt.push('\n');
-        }
-        
-        // User prompt
-        prompt.push_str("## User Request:\n");
-        prompt.push_str(&request.prompt);
-        
-        prompt
+        let (system, user) = super::prompts::build(request);
+        format!("{}\n\n## User request\n{}", system, user)
     }
 
     pub async fn complete(&self, request: AIRequest) -> Result<AIResponse, Error> {

--- a/apps/desktop/src-tauri/src/database/services/ai/prompts.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/prompts.rs
@@ -1,0 +1,123 @@
+use super::AIRequest;
+
+const MAX_TABLES_IN_PROMPT: usize = 60;
+const MAX_COLUMNS_PER_TABLE: usize = 40;
+
+/// Build (system_prompt, user_prompt) pair for a schema-grounded SQL generation request.
+pub fn build(request: &AIRequest) -> (String, String) {
+    let system = build_system_prompt(request);
+    let user = request.prompt.clone();
+    (system, user)
+}
+
+fn build_system_prompt(request: &AIRequest) -> String {
+    let engine = request
+        .context
+        .as_ref()
+        .map(|c| c.engine.as_str())
+        .unwrap_or("sql");
+
+    let mut s = String::new();
+
+    s.push_str(&format!(
+        "You are an expert {engine} analyst. Convert the user's natural-language request into a single, correct SQL query against the database schema below.\n\n"
+    ));
+
+    s.push_str("## Output format\n");
+    s.push_str(
+        "Respond with ONLY a JSON object. No markdown, no code fences, no prose outside the JSON:\n\
+         {\"sql\":\"<the sql query>\",\"explanation\":\"<one-sentence explanation>\",\"warnings\":[\"<optional safety concern>\"]}\n\n",
+    );
+
+    s.push_str("## Rules\n");
+    s.push_str("- Produce ONE statement. No semicolon-separated batches.\n");
+    s.push_str("- Default to SELECT. NEVER emit DROP, TRUNCATE, DELETE without WHERE, or UPDATE without WHERE.\n");
+    s.push_str("- Add LIMIT 100 to unbounded SELECTs unless the user asks for an aggregate.\n");
+    s.push_str("- Use exact column and table names from the schema below. Do not invent columns.\n");
+    s.push_str("- Use schema-qualified names where a non-default schema is present.\n");
+    s.push_str("- Prefer explicit JOINs with ON clauses over comma joins.\n");
+    s.push_str("- If the request is ambiguous, pick the most useful interpretation and note the assumption in `explanation`.\n");
+    s.push_str("- If destructive intent is detected, populate `warnings` but still emit the query.\n\n");
+
+    if let Some(ctx) = &request.context {
+        s.push_str("## Database schema\n");
+
+        let tables: Vec<_> = ctx.tables.iter().take(MAX_TABLES_IN_PROMPT).collect();
+        for table in &tables {
+            let qualified = if table.schema.is_empty() || table.schema == "public" {
+                table.name.clone()
+            } else {
+                format!("{}.{}", table.schema, table.name)
+            };
+
+            s.push_str(&format!("\n### {}", qualified));
+            if let Some(rows) = table.row_count_estimate {
+                s.push_str(&format!(" (~{} rows)", rows));
+            }
+            s.push('\n');
+
+            for column in table.columns.iter().take(MAX_COLUMNS_PER_TABLE) {
+                let mut annots = Vec::new();
+                if column.is_primary_key {
+                    annots.push("PK");
+                }
+                if column.is_auto_increment {
+                    annots.push("AUTO");
+                }
+                if !column.is_nullable {
+                    annots.push("NOT NULL");
+                }
+                let annot_str = if annots.is_empty() {
+                    String::new()
+                } else {
+                    format!(" [{}]", annots.join(","))
+                };
+                s.push_str(&format!(
+                    "  - {} {}{}\n",
+                    column.name, column.data_type, annot_str
+                ));
+            }
+
+            if table.columns.len() > MAX_COLUMNS_PER_TABLE {
+                s.push_str(&format!(
+                    "  ... {} more columns truncated\n",
+                    table.columns.len() - MAX_COLUMNS_PER_TABLE
+                ));
+            }
+
+            if !table.foreign_keys.is_empty() {
+                s.push_str("  Foreign keys:\n");
+                for fk in &table.foreign_keys {
+                    let target = if fk.referenced_schema.is_empty()
+                        || fk.referenced_schema == "public"
+                    {
+                        fk.referenced_table.clone()
+                    } else {
+                        format!("{}.{}", fk.referenced_schema, fk.referenced_table)
+                    };
+                    s.push_str(&format!(
+                        "  - {} -> {}.{}\n",
+                        fk.column, target, fk.referenced_column
+                    ));
+                }
+            }
+        }
+
+        if ctx.tables.len() > MAX_TABLES_IN_PROMPT {
+            s.push_str(&format!(
+                "\n... {} more tables truncated from context\n",
+                ctx.tables.len() - MAX_TABLES_IN_PROMPT
+            ));
+        }
+    }
+
+    s.push_str("\n## Examples\n");
+    s.push_str("User: count rows in users\n");
+    s.push_str("Response: {\"sql\":\"SELECT COUNT(*) FROM users\",\"explanation\":\"Total rows in users table.\",\"warnings\":[]}\n\n");
+    s.push_str("User: users who never logged in\n");
+    s.push_str("Response: {\"sql\":\"SELECT * FROM users WHERE last_login_at IS NULL LIMIT 100\",\"explanation\":\"Users whose last_login_at is null.\",\"warnings\":[]}\n\n");
+    s.push_str("User: delete all users\n");
+    s.push_str("Response: {\"sql\":\"DELETE FROM users WHERE 1=0\",\"explanation\":\"Refusing to delete all rows. Use WHERE id IN (...) instead.\",\"warnings\":[\"Request was destructive; returned a no-op DELETE.\"]}\n");
+
+    s
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -67,6 +67,11 @@ impl AppState {
 #[allow(clippy::missing_panics_doc)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Load .env file if present. Walks up from CWD — finds workspace-root .env
+    // when launched via `bun tauri:dev`. Failure is silent (prod builds).
+    // Any std::env::var lookup afterwards sees these values.
+    let _ = dotenvy::dotenv();
+
     // Set up `tracing` before anything else so startup events are captured.
     observability::init();
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -181,11 +181,13 @@ pub fn run() {
             database::commands::export_schema_drizzle,
             // AI commands
             database::commands::ai_complete,
+            database::commands::ai_complete_stream,
             database::commands::ai_set_provider,
             database::commands::ai_get_provider,
             database::commands::ai_set_gemini_key,
             database::commands::ai_configure_ollama,
             database::commands::ai_list_ollama_models,
+            database::commands::ai_groq_status,
             // Window commands
             window::commands::minimize_window,
             window::commands::maximize_window,

--- a/apps/desktop/src/core/shortcuts/shortcuts.ts
+++ b/apps/desktop/src/core/shortcuts/shortcuts.ts
@@ -108,6 +108,11 @@ export const APP_SHORTCUTS = {
 		description: 'Open query history',
 		scope: 'sql-console'
 	},
+	aiCmdK: {
+		combo: 'mod+i',
+		description: 'AI: generate SQL from prompt',
+		scope: 'sql-console'
+	},
 	saveScript: {
 		combo: 'mod+s',
 		description: 'Save script',
@@ -223,7 +228,7 @@ export const SHORTCUT_CATEGORIES: Record<string, ShortcutName[]> = {
 		'gotoDashboard', 'gotoSettings', 'gotoConnections', 'gotoEditor', 'gotoDocker',
 	],
 	'SQL Console': [
-		'runQuery', 'runSelection', 'formatQuery', 'saveScript', 'openQueryHistory', 'newTab',
+		'runQuery', 'runSelection', 'formatQuery', 'saveScript', 'openQueryHistory', 'newTab', 'aiCmdK',
 	],
 	'Editor': [
 		'find', 'replace', 'toggleComment', 'selectNextOccurrence',

--- a/apps/desktop/src/features/schema-visualizer/schema-visualizer.tsx
+++ b/apps/desktop/src/features/schema-visualizer/schema-visualizer.tsx
@@ -374,7 +374,10 @@ function SchemaVisualizerInner({ activeConnectionId, onOpenTable }: Props) {
 				onToggleMinimap={() => setShowMinimap((v) => !v)}
 				editMode={editMode}
 				onToggleEditMode={() => setEditMode((value) => !value)}
-				onRefresh={fetchSchema}
+				onRefresh={() => {
+					const controller = new AbortController()
+					void fetchSchema(controller.signal)
+				}}
 				onExportJson={handleExportJson}
 				onExportSvg={handleExportSvg}
 				onExportPng={handleExportPng}

--- a/apps/desktop/src/features/sql-console/components/ai-cmd-k.tsx
+++ b/apps/desktop/src/features/sql-console/components/ai-cmd-k.tsx
@@ -1,0 +1,302 @@
+import { Channel } from '@tauri-apps/api/core'
+import { Loader2, Sparkles, X } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { commands } from '@/lib/bindings'
+import type { AiStreamEvent } from '@/lib/bindings'
+import { Button } from '@/shared/ui/button'
+import { cn } from '@/shared/utils/cn'
+
+type Props = {
+	open: boolean
+	onClose: () => void
+	onApplySql: (sql: string, explanation: string, warnings: string[]) => void
+	activeConnectionId: string | undefined
+	isTauri: boolean
+}
+
+type ParsedResult = {
+	sql: string
+	explanation: string
+	warnings: string[]
+}
+
+function parseLlmJson(raw: string): ParsedResult {
+	// Attempt strict JSON parse first
+	const trimmed = raw.trim()
+	try {
+		const parsed = JSON.parse(trimmed)
+		return {
+			sql: String(parsed.sql ?? '').trim(),
+			explanation: String(parsed.explanation ?? '').trim(),
+			warnings: Array.isArray(parsed.warnings)
+				? parsed.warnings.map((w: unknown) => String(w))
+				: [],
+		}
+	} catch {
+		// Fallback: strip leading ``` fences if model disobeyed and returned a fence
+		const fenced = trimmed.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/i, '')
+		try {
+			const parsed = JSON.parse(fenced)
+			return {
+				sql: String(parsed.sql ?? '').trim(),
+				explanation: String(parsed.explanation ?? '').trim(),
+				warnings: Array.isArray(parsed.warnings)
+					? parsed.warnings.map((w: unknown) => String(w))
+					: [],
+			}
+		} catch {
+			// Last-resort: return raw as SQL, no explanation
+			return { sql: trimmed, explanation: '', warnings: ['Response was not valid JSON.'] }
+		}
+	}
+}
+
+export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri }: Props) {
+	const [prompt, setPrompt] = useState('')
+	const [isGenerating, setIsGenerating] = useState(false)
+	const [streamedContent, setStreamedContent] = useState('')
+	const [error, setError] = useState<string | null>(null)
+	const [lastResult, setLastResult] = useState<ParsedResult | null>(null)
+	const promptRef = useRef<HTMLTextAreaElement | null>(null)
+	const abortRef = useRef<{ cancelled: boolean }>({ cancelled: false })
+
+	useEffect(
+		function resetOnOpen() {
+			if (open) {
+				setError(null)
+				setStreamedContent('')
+				setLastResult(null)
+				setIsGenerating(false)
+				abortRef.current.cancelled = false
+				setTimeout(() => promptRef.current?.focus(), 30)
+			}
+		},
+		[open]
+	)
+
+	const handleClose = useCallback(
+		function handleClose() {
+			abortRef.current.cancelled = true
+			setIsGenerating(false)
+			onClose()
+		},
+		[onClose]
+	)
+
+	const generate = useCallback(
+		async function generate() {
+			if (!prompt.trim() || isGenerating) return
+			if (!isTauri) {
+				setError('AI generation is only available in the desktop app.')
+				return
+			}
+
+			setError(null)
+			setStreamedContent('')
+			setLastResult(null)
+			setIsGenerating(true)
+			abortRef.current.cancelled = false
+
+			const channel = new Channel<AiStreamEvent>()
+			let accumulated = ''
+
+			channel.onmessage = function onmessage(event) {
+				if (abortRef.current.cancelled) return
+				switch (event.type) {
+					case 'token':
+						accumulated += event.text
+						setStreamedContent(accumulated)
+						break
+					case 'final':
+						if (event.content && event.content.length > accumulated.length) {
+							accumulated = event.content
+							setStreamedContent(accumulated)
+						}
+						break
+					case 'error':
+						setError(event.message)
+						break
+				}
+			}
+
+			try {
+				const result = await commands.aiCompleteStream(
+					prompt,
+					activeConnectionId ?? null,
+					null,
+					channel
+				)
+				if (abortRef.current.cancelled) return
+				if (result.status === 'error') {
+					setError(typeof result.error === 'string' ? result.error : JSON.stringify(result.error))
+					return
+				}
+				const parsed = parseLlmJson(accumulated)
+				setLastResult(parsed)
+			} catch (e) {
+				if (!abortRef.current.cancelled) {
+					setError(e instanceof Error ? e.message : String(e))
+				}
+			} finally {
+				if (!abortRef.current.cancelled) {
+					setIsGenerating(false)
+				}
+			}
+		},
+		[prompt, isGenerating, activeConnectionId, isTauri]
+	)
+
+	const accept = useCallback(
+		function accept() {
+			if (!lastResult || !lastResult.sql) return
+			onApplySql(lastResult.sql, lastResult.explanation, lastResult.warnings)
+			onClose()
+		},
+		[lastResult, onApplySql, onClose]
+	)
+
+	const handleKeyDown = useCallback(
+		function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+			if (e.key === 'Escape') {
+				e.preventDefault()
+				handleClose()
+				return
+			}
+			if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+				// Not wired to execute yet; treat same as Enter for now
+				e.preventDefault()
+				if (lastResult) accept()
+				else generate()
+				return
+			}
+			if ((e.metaKey || e.ctrlKey) && e.key === 'r') {
+				e.preventDefault()
+				generate()
+				return
+			}
+			if (e.key === 'Enter' && !e.shiftKey) {
+				e.preventDefault()
+				if (lastResult) accept()
+				else generate()
+			}
+		},
+		[handleClose, lastResult, accept, generate]
+	)
+
+	if (!open) return null
+
+	return (
+		<div
+			className='fixed inset-0 z-[60] flex items-start justify-center bg-black/40 backdrop-blur-sm'
+			onClick={handleClose}
+		>
+			<div
+				className='mt-24 w-[min(720px,90vw)] rounded-lg border border-sidebar-border bg-sidebar shadow-2xl overflow-hidden'
+				onClick={(e) => e.stopPropagation()}
+			>
+				<div className='flex items-center gap-2 border-b border-sidebar-border px-3 py-2'>
+					<Sparkles className='h-4 w-4 text-primary' />
+					<span className='text-xs font-semibold text-sidebar-foreground'>
+						AI SQL
+					</span>
+					<span className='text-[10px] text-muted-foreground'>
+						schema-grounded · via Groq
+					</span>
+					<div className='ml-auto flex items-center gap-1'>
+						{isGenerating && (
+							<Loader2 className='h-3.5 w-3.5 animate-spin text-muted-foreground' />
+						)}
+						<Button
+							variant='ghost'
+							size='icon'
+							className='h-6 w-6'
+							onClick={handleClose}
+						>
+							<X className='h-3.5 w-3.5' />
+						</Button>
+					</div>
+				</div>
+
+				<div className='px-3 pt-3'>
+					<textarea
+						ref={promptRef}
+						value={prompt}
+						onChange={(e) => setPrompt(e.target.value)}
+						onKeyDown={handleKeyDown}
+						disabled={isGenerating}
+						placeholder="e.g. users who signed up last week but haven't logged in"
+						className='w-full resize-none rounded-md border border-sidebar-border bg-background px-3 py-2 text-sm outline-none focus:border-primary disabled:opacity-50'
+						rows={2}
+					/>
+					<div className='mt-1 flex items-center justify-between text-[10px] text-muted-foreground'>
+						<span>
+							Enter to {lastResult ? 'accept' : 'generate'}
+							{' · '}⌘R to regenerate{' · '}Esc to close
+						</span>
+						{!activeConnectionId && (
+							<span className='text-amber-500'>
+								No active connection — schema context disabled
+							</span>
+						)}
+					</div>
+				</div>
+
+				{error && (
+					<div className='mx-3 mt-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive font-mono'>
+						{error}
+					</div>
+				)}
+
+				{streamedContent && (
+					<div className='mx-3 mb-3 mt-3 rounded-md border border-sidebar-border bg-background'>
+						<div className='flex items-center justify-between border-b border-sidebar-border px-3 py-1.5'>
+							<span className='text-[10px] font-semibold uppercase tracking-wider text-muted-foreground'>
+								{lastResult ? 'Generated SQL' : 'Streaming...'}
+							</span>
+							{lastResult && (
+								<div className='flex items-center gap-1'>
+									<Button
+										variant='ghost'
+										size='sm'
+										className='h-6 px-2 text-[10px]'
+										onClick={generate}
+									>
+										Regenerate
+									</Button>
+									<Button
+										variant='default'
+										size='sm'
+										className='h-6 px-2 text-[10px]'
+										onClick={accept}
+									>
+										Accept
+									</Button>
+								</div>
+							)}
+						</div>
+						<pre
+							className={cn(
+								'max-h-60 overflow-auto px-3 py-2 text-xs font-mono text-sidebar-foreground whitespace-pre-wrap',
+								!lastResult && 'opacity-70'
+							)}
+						>
+							{lastResult ? lastResult.sql : streamedContent}
+						</pre>
+						{lastResult && lastResult.explanation && (
+							<div className='border-t border-sidebar-border px-3 py-2 text-[11px] text-muted-foreground'>
+								{lastResult.explanation}
+							</div>
+						)}
+						{lastResult && lastResult.warnings.length > 0 && (
+							<div className='border-t border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-600 dark:text-amber-400'>
+								{lastResult.warnings.map((w, i) => (
+									<div key={i}>⚠ {w}</div>
+								))}
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/apps/desktop/src/features/sql-console/sql-console.tsx
+++ b/apps/desktop/src/features/sql-console/sql-console.tsx
@@ -1,7 +1,7 @@
 import { PanelLeft } from 'lucide-react'
 import { useState, useCallback, useEffect } from 'react'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
-import { useAdapter } from '@/core/data-provider/context'
+import { useAdapter, useIsTauri } from '@/core/data-provider/context'
 import { getAdapterError } from '@/core/data-provider/types'
 import { useShortcut, useActiveScope, useEffectiveShortcuts } from '@/core/shortcuts'
 import {
@@ -13,6 +13,7 @@ import type { SavedQuery } from '@/lib/bindings'
 import { CheatsheetPanel } from '../../features/drizzle-runner/components/cheatsheet-panel'
 import { CodeEditor } from '../../features/drizzle-runner/components/code-editor'
 import { DEFAULT_QUERY } from '../../features/drizzle-runner/data'
+import { AiCmdK } from './components/ai-cmd-k'
 import { ConsoleToolbar } from './components/console-toolbar'
 import { QueryHistoryPanel } from './components/query-history-panel'
 import { SqlEditor } from './components/sql-editor'
@@ -32,6 +33,7 @@ type Props = {
 
 export function SqlConsole({ onToggleSidebar: _onToggleSidebar, activeConnectionId, getConnectionName }: Props) {
 	const adapter = useAdapter()
+	const isTauri = useIsTauri()
 	const [mode, setMode] = useState<'sql' | 'drizzle'>('sql')
 	const [snippets, setSnippets] = useState<SqlSnippet[]>([])
 	const [activeSnippetId, setActiveSnippetId] = useState<string | null>('playground')
@@ -47,6 +49,7 @@ export function SqlConsole({ onToggleSidebar: _onToggleSidebar, activeConnection
 	const [showCheatsheet, setShowCheatsheet] = useState(false)
 	const [showFilter, setShowFilter] = useState(false)
 	const [showHistory, setShowHistory] = useState(false)
+	const [showAiCmdK, setShowAiCmdK] = useState(false)
 	const [tables, setTables] = useState<TableInfo[]>([])
 
 	const { addToHistory } = useQueryHistory()
@@ -696,6 +699,11 @@ export function SqlConsole({ onToggleSidebar: _onToggleSidebar, activeConnection
 		{ description: sqlShortcuts.openQueryHistory.description }
 	)
 
+	$.bind(sqlShortcuts.aiCmdK.combo).on(
+		function () { setShowAiCmdK(function (v) { return !v }) },
+		{ description: sqlShortcuts.aiCmdK.description }
+	)
+
 	$.key('s')
 		.except('typing')
 		.on(
@@ -898,6 +906,20 @@ export function SqlConsole({ onToggleSidebar: _onToggleSidebar, activeConnection
 					</>
 				)}
 			</PanelGroup>
+
+			<AiCmdK
+				open={showAiCmdK}
+				onClose={() => setShowAiCmdK(false)}
+				activeConnectionId={activeConnectionId}
+				isTauri={isTauri}
+				onApplySql={function (sql) {
+					if (mode === 'sql') {
+						setCurrentSqlQuery(sql)
+					} else {
+						setCurrentDrizzleQuery(sql)
+					}
+				}}
+			/>
 		</div>
 	)
 }

--- a/apps/desktop/src/lib/bindings.ts
+++ b/apps/desktop/src/lib/bindings.ts
@@ -8,7 +8,7 @@
 
 
 export const commands = {
-async minimizeWindow() : Promise<Result<null, any>> {
+async minimizeWindow() : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("minimize_window") };
 } catch (e) {
@@ -16,7 +16,7 @@ async minimizeWindow() : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async maximizeWindow() : Promise<Result<null, any>> {
+async maximizeWindow() : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("maximize_window") };
 } catch (e) {
@@ -24,7 +24,7 @@ async maximizeWindow() : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async closeWindow() : Promise<Result<null, any>> {
+async closeWindow() : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("close_window") };
 } catch (e) {
@@ -32,7 +32,7 @@ async closeWindow() : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async openSqliteDb() : Promise<Result<string | null, any>> {
+async openSqliteDb() : Promise<Result<string | null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("open_sqlite_db") };
 } catch (e) {
@@ -40,7 +40,7 @@ async openSqliteDb() : Promise<Result<string | null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async saveSqliteDb() : Promise<Result<string | null, any>> {
+async saveSqliteDb() : Promise<Result<string | null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("save_sqlite_db") };
 } catch (e) {
@@ -48,7 +48,7 @@ async saveSqliteDb() : Promise<Result<string | null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async openFile(title: string | null) : Promise<Result<string | null, any>> {
+async openFile(title: string | null) : Promise<Result<string | null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("open_file", { title }) };
 } catch (e) {
@@ -56,7 +56,7 @@ async openFile(title: string | null) : Promise<Result<string | null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async addConnection(name: string, databaseInfo: DatabaseInfo, color: number | null) : Promise<Result<ConnectionInfo, any>> {
+async addConnection(name: string, databaseInfo: DatabaseInfo, color: number | null) : Promise<Result<ConnectionInfo, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("add_connection", { name, databaseInfo, color }) };
 } catch (e) {
@@ -64,7 +64,7 @@ async addConnection(name: string, databaseInfo: DatabaseInfo, color: number | nu
     else return { status: "error", error: e  as any };
 }
 },
-async updateConnection(connId: string, name: string, databaseInfo: DatabaseInfo, color: number | null) : Promise<Result<ConnectionInfo, any>> {
+async updateConnection(connId: string, name: string, databaseInfo: DatabaseInfo, color: number | null) : Promise<Result<ConnectionInfo, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("update_connection", { connId, name, databaseInfo, color }) };
 } catch (e) {
@@ -72,7 +72,7 @@ async updateConnection(connId: string, name: string, databaseInfo: DatabaseInfo,
     else return { status: "error", error: e  as any };
 }
 },
-async updateConnectionColor(connectionId: string, color: number | null) : Promise<Result<null, any>> {
+async updateConnectionColor(connectionId: string, color: number | null) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("update_connection_color", { connectionId, color }) };
 } catch (e) {
@@ -80,7 +80,7 @@ async updateConnectionColor(connectionId: string, color: number | null) : Promis
     else return { status: "error", error: e  as any };
 }
 },
-async connectToDatabase(connectionId: string) : Promise<Result<boolean, any>> {
+async connectToDatabase(connectionId: string) : Promise<Result<boolean, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("connect_to_database", { connectionId }) };
 } catch (e) {
@@ -88,7 +88,7 @@ async connectToDatabase(connectionId: string) : Promise<Result<boolean, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async disconnectFromDatabase(connectionId: string) : Promise<Result<null, any>> {
+async disconnectFromDatabase(connectionId: string) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("disconnect_from_database", { connectionId }) };
 } catch (e) {
@@ -96,7 +96,7 @@ async disconnectFromDatabase(connectionId: string) : Promise<Result<null, any>> 
     else return { status: "error", error: e  as any };
 }
 },
-async getConnections() : Promise<Result<ConnectionInfo[], any>> {
+async getConnections() : Promise<Result<ConnectionInfo[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_connections") };
 } catch (e) {
@@ -104,7 +104,7 @@ async getConnections() : Promise<Result<ConnectionInfo[], any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async removeConnection(connectionId: string) : Promise<Result<null, any>> {
+async removeConnection(connectionId: string) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("remove_connection", { connectionId }) };
 } catch (e) {
@@ -112,7 +112,7 @@ async removeConnection(connectionId: string) : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async testConnection(databaseInfo: DatabaseInfo) : Promise<Result<boolean, any>> {
+async testConnection(databaseInfo: DatabaseInfo) : Promise<Result<boolean, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("test_connection", { databaseInfo }) };
 } catch (e) {
@@ -120,7 +120,7 @@ async testConnection(databaseInfo: DatabaseInfo) : Promise<Result<boolean, any>>
     else return { status: "error", error: e  as any };
 }
 },
-async initializeConnections() : Promise<Result<null, any>> {
+async initializeConnections() : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("initialize_connections") };
 } catch (e) {
@@ -128,7 +128,7 @@ async initializeConnections() : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getRecentConnections(limit: number | null) : Promise<Result<ConnectionInfo[], any>> {
+async getRecentConnections(limit: number | null) : Promise<Result<ConnectionInfo[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_recent_connections", { limit }) };
 } catch (e) {
@@ -136,7 +136,7 @@ async getRecentConnections(limit: number | null) : Promise<Result<ConnectionInfo
     else return { status: "error", error: e  as any };
 }
 },
-async getConnectionHistory(dbTypeFilter: string | null, successFilter: boolean | null, limit: number | null) : Promise<Result<ConnectionHistoryEntry[], any>> {
+async getConnectionHistory(dbTypeFilter: string | null, successFilter: boolean | null, limit: number | null) : Promise<Result<ConnectionHistoryEntry[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_connection_history", { dbTypeFilter, successFilter, limit }) };
 } catch (e) {
@@ -144,7 +144,7 @@ async getConnectionHistory(dbTypeFilter: string | null, successFilter: boolean |
     else return { status: "error", error: e  as any };
 }
 },
-async setConnectionPin(connectionId: string, pin: string | null) : Promise<Result<null, any>> {
+async setConnectionPin(connectionId: string, pin: string | null) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("set_connection_pin", { connectionId, pin }) };
 } catch (e) {
@@ -152,7 +152,7 @@ async setConnectionPin(connectionId: string, pin: string | null) : Promise<Resul
     else return { status: "error", error: e  as any };
 }
 },
-async verifyPinAndGetCredentials(connectionId: string, pin: string) : Promise<Result<string | null, any>> {
+async verifyPinAndGetCredentials(connectionId: string, pin: string) : Promise<Result<string | null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("verify_pin_and_get_credentials", { connectionId, pin }) };
 } catch (e) {
@@ -160,7 +160,7 @@ async verifyPinAndGetCredentials(connectionId: string, pin: string) : Promise<Re
     else return { status: "error", error: e  as any };
 }
 },
-async startQuery(connectionId: string, query: string) : Promise<Result<number[], any>> {
+async startQuery(connectionId: string, query: string) : Promise<Result<number[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("start_query", { connectionId, query }) };
 } catch (e) {
@@ -168,7 +168,7 @@ async startQuery(connectionId: string, query: string) : Promise<Result<number[],
     else return { status: "error", error: e  as any };
 }
 },
-async fetchQuery(queryId: number) : Promise<Result<StatementInfo, any>> {
+async fetchQuery(queryId: number) : Promise<Result<StatementInfo, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("fetch_query", { queryId }) };
 } catch (e) {
@@ -176,7 +176,7 @@ async fetchQuery(queryId: number) : Promise<Result<StatementInfo, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async fetchPage(queryId: number, pageIndex: number) : Promise<Result<JsonValue | null, any>> {
+async fetchPage(queryId: number, pageIndex: number) : Promise<Result<JsonValue | null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("fetch_page", { queryId, pageIndex }) };
 } catch (e) {
@@ -184,7 +184,7 @@ async fetchPage(queryId: number, pageIndex: number) : Promise<Result<JsonValue |
     else return { status: "error", error: e  as any };
 }
 },
-async getQueryStatus(queryId: number) : Promise<Result<QueryStatus, any>> {
+async getQueryStatus(queryId: number) : Promise<Result<QueryStatus, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_query_status", { queryId }) };
 } catch (e) {
@@ -192,7 +192,7 @@ async getQueryStatus(queryId: number) : Promise<Result<QueryStatus, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getPageCount(queryId: number) : Promise<Result<number, any>> {
+async getPageCount(queryId: number) : Promise<Result<number, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_page_count", { queryId }) };
 } catch (e) {
@@ -200,7 +200,7 @@ async getPageCount(queryId: number) : Promise<Result<number, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getColumns(queryId: number) : Promise<Result<JsonValue | null, any>> {
+async getColumns(queryId: number) : Promise<Result<JsonValue | null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_columns", { queryId }) };
 } catch (e) {
@@ -208,7 +208,7 @@ async getColumns(queryId: number) : Promise<Result<JsonValue | null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async saveQueryToHistory(connectionId: string, query: string, durationMs: number | null, status: string, rowCount: number, errorMessage: string | null) : Promise<Result<null, any>> {
+async saveQueryToHistory(connectionId: string, query: string, durationMs: number | null, status: string, rowCount: number, errorMessage: string | null) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("save_query_to_history", { connectionId, query, durationMs, status, rowCount, errorMessage }) };
 } catch (e) {
@@ -216,7 +216,7 @@ async saveQueryToHistory(connectionId: string, query: string, durationMs: number
     else return { status: "error", error: e  as any };
 }
 },
-async getQueryHistory(connectionId: string, limit: number | null) : Promise<Result<QueryHistoryEntry[], any>> {
+async getQueryHistory(connectionId: string, limit: number | null) : Promise<Result<QueryHistoryEntry[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_query_history", { connectionId, limit }) };
 } catch (e) {
@@ -224,7 +224,7 @@ async getQueryHistory(connectionId: string, limit: number | null) : Promise<Resu
     else return { status: "error", error: e  as any };
 }
 },
-async startLiveMonitor(connectionId: string, tableName: string, intervalMs: number, changeTypes: LiveMonitorChangeType[]) : Promise<Result<LiveMonitorSession, any>> {
+async startLiveMonitor(connectionId: string, tableName: string, intervalMs: number, changeTypes: LiveMonitorChangeType[]) : Promise<Result<LiveMonitorSession, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("start_live_monitor", { connectionId, tableName, intervalMs, changeTypes }) };
 } catch (e) {
@@ -232,7 +232,7 @@ async startLiveMonitor(connectionId: string, tableName: string, intervalMs: numb
     else return { status: "error", error: e  as any };
 }
 },
-async stopLiveMonitor(monitorId: string) : Promise<Result<null, any>> {
+async stopLiveMonitor(monitorId: string) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("stop_live_monitor", { monitorId }) };
 } catch (e) {
@@ -240,7 +240,7 @@ async stopLiveMonitor(monitorId: string) : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getRecentQueries(connectionId: string | null, limit: number | null, statusFilter: string | null) : Promise<Result<QueryHistoryEntry[], any>> {
+async getRecentQueries(connectionId: string | null, limit: number | null, statusFilter: string | null) : Promise<Result<QueryHistoryEntry[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_recent_queries", { connectionId, limit, statusFilter }) };
 } catch (e) {
@@ -248,7 +248,7 @@ async getRecentQueries(connectionId: string | null, limit: number | null, status
     else return { status: "error", error: e  as any };
 }
 },
-async saveScript(name: string, content: string, connectionId: string | null, description: string | null) : Promise<Result<number, any>> {
+async saveScript(name: string, content: string, connectionId: string | null, description: string | null) : Promise<Result<number, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("save_script", { name, content, connectionId, description }) };
 } catch (e) {
@@ -256,7 +256,7 @@ async saveScript(name: string, content: string, connectionId: string | null, des
     else return { status: "error", error: e  as any };
 }
 },
-async updateScript(id: number, name: string, content: string, connectionId: string | null, description: string | null) : Promise<Result<null, any>> {
+async updateScript(id: number, name: string, content: string, connectionId: string | null, description: string | null) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("update_script", { id, name, content, connectionId, description }) };
 } catch (e) {
@@ -264,7 +264,7 @@ async updateScript(id: number, name: string, content: string, connectionId: stri
     else return { status: "error", error: e  as any };
 }
 },
-async getScripts(connectionId: string | null) : Promise<Result<SavedQuery[], any>> {
+async getScripts(connectionId: string | null) : Promise<Result<SavedQuery[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_scripts", { connectionId }) };
 } catch (e) {
@@ -272,7 +272,7 @@ async getScripts(connectionId: string | null) : Promise<Result<SavedQuery[], any
     else return { status: "error", error: e  as any };
 }
 },
-async deleteScript(id: number) : Promise<Result<null, any>> {
+async deleteScript(id: number) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("delete_script", { id }) };
 } catch (e) {
@@ -280,7 +280,7 @@ async deleteScript(id: number) : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getSnippets(languageFilter: string | null, isSystemFilter: boolean | null, categoryFilter: string | null) : Promise<Result<SavedQuery[], any>> {
+async getSnippets(languageFilter: string | null, isSystemFilter: boolean | null, categoryFilter: string | null) : Promise<Result<SavedQuery[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_snippets", { languageFilter, isSystemFilter, categoryFilter }) };
 } catch (e) {
@@ -288,7 +288,7 @@ async getSnippets(languageFilter: string | null, isSystemFilter: boolean | null,
     else return { status: "error", error: e  as any };
 }
 },
-async saveSnippet(name: string, content: string, language: string | null, tags: string | null, category: string | null, connectionId: string | null, description: string | null, folderId: number | null) : Promise<Result<number, any>> {
+async saveSnippet(name: string, content: string, language: string | null, tags: string | null, category: string | null, connectionId: string | null, description: string | null, folderId: number | null) : Promise<Result<number, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("save_snippet", { name, content, language, tags, category, connectionId, description, folderId }) };
 } catch (e) {
@@ -296,7 +296,7 @@ async saveSnippet(name: string, content: string, language: string | null, tags: 
     else return { status: "error", error: e  as any };
 }
 },
-async updateSnippet(id: number, name: string, content: string, language: string | null, tags: string | null, category: string | null, description: string | null, folderId: number | null, connectionId: string | null) : Promise<Result<null, any>> {
+async updateSnippet(id: number, name: string, content: string, language: string | null, tags: string | null, category: string | null, description: string | null, folderId: number | null, connectionId: string | null) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("update_snippet", { id, name, content, language, tags, category, description, folderId, connectionId }) };
 } catch (e) {
@@ -304,7 +304,7 @@ async updateSnippet(id: number, name: string, content: string, language: string 
     else return { status: "error", error: e  as any };
 }
 },
-async deleteSnippet(id: number) : Promise<Result<null, any>> {
+async deleteSnippet(id: number) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("delete_snippet", { id }) };
 } catch (e) {
@@ -312,7 +312,7 @@ async deleteSnippet(id: number) : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async seedSystemSnippets() : Promise<Result<number, any>> {
+async seedSystemSnippets() : Promise<Result<number, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("seed_system_snippets") };
 } catch (e) {
@@ -320,7 +320,7 @@ async seedSystemSnippets() : Promise<Result<number, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getSnippetFolders() : Promise<Result<SnippetFolder[], any>> {
+async getSnippetFolders() : Promise<Result<SnippetFolder[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_snippet_folders") };
 } catch (e) {
@@ -328,7 +328,7 @@ async getSnippetFolders() : Promise<Result<SnippetFolder[], any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async createSnippetFolder(name: string, parentId: number | null, color: string | null) : Promise<Result<number, any>> {
+async createSnippetFolder(name: string, parentId: number | null, color: string | null) : Promise<Result<number, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("create_snippet_folder", { name, parentId, color }) };
 } catch (e) {
@@ -336,7 +336,7 @@ async createSnippetFolder(name: string, parentId: number | null, color: string |
     else return { status: "error", error: e  as any };
 }
 },
-async updateSnippetFolder(id: number, name: string, color: string | null) : Promise<Result<null, any>> {
+async updateSnippetFolder(id: number, name: string, color: string | null) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("update_snippet_folder", { id, name, color }) };
 } catch (e) {
@@ -344,7 +344,7 @@ async updateSnippetFolder(id: number, name: string, color: string | null) : Prom
     else return { status: "error", error: e  as any };
 }
 },
-async deleteSnippetFolder(id: number) : Promise<Result<null, any>> {
+async deleteSnippetFolder(id: number) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("delete_snippet_folder", { id }) };
 } catch (e) {
@@ -352,7 +352,7 @@ async deleteSnippetFolder(id: number) : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async saveSessionState(sessionData: string) : Promise<Result<null, any>> {
+async saveSessionState(sessionData: string) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("save_session_state", { sessionData }) };
 } catch (e) {
@@ -360,7 +360,7 @@ async saveSessionState(sessionData: string) : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getSessionState() : Promise<Result<string | null, any>> {
+async getSessionState() : Promise<Result<string | null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_session_state") };
 } catch (e) {
@@ -368,7 +368,7 @@ async getSessionState() : Promise<Result<string | null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getSetting(key: string) : Promise<Result<string | null, any>> {
+async getSetting(key: string) : Promise<Result<string | null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_setting", { key }) };
 } catch (e) {
@@ -376,7 +376,7 @@ async getSetting(key: string) : Promise<Result<string | null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async setSetting(key: string, value: string) : Promise<Result<null, any>> {
+async setSetting(key: string, value: string) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("set_setting", { key, value }) };
 } catch (e) {
@@ -384,7 +384,7 @@ async setSetting(key: string, value: string) : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async insertRow(connectionId: string, tableName: string, schemaName: string | null, rowData: Partial<{ [key in string]: JsonValue }>) : Promise<Result<MutationResult, any>> {
+async insertRow(connectionId: string, tableName: string, schemaName: string | null, rowData: Partial<{ [key in string]: JsonValue }>) : Promise<Result<MutationResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("insert_row", { connectionId, tableName, schemaName, rowData }) };
 } catch (e) {
@@ -392,7 +392,7 @@ async insertRow(connectionId: string, tableName: string, schemaName: string | nu
     else return { status: "error", error: e  as any };
 }
 },
-async updateCell(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValue: JsonValue, columnName: string, newValue: JsonValue) : Promise<Result<MutationResult, any>> {
+async updateCell(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValue: JsonValue, columnName: string, newValue: JsonValue) : Promise<Result<MutationResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("update_cell", { connectionId, tableName, schemaName, primaryKeyColumn, primaryKeyValue, columnName, newValue }) };
 } catch (e) {
@@ -400,7 +400,7 @@ async updateCell(connectionId: string, tableName: string, schemaName: string | n
     else return { status: "error", error: e  as any };
 }
 },
-async deleteRows(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValues: JsonValue[]) : Promise<Result<MutationResult, any>> {
+async deleteRows(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValues: JsonValue[]) : Promise<Result<MutationResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("delete_rows", { connectionId, tableName, schemaName, primaryKeyColumn, primaryKeyValues }) };
 } catch (e) {
@@ -408,7 +408,7 @@ async deleteRows(connectionId: string, tableName: string, schemaName: string | n
     else return { status: "error", error: e  as any };
 }
 },
-async duplicateRow(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValue: JsonValue) : Promise<Result<MutationResult, any>> {
+async duplicateRow(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValue: JsonValue) : Promise<Result<MutationResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("duplicate_row", { connectionId, tableName, schemaName, primaryKeyColumn, primaryKeyValue }) };
 } catch (e) {
@@ -416,7 +416,7 @@ async duplicateRow(connectionId: string, tableName: string, schemaName: string |
     else return { status: "error", error: e  as any };
 }
 },
-async exportTable(connectionId: string, tableName: string, schemaName: string | null, format: ExportFormat, limit: number | null) : Promise<Result<string, any>> {
+async exportTable(connectionId: string, tableName: string, schemaName: string | null, format: ExportFormat, limit: number | null) : Promise<Result<string, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("export_table", { connectionId, tableName, schemaName, format, limit }) };
 } catch (e) {
@@ -424,7 +424,7 @@ async exportTable(connectionId: string, tableName: string, schemaName: string | 
     else return { status: "error", error: e  as any };
 }
 },
-async softDeleteRows(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValues: JsonValue[], softDeleteColumn: string | null) : Promise<Result<SoftDeleteResult, any>> {
+async softDeleteRows(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValues: JsonValue[], softDeleteColumn: string | null) : Promise<Result<SoftDeleteResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("soft_delete_rows", { connectionId, tableName, schemaName, primaryKeyColumn, primaryKeyValues, softDeleteColumn }) };
 } catch (e) {
@@ -432,7 +432,7 @@ async softDeleteRows(connectionId: string, tableName: string, schemaName: string
     else return { status: "error", error: e  as any };
 }
 },
-async undoSoftDelete(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValues: JsonValue[], softDeleteColumn: string) : Promise<Result<MutationResult, any>> {
+async undoSoftDelete(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValues: JsonValue[], softDeleteColumn: string) : Promise<Result<MutationResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("undo_soft_delete", { connectionId, tableName, schemaName, primaryKeyColumn, primaryKeyValues, softDeleteColumn }) };
 } catch (e) {
@@ -440,7 +440,7 @@ async undoSoftDelete(connectionId: string, tableName: string, schemaName: string
     else return { status: "error", error: e  as any };
 }
 },
-async truncateTable(connectionId: string, tableName: string, schemaName: string | null, cascade: boolean | null) : Promise<Result<TruncateResult, any>> {
+async truncateTable(connectionId: string, tableName: string, schemaName: string | null, cascade: boolean | null) : Promise<Result<TruncateResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("truncate_table", { connectionId, tableName, schemaName, cascade }) };
 } catch (e) {
@@ -448,7 +448,7 @@ async truncateTable(connectionId: string, tableName: string, schemaName: string 
     else return { status: "error", error: e  as any };
 }
 },
-async truncateDatabase(connectionId: string, schemaName: string | null, confirm: boolean) : Promise<Result<TruncateResult, any>> {
+async truncateDatabase(connectionId: string, schemaName: string | null, confirm: boolean) : Promise<Result<TruncateResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("truncate_database", { connectionId, schemaName, confirm }) };
 } catch (e) {
@@ -456,7 +456,7 @@ async truncateDatabase(connectionId: string, schemaName: string | null, confirm:
     else return { status: "error", error: e  as any };
 }
 },
-async dumpDatabase(connectionId: string, outputPath: string) : Promise<Result<DumpResult, any>> {
+async dumpDatabase(connectionId: string, outputPath: string) : Promise<Result<DumpResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("dump_database", { connectionId, outputPath }) };
 } catch (e) {
@@ -464,7 +464,7 @@ async dumpDatabase(connectionId: string, outputPath: string) : Promise<Result<Du
     else return { status: "error", error: e  as any };
 }
 },
-async executeBatch(connectionId: string, statements: string[]) : Promise<Result<MutationResult, any>> {
+async executeBatch(connectionId: string, statements: string[]) : Promise<Result<MutationResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("execute_batch", { connectionId, statements }) };
 } catch (e) {
@@ -472,7 +472,7 @@ async executeBatch(connectionId: string, statements: string[]) : Promise<Result<
     else return { status: "error", error: e  as any };
 }
 },
-async getDatabaseSchema(connectionId: string) : Promise<Result<DatabaseSchema, any>> {
+async getDatabaseSchema(connectionId: string) : Promise<Result<DatabaseSchema, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_database_schema", { connectionId }) };
 } catch (e) {
@@ -480,7 +480,7 @@ async getDatabaseSchema(connectionId: string) : Promise<Result<DatabaseSchema, a
     else return { status: "error", error: e  as any };
 }
 },
-async getDatabaseMetadata(connectionId: string) : Promise<Result<DatabaseMetadata, any>> {
+async getDatabaseMetadata(connectionId: string) : Promise<Result<DatabaseMetadata, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_database_metadata", { connectionId }) };
 } catch (e) {
@@ -488,7 +488,7 @@ async getDatabaseMetadata(connectionId: string) : Promise<Result<DatabaseMetadat
     else return { status: "error", error: e  as any };
 }
 },
-async seedTable(connectionId: string, tableName: string, schemaName: string | null, count: number) : Promise<Result<SeedResult, any>> {
+async seedTable(connectionId: string, tableName: string, schemaName: string | null, count: number) : Promise<Result<SeedResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("seed_table", { connectionId, tableName, schemaName, count }) };
 } catch (e) {
@@ -496,7 +496,7 @@ async seedTable(connectionId: string, tableName: string, schemaName: string | nu
     else return { status: "error", error: e  as any };
 }
 },
-async parseSql(sql: string) : Promise<Result<JsonValue, any>> {
+async parseSql(sql: string) : Promise<Result<JsonValue, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("parse_sql", { sql }) };
 } catch (e) {
@@ -504,7 +504,7 @@ async parseSql(sql: string) : Promise<Result<JsonValue, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async buildSql(ast: JsonValue) : Promise<Result<string, any>> {
+async buildSql(ast: JsonValue) : Promise<Result<string, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("build_sql", { ast }) };
 } catch (e) {
@@ -515,7 +515,7 @@ async buildSql(ast: JsonValue) : Promise<Result<string, any>> {
 /**
  * Export database schema to SQL DDL format.
  */
-async exportSchemaSql(connectionId: string, dialect: string) : Promise<Result<string, any>> {
+async exportSchemaSql(connectionId: string, dialect: string) : Promise<Result<string, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("export_schema_sql", { connectionId, dialect }) };
 } catch (e) {
@@ -526,7 +526,7 @@ async exportSchemaSql(connectionId: string, dialect: string) : Promise<Result<st
 /**
  * Export database schema to Drizzle ORM TypeScript format.
  */
-async exportSchemaDrizzle(connectionId: string, dialect: string) : Promise<Result<string, any>> {
+async exportSchemaDrizzle(connectionId: string, dialect: string) : Promise<Result<string, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("export_schema_drizzle", { connectionId, dialect }) };
 } catch (e) {
@@ -534,7 +534,7 @@ async exportSchemaDrizzle(connectionId: string, dialect: string) : Promise<Resul
     else return { status: "error", error: e  as any };
 }
 },
-async aiComplete(prompt: string, connectionId: string | null, maxTokens: number | null) : Promise<Result<AIResponse, any>> {
+async aiComplete(prompt: string, connectionId: string | null, maxTokens: number | null) : Promise<Result<AIResponse, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("ai_complete", { prompt, connectionId, maxTokens }) };
 } catch (e) {
@@ -542,7 +542,15 @@ async aiComplete(prompt: string, connectionId: string | null, maxTokens: number 
     else return { status: "error", error: e  as any };
 }
 },
-async aiSetProvider(provider: string) : Promise<Result<null, any>> {
+async aiCompleteStream(prompt: string, connectionId: string | null, maxTokens: number | null, onEvent: TAURI_CHANNEL<AiStreamEvent>) : Promise<Result<null, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_complete_stream", { prompt, connectionId, maxTokens, onEvent }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async aiSetProvider(provider: string) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("ai_set_provider", { provider }) };
 } catch (e) {
@@ -550,7 +558,7 @@ async aiSetProvider(provider: string) : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async aiGetProvider() : Promise<Result<string, any>> {
+async aiGetProvider() : Promise<Result<string, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("ai_get_provider") };
 } catch (e) {
@@ -558,7 +566,7 @@ async aiGetProvider() : Promise<Result<string, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async aiSetGeminiKey(apiKey: string) : Promise<Result<null, any>> {
+async aiSetGeminiKey(apiKey: string) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("ai_set_gemini_key", { apiKey }) };
 } catch (e) {
@@ -566,7 +574,7 @@ async aiSetGeminiKey(apiKey: string) : Promise<Result<null, any>> {
     else return { status: "error", error: e  as any };
 }
 },
-async aiConfigureOllama(endpoint: string | null, model: string | null) : Promise<Result<null, any>> {
+async aiConfigureOllama(endpoint: string | null, model: string | null) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("ai_configure_ollama", { endpoint, model }) };
 } catch (e) {
@@ -574,9 +582,21 @@ async aiConfigureOllama(endpoint: string | null, model: string | null) : Promise
     else return { status: "error", error: e  as any };
 }
 },
-async aiListOllamaModels() : Promise<Result<string[], any>> {
+async aiListOllamaModels() : Promise<Result<string[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("ai_list_ollama_models") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Check whether Groq provider is usable (env keys present).
+ * Returns key count detected. Never exposes the key values.
+ */
+async aiGroqStatus() : Promise<Result<GroqStatus, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_groq_status") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -595,6 +615,7 @@ async aiListOllamaModels() : Promise<Result<string[], any>> {
 /** user-defined types **/
 
 export type AIResponse = { content: string; suggested_queries: string[] | null; tokens_used: number | null; provider: string }
+export type AiStreamEvent = { type: "token"; text: string } | { type: "final"; content: string } | { type: "error"; message: string }
 export type ColumnInfo = { name: string; data_type: string; is_nullable: boolean; default_value: string | null; 
 /**
  * Whether this column is part of the primary key
@@ -680,6 +701,7 @@ referenced_column: string;
  * The schema of the referenced table (empty for SQLite)
  */
 referenced_schema: string }
+export type GroqStatus = { available: boolean; key_count: number }
 export type IndexInfo = { name: string; column_names: string[]; is_unique: boolean; is_primary: boolean }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
 export type LiveMonitorChangeType = "insert" | "update" | "delete"
@@ -707,6 +729,7 @@ deleted_at: number;
 undo_window_seconds: number }
 export type SshConfig = { host: string; port: number; username: string; private_key_path: string | null; password: string | null }
 export type StatementInfo = { returns_values: boolean; status: QueryStatus; first_page: JsonValue; affected_rows: number | null; error: string | null }
+export type TAURI_CHANNEL<TSend> = null
 export type TableInfo = { name: string; schema: string; columns: ColumnInfo[]; 
 /**
  * Names of columns that form the primary key (supports composite keys)


### PR DESCRIPTION
## Summary

Adds an inline AI SQL generator to the SQL Console — ⌘I opens an overlay, streams a schema-aware SQL query from Groq, and inserts the result into the editor on Enter.

Runs entirely on free-tier providers — **Groq becomes the new default** with multi-key rotation to sidestep rate limits.

## Setup

Set one or more keys in your shell env. The app picks them up on start:

\`\`\`bash
export GROQ_API_KEY_1=gsk_...
export GROQ_API_KEY_2=gsk_...
export GROQ_API_KEY_3=gsk_...
# Optional model override:
export GROQ_MODEL=llama-3.3-70b-versatile
\`\`\`

On a 429 or 401 the client transparently rotates to the next key. Keys are never persisted in app storage.

## UX

- **⌘I** in SQL Console → overlay at top
- Type natural language, **Enter** to generate, **Enter again** to accept
- **⌘R** regenerate, **Esc** cancel
- Schema grounding: the active connection's tables, types, PKs and FKs are injected into the system prompt

## Backend

- \`services/ai/groq.rs\` — OpenAI-compatible client, env-driven rotating keys, SSE streaming via \`bytes_stream\`
- \`services/ai/prompts.rs\` — unified schema prompt shared by Groq / Gemini / Ollama; includes rules (no DROP, LIMIT 100, schema-qualified names) and few-shot examples
- Enriched \`SchemaContext\` — \`ColumnContext\` (type, nullable, PK, auto-increment), \`ForeignKeyContext[]\`, row estimates, engine tag
- \`AiStreamEvent\` + \`ai_complete_stream\` command via \`tauri::ipc::Channel\`
- \`ai_groq_status\` — reports env-key presence/count without exposing values
- Non-Groq providers fall back gracefully to a single \`Final\` event

## Prior art / inspiration

- Vercel Natural Language Postgres — https://vercel.com/templates/next.js/natural-language-postgres
- Supabase database.build — https://github.com/supabase-community/database-build · https://supabase.com/blog/database-build-v2

## Side-effect

Error shape in regenerated bindings is now \`{ kind, detail }\` instead of \`any\` for commands touched by the new \`specta::Type\` derives. Nice free upgrade.

## Test plan

- [ ] Set \`GROQ_API_KEY_1\` → open SQL Console → ⌘I → type \"count users\" → SQL streams in → Enter inserts
- [ ] Unset all keys → ⌘I → \"No GROQ_API_KEY...\" error surfaced cleanly
- [ ] Set 2 keys, simulate 429 on first → second key used transparently
- [ ] Destructive intent (\"delete all users\") → model returns no-op with warning
- [ ] No active connection → overlay warns \"schema context disabled\", still generates against base system prompt
- [ ] tsc --noEmit exits 0 (verified)
- [ ] cargo check (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)