### PR TITLE
feat: AI encrypted key store + data-grid refactor (0.0.109)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,15 @@
 GEMINI_API_KEY=your-api-key
 
 # Groq API keys — used by the AI SQL command palette (⌘I / mod+i).
-# You can set up to 10 keys; the backend rotates across them on 429 / 401.
+#
+# Recommended: add keys via the desktop app at Settings → AI Keys (Groq).
+# Keys saved in the UI are encrypted with AES-256-GCM and the master key is stored in
+# your OS keychain (Keychain on macOS, libsecret/secret-service on Linux, Credential Manager
+# on Windows). UI-stored keys persist across launches and survive app restarts.
+#
+# Env-based keys below remain supported and are merged with UI-stored keys at runtime.
+# The backend rotates across the merged set on 429 / 401 / 5xx errors.
+#
 # Free-tier keys: https://console.groq.com/keys
 GROQ_API_KEY_1=your-groq-key-here
 # GROQ_API_KEY_2=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.0.109 - Data Grid Refactor & Schema Visualizer Fix
+
+**Date:** 2026-04-25
+
+**Highlights**
+
+- Split the 1455-line `data-grid.tsx` into a 245-line shell plus 15 focused modules under `data-grid/` — extracted hooks (`use-cell-editing`, `use-cell-selection`, `use-row-selection`, `use-grid-keyboard`, `use-column-resize`, `use-context-menu-reporting`, `use-focused-cell`, `use-right-drag-scroll`), child components (`cell-value`, `draft-row`, `empty-states`, `grid-body`, `grid-header`), and pure modules (`selection.ts`, `types.ts`). Same behavior, far cleaner ownership.
+- Restored the broken imports in `schema-visualizer/components/table-node.tsx` (Handle, Position, NodeProps, Key, LinkIcon) — `tsc -b` is now clean.
+- Bundles every change shipped on this branch: AI encrypted key store (Settings → AI Keys), abort path for the ⌘I overlay, JSON-mode streaming, key rotation on 5xx/403, and Insert + Run.
+
 ## 0.0.108 - AI SQL Generator: Encrypted Key Store, Test, Abort & Insert+Run
 
 **Date:** 2026-04-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.0.108 - AI SQL Generator: Encrypted Key Store, Test, Abort & Insert+Run
+
+**Date:** 2026-04-24
+
+**Highlights**
+
+- Added an encrypted Groq API key store inside the app — Settings → AI Keys (Groq) lets you add, label, enable/disable, test, and delete keys. Ciphertext is AES-256-GCM and the master key lives in the OS keychain (Keychain / libsecret / Credential Manager).
+- Env-based keys (`GROQ_API_KEY`, `GROQ_API_KEY_1..10`, `GROQ_MODEL`) are still honored and merged with UI-stored keys at runtime, with duplicate keys deduplicated.
+- New "Test" button validates a key against Groq before saving, and a per-key live test button records the result in the row.
+- The ⌘I overlay now shows a status badge (`N keys` / `no keys`) so missing configuration is obvious before you type a prompt.
+- New "Insert + Run" action — accepting an AI suggestion with ⌘⏎ pastes the SQL into the editor and immediately executes it.
+- Added a real abort path — closing the overlay or hitting Esc mid-stream calls `ai_abort_stream` and the backend short-circuits the SSE loop.
+- Streaming completions now request `response_format: json_object`, which keeps tokens inside a JSON envelope and stops the model wandering into prose / markdown fences mid-stream.
+- Key rotation now also fires on `5xx` and `403` errors (was 429/401 only) so transient provider issues fail over instead of bubbling up.
+- Bumped reqwest client to a 60s timeout for streaming and a separate 15s client for key tests.
+
 ## 0.0.107 - Self-hosted APT Repository (sudo apt install dora)
 
 **Date:** 2026-04-19

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dora/desktop",
-	"version": "0.0.108",
+	"version": "0.0.109",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dora/desktop",
-	"version": "0.0.106",
+	"version": "0.0.108",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.0.106"
+version = "0.0.108"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.0.108"
+version = "0.0.109"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.106"
+version = "0.0.108"
 description = ""
 authors = ["Remco Stoeten"]
 license = "GPLv3"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.108"
+version = "0.0.109"
 description = ""
 authors = ["Remco Stoeten"]
 license = "GPLv3"

--- a/apps/desktop/src-tauri/migrations/008.sql
+++ b/apps/desktop/src-tauri/migrations/008.sql
@@ -1,0 +1,16 @@
+-- Migration 008: AI provider API key store
+-- Stores user-managed API keys for AI providers (Groq today, others later).
+-- Ciphertext is AES-256-GCM via security::encrypt; the encryption key lives in the OS keyring.
+CREATE TABLE IF NOT EXISTS ai_api_keys (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider     TEXT NOT NULL,
+    label        TEXT NOT NULL,
+    ciphertext   TEXT NOT NULL,
+    is_active    INTEGER NOT NULL DEFAULT 1,
+    last_tested  INTEGER,
+    last_status  TEXT,
+    created_at   INTEGER NOT NULL,
+    updated_at   INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_api_keys_provider ON ai_api_keys(provider, is_active);

--- a/apps/desktop/src-tauri/src/bindings.rs
+++ b/apps/desktop/src-tauri/src/bindings.rs
@@ -79,7 +79,14 @@ pub fn generate_bindings() -> Builder<tauri::Wry> {
         db_commands::ai_set_gemini_key,
         db_commands::ai_configure_ollama,
         db_commands::ai_list_ollama_models,
-        db_commands::ai_groq_status
+        db_commands::ai_groq_status,
+        db_commands::ai_abort_stream,
+        db_commands::ai_keys_list,
+        db_commands::ai_keys_add,
+        db_commands::ai_keys_delete,
+        db_commands::ai_keys_set_active,
+        db_commands::ai_keys_test,
+        db_commands::ai_keys_test_raw
     ])
 }
 

--- a/apps/desktop/src-tauri/src/database/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/database/commands/ai.rs
@@ -1,3 +1,6 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use tauri::State;
 use uuid::Uuid;
 
@@ -10,6 +13,7 @@ use crate::{
         types::DatabaseSchema,
     },
     error::Error,
+    storage::AiApiKeyRecord,
     AppState,
 };
 
@@ -102,6 +106,7 @@ pub async fn ai_complete(
 #[tauri::command]
 #[specta::specta]
 pub async fn ai_complete_stream(
+    request_id: String,
     prompt: String,
     connection_id: Option<Uuid>,
     max_tokens: Option<u32>,
@@ -124,6 +129,9 @@ pub async fn ai_complete_stream(
         max_tokens,
     };
 
+    let cancel = Arc::new(AtomicBool::new(false));
+    state.ai_cancel_flags.insert(request_id.clone(), cancel.clone());
+
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<AiStreamEvent>();
 
     // Forward internal channel to Tauri IPC channel
@@ -136,10 +144,12 @@ pub async fn ai_complete_stream(
     let svc = AIService {
         storage: &state.storage,
     };
-    let result = svc.complete_stream(request, tx).await;
+    let result = svc.complete_stream(request, tx, cancel).await;
 
     // Wait for forwarder to drain
     let _ = forward_handle.await;
+
+    state.ai_cancel_flags.remove(&request_id);
 
     if let Err(ref e) = result {
         // Best-effort: errors are surfaced through the command return value,
@@ -148,6 +158,17 @@ pub async fn ai_complete_stream(
     }
 
     result
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_abort_stream(request_id: String, state: State<'_, AppState>) -> Result<bool, Error> {
+    if let Some(flag) = state.ai_cancel_flags.get(&request_id) {
+        flag.store(true, Ordering::Relaxed);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
 }
 
 #[tauri::command]
@@ -215,12 +236,12 @@ pub async fn ai_list_ollama_models(state: State<'_, AppState>) -> Result<Vec<Str
     client.list_models().await
 }
 
-/// Check whether Groq provider is usable (env keys present).
+/// Check whether Groq provider is usable (env or DB keys present).
 /// Returns key count detected. Never exposes the key values.
 #[tauri::command]
 #[specta::specta]
-pub async fn ai_groq_status() -> Result<GroqStatus, Error> {
-    match GroqClient::from_env() {
+pub async fn ai_groq_status(state: State<'_, AppState>) -> Result<GroqStatus, Error> {
+    match GroqClient::from_env_and_storage(&state.storage) {
         Ok(client) => Ok(GroqStatus {
             available: true,
             key_count: client.key_count(),
@@ -230,4 +251,80 @@ pub async fn ai_groq_status() -> Result<GroqStatus, Error> {
             key_count: 0,
         }),
     }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_keys_list(
+    provider: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<AiApiKeyRecord>, Error> {
+    state.storage.ai_keys_list(&provider)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_keys_add(
+    provider: String,
+    label: String,
+    api_key: String,
+    state: State<'_, AppState>,
+) -> Result<i64, Error> {
+    if api_key.trim().is_empty() {
+        return Err(Error::InvalidInput("API key cannot be empty".into()));
+    }
+    state.storage.ai_keys_add(&provider, &label, api_key.trim())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_keys_delete(id: i64, state: State<'_, AppState>) -> Result<(), Error> {
+    state.storage.ai_keys_delete(id)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_keys_set_active(
+    id: i64,
+    active: bool,
+    state: State<'_, AppState>,
+) -> Result<(), Error> {
+    state.storage.ai_keys_set_active(id, active)
+}
+
+#[derive(Debug, Clone, serde::Serialize, specta::Type)]
+pub struct AiKeyTestResult {
+    pub ok: bool,
+    pub message: String,
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_keys_test(
+    id: i64,
+    state: State<'_, AppState>,
+) -> Result<AiKeyTestResult, Error> {
+    let plaintext = state
+        .storage
+        .ai_keys_get_decrypted(id)?
+        .ok_or_else(|| Error::InvalidInput(format!("No AI key with id {}", id)))?;
+
+    let result = GroqClient::test_key(&plaintext, None).await;
+    let (ok, message) = match &result {
+        Ok(msg) => (true, msg.clone()),
+        Err(e) => (false, e.to_string()),
+    };
+    let _ = state.storage.ai_keys_record_test(id, ok, &message);
+    Ok(AiKeyTestResult { ok, message })
+}
+
+/// Test an unsaved key (used by the "Test before save" button).
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_keys_test_raw(api_key: String) -> Result<AiKeyTestResult, Error> {
+    let result = GroqClient::test_key(api_key.trim(), None).await;
+    Ok(match result {
+        Ok(msg) => AiKeyTestResult { ok: true, message: msg },
+        Err(e) => AiKeyTestResult { ok: false, message: e.to_string() },
+    })
 }

--- a/apps/desktop/src-tauri/src/database/services/ai/groq.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/groq.rs
@@ -1,4 +1,6 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -6,6 +8,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use super::{AIRequest, AIResponse, AiStreamEvent};
 use crate::error::Error;
+use crate::storage::Storage;
 
 const GROQ_API_URL: &str = "https://api.groq.com/openai/v1/chat/completions";
 const DEFAULT_MODEL: &str = "llama-3.3-70b-versatile";
@@ -81,14 +84,24 @@ pub struct GroqClient {
 
 impl GroqClient {
     pub fn from_env() -> Result<Self, Error> {
-        let mut keys = Vec::new();
+        Self::from_sources(Self::collect_env_keys())
+    }
 
+    /// Build a client merging env keys + DB-stored keys for the given storage.
+    pub fn from_env_and_storage(storage: &Storage) -> Result<Self, Error> {
+        let mut keys = Self::collect_env_keys();
+        let db_keys = storage.ai_keys_active_decrypted("groq").unwrap_or_default();
+        keys.extend(db_keys);
+        Self::from_sources(keys)
+    }
+
+    fn collect_env_keys() -> Vec<String> {
+        let mut keys = Vec::new();
         if let Ok(k) = std::env::var("GROQ_API_KEY") {
             if !k.is_empty() {
                 keys.push(k);
             }
         }
-
         for i in 1..=10 {
             if let Ok(k) = std::env::var(format!("GROQ_API_KEY_{}", i)) {
                 if !k.is_empty() {
@@ -96,10 +109,20 @@ impl GroqClient {
                 }
             }
         }
+        keys
+    }
+
+    fn from_sources(keys: Vec<String>) -> Result<Self, Error> {
+        // Dedupe while preserving order
+        let mut seen = std::collections::HashSet::new();
+        let keys: Vec<String> = keys
+            .into_iter()
+            .filter(|k| !k.is_empty() && seen.insert(k.clone()))
+            .collect();
 
         if keys.is_empty() {
             return Err(Error::InvalidInput(
-                "No GROQ_API_KEY or GROQ_API_KEY_1..10 env vars found".into(),
+                "No Groq API keys configured. Add one in Settings → AI Keys, or set GROQ_API_KEY[ _1..10 ] in your environment.".into(),
             ));
         }
 
@@ -107,8 +130,45 @@ impl GroqClient {
             keys,
             counter: AtomicUsize::new(0),
             model: std::env::var("GROQ_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string()),
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(60))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
         })
+    }
+
+    /// Validate a single key without persisting anything. Returns Ok on 2xx, Err otherwise.
+    pub async fn test_key(api_key: &str, model: Option<&str>) -> Result<String, Error> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()
+            .map_err(|e| Error::Any(anyhow::anyhow!("client build failed: {}", e)))?;
+
+        let body = serde_json::json!({
+            "model": model.unwrap_or(DEFAULT_MODEL),
+            "messages": [
+                {"role": "system", "content": "Reply with the word OK only."},
+                {"role": "user", "content": "ping"}
+            ],
+            "max_tokens": 4,
+            "temperature": 0.0,
+        });
+
+        let response = client
+            .post(GROQ_API_URL)
+            .bearer_auth(api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| Error::Any(anyhow::anyhow!("request failed: {}", e)))?;
+
+        let status = response.status();
+        if status.is_success() {
+            Ok(format!("ok ({})", status.as_u16()))
+        } else {
+            let text = response.text().await.unwrap_or_default();
+            Err(Error::Any(anyhow::anyhow!("{}: {}", status, text)))
+        }
     }
 
     pub fn key_count(&self) -> usize {
@@ -121,6 +181,9 @@ impl GroqClient {
     }
 
     fn build_request(&self, system: String, user: String, max_tokens: Option<u32>, stream: bool) -> GroqRequest {
+        // Groq's OpenAI-compatible endpoint accepts json_object response_format alongside stream.
+        // Forcing it on both paths keeps streamed deltas inside a JSON envelope and avoids the
+        // model wandering into prose / markdown fences mid-stream.
         GroqRequest {
             model: self.model.clone(),
             messages: vec![
@@ -136,42 +199,49 @@ impl GroqClient {
             max_tokens,
             stream,
             temperature: Some(0.2),
-            response_format: if stream {
-                None
-            } else {
-                Some(ResponseFormat {
-                    kind: "json_object".into(),
-                })
-            },
+            response_format: Some(ResponseFormat {
+                kind: "json_object".into(),
+            }),
         }
     }
 
-    /// Non-streaming completion with key rotation on 429.
+    fn should_rotate(status: reqwest::StatusCode) -> bool {
+        status == reqwest::StatusCode::TOO_MANY_REQUESTS
+            || status == reqwest::StatusCode::UNAUTHORIZED
+            || status == reqwest::StatusCode::FORBIDDEN
+            || status.is_server_error()
+    }
+
+    /// Non-streaming completion with key rotation on 429/5xx/auth errors.
     pub async fn complete(&self, request: AIRequest) -> Result<AIResponse, Error> {
         let (system, user) = super::prompts::build(&request);
         let body = self.build_request(system, user, request.max_tokens, false);
 
-        let max_retries = self.keys.len();
+        let max_retries = self.keys.len().max(1);
         let mut last_err: Option<Error> = None;
 
         for _ in 0..max_retries {
             let key = self.next_key().to_string();
-            let response = self
+            let response = match self
                 .client
                 .post(GROQ_API_URL)
                 .bearer_auth(&key)
                 .json(&body)
                 .send()
                 .await
-                .map_err(|e| Error::Any(anyhow::anyhow!("Groq request failed: {}", e)))?;
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    last_err = Some(Error::Any(anyhow::anyhow!("Groq request failed: {}", e)));
+                    continue;
+                }
+            };
 
             let status = response.status();
-            if status == reqwest::StatusCode::TOO_MANY_REQUESTS
-                || status == reqwest::StatusCode::UNAUTHORIZED
-            {
+            if Self::should_rotate(status) {
                 let body_text = response.text().await.unwrap_or_default();
                 last_err = Some(Error::Any(anyhow::anyhow!(
-                    "Groq key exhausted (status {}): {}",
+                    "Groq key/provider error (status {}): {}",
                     status,
                     body_text
                 )));
@@ -213,36 +283,45 @@ impl GroqClient {
         }))
     }
 
-    /// Streaming completion. Emits AiStreamEvent via sender.
+    /// Streaming completion. Emits AiStreamEvent via sender. Honors `cancel` flag and
+    /// rotates keys on 429/5xx/auth errors before any tokens are streamed.
     pub async fn complete_stream(
         &self,
         request: AIRequest,
         sender: UnboundedSender<AiStreamEvent>,
+        cancel: Arc<AtomicBool>,
     ) -> Result<(), Error> {
         let (system, user) = super::prompts::build(&request);
         let body = self.build_request(system, user, request.max_tokens, true);
 
-        let max_retries = self.keys.len();
+        let max_retries = self.keys.len().max(1);
         let mut last_err: Option<Error> = None;
 
         for _ in 0..max_retries {
+            if cancel.load(Ordering::Relaxed) {
+                return Ok(());
+            }
             let key = self.next_key().to_string();
-            let response = self
+            let response = match self
                 .client
                 .post(GROQ_API_URL)
                 .bearer_auth(&key)
                 .json(&body)
                 .send()
                 .await
-                .map_err(|e| Error::Any(anyhow::anyhow!("Groq request failed: {}", e)))?;
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    last_err = Some(Error::Any(anyhow::anyhow!("Groq request failed: {}", e)));
+                    continue;
+                }
+            };
 
             let status = response.status();
-            if status == reqwest::StatusCode::TOO_MANY_REQUESTS
-                || status == reqwest::StatusCode::UNAUTHORIZED
-            {
+            if Self::should_rotate(status) {
                 let body_text = response.text().await.unwrap_or_default();
                 last_err = Some(Error::Any(anyhow::anyhow!(
-                    "Groq key exhausted (status {}): {}",
+                    "Groq key/provider error (status {}): {}",
                     status,
                     body_text
                 )));
@@ -263,6 +342,9 @@ impl GroqClient {
             let mut full_content = String::new();
 
             while let Some(chunk_result) = stream.next().await {
+                if cancel.load(Ordering::Relaxed) {
+                    return Ok(());
+                }
                 let chunk = chunk_result.map_err(|e| {
                     Error::Any(anyhow::anyhow!("Groq stream error: {}", e))
                 })?;

--- a/apps/desktop/src-tauri/src/database/services/ai/mod.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/mod.rs
@@ -119,7 +119,7 @@ impl<'a> AIService<'a> {
 
         match provider {
             AIProvider::Groq => {
-                let client = GroqClient::from_env()?;
+                let client = GroqClient::from_env_and_storage(self.storage)?;
                 client.complete(request).await
             }
             AIProvider::Gemini => {
@@ -156,13 +156,14 @@ impl<'a> AIService<'a> {
         &self,
         request: AIRequest,
         sender: tokio::sync::mpsc::UnboundedSender<AiStreamEvent>,
+        cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
     ) -> Result<(), Error> {
         let provider = self.get_provider()?;
 
         match provider {
             AIProvider::Groq => {
-                let client = GroqClient::from_env()?;
-                client.complete_stream(request, sender).await
+                let client = GroqClient::from_env_and_storage(self.storage)?;
+                client.complete_stream(request, sender, cancel).await
             }
             _ => {
                 let response = self.complete(request).await?;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -39,6 +39,8 @@ pub struct AppState {
     pub stmt_manager: StatementManager,
     /// Command registry with keyboard shortcuts
     pub command_registry: RwLock<CommandRegistry>,
+    /// Cancellation flags keyed by AI request id, set by the abort command and observed by the streaming loop.
+    pub ai_cancel_flags: DashMap<String, Arc<std::sync::atomic::AtomicBool>>,
 }
 
 impl AppState {
@@ -60,6 +62,7 @@ impl AppState {
             storage,
             stmt_manager: StatementManager::new(),
             command_registry: RwLock::new(command_registry),
+            ai_cancel_flags: DashMap::new(),
         })
     }
 }
@@ -193,6 +196,13 @@ pub fn run() {
             database::commands::ai_configure_ollama,
             database::commands::ai_list_ollama_models,
             database::commands::ai_groq_status,
+            database::commands::ai_abort_stream,
+            database::commands::ai_keys_list,
+            database::commands::ai_keys_add,
+            database::commands::ai_keys_delete,
+            database::commands::ai_keys_set_active,
+            database::commands::ai_keys_test,
+            database::commands::ai_keys_test_raw,
             // Window commands
             window::commands::minimize_window,
             window::commands::maximize_window,

--- a/apps/desktop/src-tauri/src/storage/ai_keys.rs
+++ b/apps/desktop/src-tauri/src/storage/ai_keys.rs
@@ -1,0 +1,159 @@
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+use super::Storage;
+use crate::security;
+use crate::Result;
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct AiApiKeyRecord {
+    pub id: i64,
+    pub provider: String,
+    pub label: String,
+    pub is_active: bool,
+    pub last_tested: Option<i64>,
+    pub last_status: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+impl Storage {
+    pub fn ai_keys_list(&self, provider: &str) -> Result<Vec<AiApiKeyRecord>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, provider, label, is_active, last_tested, last_status, created_at, updated_at \
+                 FROM ai_api_keys WHERE provider = ?1 ORDER BY created_at ASC",
+            )
+            .context("Failed to prepare ai_keys_list statement")?;
+        let rows = stmt
+            .query_map([provider], |row| {
+                Ok(AiApiKeyRecord {
+                    id: row.get(0)?,
+                    provider: row.get(1)?,
+                    label: row.get(2)?,
+                    is_active: row.get::<_, i64>(3)? != 0,
+                    last_tested: row.get(4)?,
+                    last_status: row.get(5)?,
+                    created_at: row.get(6)?,
+                    updated_at: row.get(7)?,
+                })
+            })
+            .context("Failed to query ai_api_keys")?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.context("Failed to read ai_api_keys row")?);
+        }
+        Ok(out)
+    }
+
+    pub fn ai_keys_active_decrypted(&self, provider: &str) -> Result<Vec<String>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT ciphertext FROM ai_api_keys \
+                 WHERE provider = ?1 AND is_active = 1 ORDER BY id ASC",
+            )
+            .context("Failed to prepare ai_keys_active statement")?;
+        let rows = stmt
+            .query_map([provider], |row| row.get::<_, String>(0))
+            .context("Failed to query active ai_api_keys")?;
+
+        let mut keys = Vec::new();
+        for row in rows {
+            let ct = row.context("Failed to read ciphertext")?;
+            match security::decrypt(&ct) {
+                Ok(pt) if !pt.is_empty() => keys.push(pt),
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!("Failed to decrypt ai_api_keys row: {}", e);
+                }
+            }
+        }
+        Ok(keys)
+    }
+
+    pub fn ai_keys_add(&self, provider: &str, label: &str, plaintext: &str) -> Result<i64> {
+        let ciphertext = security::encrypt(plaintext)
+            .map_err(|e| crate::Error::Any(anyhow::anyhow!("Encrypt failed: {}", e)))?;
+        let now = chrono::Utc::now().timestamp();
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
+        conn.execute(
+            "INSERT INTO ai_api_keys (provider, label, ciphertext, is_active, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, 1, ?4, ?4)",
+            (provider, label, ciphertext, now),
+        )
+        .context("Failed to insert ai_api_keys row")?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    pub fn ai_keys_delete(&self, id: i64) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
+        conn.execute("DELETE FROM ai_api_keys WHERE id = ?1", [id])
+            .context("Failed to delete ai_api_keys row")?;
+        Ok(())
+    }
+
+    pub fn ai_keys_set_active(&self, id: i64, active: bool) -> Result<()> {
+        let now = chrono::Utc::now().timestamp();
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
+        conn.execute(
+            "UPDATE ai_api_keys SET is_active = ?1, updated_at = ?2 WHERE id = ?3",
+            (if active { 1 } else { 0 }, now, id),
+        )
+        .context("Failed to update ai_api_keys is_active")?;
+        Ok(())
+    }
+
+    pub fn ai_keys_record_test(&self, id: i64, ok: bool, message: &str) -> Result<()> {
+        let now = chrono::Utc::now().timestamp();
+        let status = if ok { format!("ok: {}", message) } else { format!("err: {}", message) };
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
+        conn.execute(
+            "UPDATE ai_api_keys SET last_tested = ?1, last_status = ?2, updated_at = ?1 WHERE id = ?3",
+            (now, status, id),
+        )
+        .context("Failed to record ai_keys test")?;
+        Ok(())
+    }
+
+    pub fn ai_keys_get_decrypted(&self, id: i64) -> Result<Option<String>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| crate::Error::Internal("lock poisoned".into()))?;
+        let mut stmt = conn
+            .prepare("SELECT ciphertext FROM ai_api_keys WHERE id = ?1")
+            .context("Failed to prepare ai_keys_get statement")?;
+        let mut rows = stmt
+            .query_map([id], |row| row.get::<_, String>(0))
+            .context("Failed to query ai_api_keys by id")?;
+        if let Some(row) = rows.next() {
+            let ct = row.context("Failed to read ciphertext")?;
+            let pt = security::decrypt(&ct)
+                .map_err(|e| crate::Error::Any(anyhow::anyhow!("Decrypt failed: {}", e)))?;
+            Ok(Some(pt))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/storage/migrator.rs
+++ b/apps/desktop/src-tauri/src/storage/migrator.rs
@@ -16,6 +16,7 @@ impl Migrator {
                 include_str!("../../migrations/005.sql"),
                 include_str!("../../migrations/006.sql"),
                 include_str!("../../migrations/007.sql"),
+                include_str!("../../migrations/008.sql"),
             ],
         }
     }

--- a/apps/desktop/src-tauri/src/storage/mod.rs
+++ b/apps/desktop/src-tauri/src/storage/mod.rs
@@ -1,3 +1,4 @@
+mod ai_keys;
 mod connection_history;
 mod connections;
 mod migrator;
@@ -7,6 +8,7 @@ mod settings;
 mod snippet_folders;
 mod types;
 
+pub use ai_keys::AiApiKeyRecord;
 pub use types::{ConnectionHistoryEntry, QueryHistoryEntry, SavedQuery, SnippetFolder};
 
 use std::path::PathBuf;

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
 	"productName": "Dora",
-	"version": "0.0.106",
+	"version": "0.0.108",
 	"identifier": "com.Dora.dev",
 	"build": {
 		"frontendDist": "../dist",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
 	"productName": "Dora",
-	"version": "0.0.108",
+	"version": "0.0.109",
 	"identifier": "com.Dora.dev",
 	"build": {
 		"frontendDist": "../dist",

--- a/apps/desktop/src/features/database-studio/components/data-grid.tsx
+++ b/apps/desktop/src/features/database-studio/components/data-grid.tsx
@@ -1,32 +1,28 @@
-import { ArrowDown, ArrowUp, ArrowUpDown, Database, Check, X } from 'lucide-react'
-import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react'
+import React, { useState, useRef, useEffect, useMemo } from 'react'
 import { useShortcut, useEffectiveShortcuts, useActiveScope } from '@/core/shortcuts'
-import { Checkbox } from '@/shared/ui/checkbox'
 import { cn } from '@/shared/utils/cn'
 import { ColumnDefinition, SortDescriptor, FilterDescriptor } from '../types'
-import { CellContextMenu } from './cell-context-menu'
-import { DateCell } from './cells/date-cell'
-import { IpCell } from './cells/ip-cell'
-import { TokenCell } from './cells/token-cell'
-import { RowContextMenu, RowAction } from './row-context-menu'
+import { NoColumnsState } from './data-grid/empty-states'
+import { GridBody } from './data-grid/grid-body'
+import { GridHeader } from './data-grid/grid-header'
+import { getCellsInRectangle } from './data-grid/selection'
+import { CellPosition, ContextMenuState } from './data-grid/types'
+import { useCellEditing } from './data-grid/use-cell-editing'
+import { useCellSelection } from './data-grid/use-cell-selection'
+import { useContextMenuReporting } from './data-grid/use-context-menu-reporting'
+import { useFocusedCell } from './data-grid/use-focused-cell'
+import { useGridKeyboard } from './data-grid/use-grid-keyboard'
+import { useRightDragScroll } from './data-grid/use-right-drag-scroll'
+import { useRowSelection } from './data-grid/use-row-selection'
+import {
+	DEFAULT_COLUMN_WIDTH,
+	MIN_COLUMN_WIDTH,
+	useColumnResize
+} from './data-grid/use-column-resize'
+import { RowAction } from './row-context-menu'
 import { ScrollHint } from './scroll-hint'
 
-type EditingCell = {
-	rowIndex: number
-	columnName: string
-}
-
-type CellPosition = {
-	row: number
-	col: number
-}
-
-export type ContextMenuState = {
-	kind: 'cell' | 'row'
-	cell: { row: number; col: number }
-	x: number
-	y: number
-} | null
+export type { ContextMenuState }
 
 type Props = {
 	columns: ColumnDefinition[]
@@ -60,9 +56,6 @@ type Props = {
 	draftInsertIndex?: number | null
 }
 
-const MIN_COLUMN_WIDTH = 100
-const DEFAULT_COLUMN_WIDTH = 150
-
 export function DataGrid({
 	columns,
 	rows,
@@ -89,70 +82,23 @@ export function DataGrid({
 	pendingEdits,
 	draftInsertIndex
 }: Props) {
-	const [editingCell, setEditingCell] = useState<EditingCell | null>(null)
-	const [editValue, setEditValue] = useState<string>('')
-	const editInputRef = useRef<HTMLInputElement>(null)
-
-	// Refs to always hold the latest values – eliminates stale-closure bugs in
-	// blur / Tab handlers that fire after React has batched but not yet committed.
-	const editValueRef = useRef(editValue)
-	editValueRef.current = editValue
-	const editingCellRef = useRef(editingCell)
-	editingCellRef.current = editingCell
-	// When true the next onBlur should skip saving (Tab already saved & moved).
-	const skipNextBlurSaveRef = useRef(false)
-
 	const lastClickedRowRef = useRef<number | null>(null)
 
-	const [columnWidths, setColumnWidths] = useState<Record<string, number>>({})
-	const [resizingColumn, setResizingColumn] = useState<string | null>(null)
-	const startXRef = useRef(0)
-	const startWidthRef = useRef(0)
+	const { resizingColumn, getColumnWidth, handleResizeStart, handleResizeDoubleClick } =
+		useColumnResize()
 
 	const allSelected = rows.length > 0 && selectedRows.size === rows.length
 	const someSelected = selectedRows.size > 0 && selectedRows.size < rows.length
 
-	const [focusedCell, setFocusedCellInternal] = useState<{ row: number; col: number } | null>(
-		initialFocusedCell ?? null
-	)
-
-	useEffect(() => {
-		if (
-			initialFocusedCell &&
-			(!focusedCell ||
-				focusedCell.row !== initialFocusedCell.row ||
-				focusedCell.col !== initialFocusedCell.col)
-		) {
-			setFocusedCellInternal(initialFocusedCell)
-			return
-		}
-
-		if (!initialFocusedCell && focusedCell) {
-			setFocusedCellInternal(null)
-		}
-	}, [initialFocusedCell, focusedCell])
+	const { focusedCell, setFocusedCell } = useFocusedCell(initialFocusedCell, onFocusedCellChange)
 
 	const gridRef = useRef<HTMLTableElement>(null)
 	const scrollContainerRef = useRef<HTMLDivElement>(null)
 
-	const [internalSelectedCells, setInternalSelectedCells] = useState<Set<string>>(new Set())
-	const selectedCellsSet = externalSelectedCells ?? internalSelectedCells
-	const selectedCellsByRow = useMemo(() => {
-		const byRow = new Map<number, Set<number>>()
-		for (const key of selectedCellsSet) {
-			const [rowPart, colPart] = key.split(':')
-			const rowIndex = Number(rowPart)
-			const colIndex = Number(colPart)
-			if (Number.isNaN(rowIndex) || Number.isNaN(colIndex)) continue
-			const current = byRow.get(rowIndex)
-			if (current) {
-				current.add(colIndex)
-			} else {
-				byRow.set(rowIndex, new Set([colIndex]))
-			}
-		}
-		return byRow
-	}, [selectedCellsSet])
+	const { selectedCellsSet, selectedCellsByRow, updateCellSelection } = useCellSelection(
+		externalSelectedCells,
+		onCellSelectionChange
+	)
 
 	const effectiveSelectedRows = useMemo(() => {
 		if (selectedRows.size > 0) return selectedRows
@@ -169,81 +115,30 @@ export function DataGrid({
 	const [isDragging, setIsDragging] = useState(false)
 	const [dragStart, setDragStart] = useState<CellPosition | null>(null)
 
-	// Right-click drag state
-	const [isRightDragging, setIsRightDragging] = useState(false)
-	const rightDragStartRef = useRef<{ x: number; scrollLeft: number } | null>(null)
-	const hasRightDraggedRef = useRef(false)
-	const pendingNavFrameRef = useRef<number | null>(null)
+	const { hasRightDraggedRef, isRightDragging, handleRightDragStart } =
+		useRightDragScroll(scrollContainerRef)
 
-	function setFocusedCell(cell: { row: number; col: number } | null) {
-		setFocusedCellInternal(cell)
-		if (onFocusedCellChange) {
-			onFocusedCellChange(cell)
-		}
-	}
+	const {
+		editingCell,
+		setEditingCell,
+		editValue,
+		setEditValue,
+		editInputRef,
+		handleCellDoubleClick,
+		handleSaveEdit,
+		handleEditKeyDown
+	} = useCellEditing({
+		columns,
+		gridRef,
+		onCellEdit,
+		rows,
+		setAnchorCell,
+		setFocusedCell,
+		updateCellSelection
+	})
 
-	function updateCellSelection(cells: Set<string>) {
-		if (onCellSelectionChange) {
-			onCellSelectionChange(cells)
-		} else {
-			setInternalSelectedCells(cells)
-		}
-	}
-
-	const lastContextMenuCoordsRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
-
-	function handleCellContextMenuChange(open: boolean, row: number, col: number) {
-		if (onContextMenuChange) {
-			if (open) {
-				onContextMenuChange({
-					kind: 'cell',
-					cell: { row, col },
-					x: lastContextMenuCoordsRef.current.x,
-					y: lastContextMenuCoordsRef.current.y
-				})
-			} else {
-				onContextMenuChange(null)
-			}
-		}
-	}
-
-	function handleRowContextMenuChange(open: boolean, row: number) {
-		if (onContextMenuChange) {
-			if (open) {
-				onContextMenuChange({
-					kind: 'row',
-					cell: { row, col: 0 },
-					x: lastContextMenuCoordsRef.current.x,
-					y: lastContextMenuCoordsRef.current.y
-				})
-			} else {
-				onContextMenuChange(null)
-			}
-		}
-	}
-
-	function handleContextMenuCapture(e: React.MouseEvent) {
-		lastContextMenuCoordsRef.current = { x: e.clientX, y: e.clientY }
-	}
-
-	function getCellKey(row: number, col: number): string {
-		return `${row}:${col}`
-	}
-
-	function getCellsInRectangle(start: CellPosition, end: CellPosition): Set<string> {
-		const minRow = Math.min(start.row, end.row)
-		const maxRow = Math.max(start.row, end.row)
-		const minCol = Math.min(start.col, end.col)
-		const maxCol = Math.max(start.col, end.col)
-
-		const cells = new Set<string>()
-		for (let r = minRow; r <= maxRow; r++) {
-			for (let c = minCol; c <= maxCol; c++) {
-				cells.add(getCellKey(r, c))
-			}
-		}
-		return cells
-	}
+	const { handleCellContextMenuChange, handleRowContextMenuChange, handleContextMenuCapture } =
+		useContextMenuReporting(onContextMenuChange)
 
 	function handleCellMouseDown(e: React.MouseEvent, rowIndex: number, colIndex: number) {
 		if (e.button !== 0) return
@@ -259,20 +154,13 @@ export function DataGrid({
 		setAnchorCell(cellPos)
 	}
 
-	function ensureRowSelectionForContextMenu(rowIndex: number) {
-		if (selectedRows.has(rowIndex)) return
-		onSelectAll(false)
-		onRowSelect(rowIndex, true)
-		lastClickedRowRef.current = rowIndex
-	}
-
-	useEffect(function cleanupPendingFrame() {
-		return function () {
-			if (pendingNavFrameRef.current !== null) {
-				cancelAnimationFrame(pendingNavFrameRef.current)
-			}
-		}
-	}, [])
+	const { handleRowClick, ensureRowSelectionForContextMenu } = useRowSelection({
+		lastClickedRowRef,
+		onRowSelect,
+		onRowsSelect,
+		onSelectAll,
+		selectedRows
+	})
 
 	useEffect(
 		function keepFocusedCellInView() {
@@ -340,33 +228,6 @@ export function DataGrid({
 			{ description: shortcuts.deselect.description }
 		)
 
-	const handleRowClick = useCallback(
-		function (e: React.MouseEvent, rowIndex: number) {
-			if (e.button !== 0) return
-
-			if (e.shiftKey) {
-				e.preventDefault()
-			}
-
-			if (e.shiftKey && lastClickedRowRef.current !== null && onRowsSelect) {
-				const start = Math.min(lastClickedRowRef.current, rowIndex)
-				const end = Math.max(lastClickedRowRef.current, rowIndex)
-				const range = []
-				for (let i = start; i <= end; i++) {
-					range.push(i)
-				}
-				onRowsSelect(range, true)
-			} else if (e.ctrlKey || e.metaKey) {
-				onRowSelect(rowIndex, !selectedRows.has(rowIndex))
-				lastClickedRowRef.current = rowIndex
-			} else {
-				// Single click only updates the anchor for range selection, does NOT select the row
-				lastClickedRowRef.current = rowIndex
-			}
-		},
-		[selectedRows, onRowSelect, onRowsSelect]
-	)
-
 	function handleSort(columnName: string) {
 		if (!onSortChange) return
 
@@ -381,545 +242,30 @@ export function DataGrid({
 		}
 	}
 
-	function getColumnWidth(colName: string) {
-		return columnWidths[colName]
-	}
-
-	const handleResizeStart = useCallback(
-		function (e: React.MouseEvent, columnName: string) {
-			e.preventDefault()
-			e.stopPropagation()
-
-			setResizingColumn(columnName)
-			startXRef.current = e.clientX
-
-			const currentWidth = columnWidths[columnName]
-			if (typeof currentWidth === 'number') {
-				startWidthRef.current = currentWidth
-			} else {
-				const th = (e.target as HTMLElement).closest('th')
-				startWidthRef.current = th?.getBoundingClientRect().width ?? DEFAULT_COLUMN_WIDTH
-			}
-		},
-		[columnWidths]
-	)
-
-	// Handle mouse move during resize
-	useEffect(
-		function () {
-			if (!resizingColumn) return
-
-			const handleMouseMove = function (e: MouseEvent) {
-				const delta = e.clientX - startXRef.current
-				const newWidth = Math.max(MIN_COLUMN_WIDTH, startWidthRef.current + delta)
-
-				setColumnWidths(function (prev) {
-					return {
-						...prev,
-						[resizingColumn]: newWidth
-					}
-				})
-			}
-
-			const handleMouseUp = function () {
-				setResizingColumn(null)
-			}
-
-			document.addEventListener('mousemove', handleMouseMove)
-			document.addEventListener('mouseup', handleMouseUp)
-
-			return function () {
-				document.removeEventListener('mousemove', handleMouseMove)
-				document.removeEventListener('mouseup', handleMouseUp)
-			}
-		},
-		[resizingColumn]
-	)
-
-	const handleResizeDoubleClick = useCallback(function (
-		e: React.MouseEvent,
-		columnName: string,
-		columnType?: string
-	) {
-		e.preventDefault()
-		e.stopPropagation()
-
-		const canvas = document.createElement('canvas')
-		const ctx = canvas.getContext('2d')
-		if (!ctx) {
-			setColumnWidths(function (prev) {
-				const next = { ...prev }
-				delete next[columnName]
-				return next
-			})
-			return
-		}
-
-		ctx.font = '12px Inter, system-ui, sans-serif'
-		const nameWidth = ctx.measureText(columnName).width
-
-		let typeWidth = 0
-		if (columnType && columnType !== 'unknown') {
-			ctx.font = "10px 'JetBrains Mono', monospace"
-			typeWidth = ctx.measureText(columnType).width
-		}
-
-		const sortIconWidth = 16
-		const padding = 32
-		const gap = typeWidth > 0 ? 8 : 0
-		const optimalWidth = Math.ceil(nameWidth + typeWidth + sortIconWidth + padding + gap)
-		const finalWidth = Math.max(MIN_COLUMN_WIDTH, optimalWidth)
-
-		setColumnWidths(function (prev) {
-			return { ...prev, [columnName]: finalWidth }
-		})
-	}, [])
-
-	const handleCellDoubleClick = useCallback(function (
-		rowIndex: number,
-		columnName: string,
-		currentValue: unknown
-	) {
-		setEditingCell({ rowIndex, columnName })
-		setEditValue(
-			currentValue === null || currentValue === undefined ? '' : String(currentValue)
-		)
-	}, [])
-
-	const refocusGrid = useCallback(function () {
-		requestAnimationFrame(function () {
-			gridRef.current?.focus()
-		})
-	}, [])
-
-	const handleSaveEdit = useCallback(
-		function () {
-			// If Tab already saved & moved to the next cell, skip the redundant
-			// blur-triggered save so we don't clobber the next-cell editing state.
-			if (skipNextBlurSaveRef.current) {
-				skipNextBlurSaveRef.current = false
-				return
-			}
-			const cell = editingCellRef.current
-			const value = editValueRef.current
-			if (cell && onCellEdit) {
-				onCellEdit(cell.rowIndex, cell.columnName, value)
-			}
-			// Clear ref immediately so a second call (e.g. blur after mousedown
-			// already saved) won't double-fire before React re-renders.
-			editingCellRef.current = null
-			setEditingCell(null)
-			setEditValue('')
-			refocusGrid()
-		},
-		[onCellEdit, refocusGrid]
-	)
-
-	const handleCancelEdit = useCallback(
-		function () {
-			setEditingCell(null)
-			setEditValue('')
-			refocusGrid()
-		},
-		[refocusGrid]
-	)
-
-	const handleSaveEditAndMove = useCallback(
-		function (direction: 'next' | 'prev') {
-			const cell = editingCellRef.current
-			if (!cell) return
-
-			// Save current cell using ref values (always fresh).
-			if (onCellEdit) {
-				onCellEdit(cell.rowIndex, cell.columnName, editValueRef.current)
-			}
-
-			// Mark so the upcoming blur on the old <input> doesn't double-save.
-			skipNextBlurSaveRef.current = true
-
-			const colIndex = columns.findIndex(function (c) {
-				return c.name === cell.columnName
-			})
-			const maxCol = columns.length - 1
-			const maxRow = rows.length - 1
-			let nextRow = cell.rowIndex
-			let nextCol = colIndex
-
-			if (direction === 'next') {
-				if (colIndex < maxCol) {
-					nextCol = colIndex + 1
-				} else if (cell.rowIndex < maxRow) {
-					nextRow = cell.rowIndex + 1
-					nextCol = 0
-				}
-			} else {
-				if (colIndex > 0) {
-					nextCol = colIndex - 1
-				} else if (cell.rowIndex > 0) {
-					nextRow = cell.rowIndex - 1
-					nextCol = maxCol
-				}
-			}
-
-			const newPos = { row: nextRow, col: nextCol }
-			setFocusedCell(newPos)
-			setAnchorCell(newPos)
-			updateCellSelection(new Set([getCellKey(nextRow, nextCol)]))
-			setEditingCell({ rowIndex: nextRow, columnName: columns[nextCol].name })
-			setEditValue(
-				rows[nextRow][columns[nextCol].name] === null ||
-					rows[nextRow][columns[nextCol].name] === undefined
-					? ''
-					: String(rows[nextRow][columns[nextCol].name])
-			)
-		},
-		[onCellEdit, columns, rows]
-	)
-
-	const handleEditKeyDown = useCallback(
-		function (e: React.KeyboardEvent) {
-			if (e.key === 'Enter') {
-				e.preventDefault()
-				handleSaveEdit()
-			} else if (e.key === 'Escape') {
-				e.preventDefault()
-				handleCancelEdit()
-			} else if (e.key === 'Tab') {
-				e.preventDefault()
-				handleSaveEditAndMove(e.shiftKey ? 'prev' : 'next')
-			}
-		},
-		[handleSaveEdit, handleCancelEdit, handleSaveEditAndMove]
-	)
-
-	// Focus input when editing cell changes
-	useEffect(() => {
-		if (editingCell && editInputRef.current) {
-			const timer = setTimeout(function () {
-				if (editInputRef.current) {
-					editInputRef.current.focus()
-					editInputRef.current.select()
-				}
-			}, 10)
-			return function () {
-				clearTimeout(timer)
-			}
-		}
-	}, [editingCell])
-
-	const handleGridKeyDown = useCallback(
-		function (e: React.KeyboardEvent) {
-			// If no cell is focused yet, focus cell 0,0 on any arrow/tab/enter
-			if (!focusedCell) {
-				if (
-					rows.length > 0 &&
-					columns.length > 0 &&
-					(e.key === 'ArrowDown' ||
-						e.key === 'ArrowUp' ||
-						e.key === 'ArrowLeft' ||
-						e.key === 'ArrowRight' ||
-						e.key === 'Tab' ||
-						e.key === 'Enter')
-				) {
-					e.preventDefault()
-					const firstPos = { row: 0, col: 0 }
-					setFocusedCell(firstPos)
-					setAnchorCell(firstPos)
-					updateCellSelection(new Set([getCellKey(0, 0)]))
-				}
-				return
-			}
-			if (editingCell) return
-
-			const { row, col } = focusedCell
-			const maxRow = rows.length - 1
-			const maxCol = columns.length - 1
-
-			function moveAndMaybeSelect(newRow: number, newCol: number) {
-				const newPos: CellPosition = { row: newRow, col: newCol }
-				if (pendingNavFrameRef.current !== null) {
-					cancelAnimationFrame(pendingNavFrameRef.current)
-				}
-				pendingNavFrameRef.current = requestAnimationFrame(function () {
-					setFocusedCell(newPos)
-					if (e.shiftKey && anchorCell) {
-						const rangeCells = getCellsInRectangle(anchorCell, newPos)
-						updateCellSelection(rangeCells)
-					} else if (!e.shiftKey) {
-						setAnchorCell(newPos)
-						updateCellSelection(new Set([getCellKey(newRow, newCol)]))
-					}
-					pendingNavFrameRef.current = null
-				})
-			}
-
-			switch (e.key) {
-				case 'ArrowUp':
-					e.preventDefault()
-					if (e.ctrlKey || e.metaKey) {
-						moveAndMaybeSelect(0, col)
-					} else if (row > 0) {
-						moveAndMaybeSelect(row - 1, col)
-					}
-					break
-				case 'ArrowDown':
-					e.preventDefault()
-					if (e.ctrlKey || e.metaKey) {
-						moveAndMaybeSelect(maxRow, col)
-					} else if (row < maxRow) {
-						moveAndMaybeSelect(row + 1, col)
-					}
-					break
-				case 'ArrowLeft':
-					e.preventDefault()
-					if (e.ctrlKey || e.metaKey) {
-						moveAndMaybeSelect(row, 0)
-					} else if (col > 0) {
-						moveAndMaybeSelect(row, col - 1)
-					}
-					break
-				case 'ArrowRight':
-					e.preventDefault()
-					if (e.ctrlKey || e.metaKey) {
-						moveAndMaybeSelect(row, maxCol)
-					} else if (col < maxCol) {
-						moveAndMaybeSelect(row, col + 1)
-					}
-					break
-				case 'Tab':
-					e.preventDefault()
-					if (e.shiftKey) {
-						if (col > 0) {
-							moveAndMaybeSelect(row, col - 1)
-						} else if (row > 0) {
-							moveAndMaybeSelect(row - 1, maxCol)
-						}
-					} else {
-						if (col < maxCol) {
-							moveAndMaybeSelect(row, col + 1)
-						} else if (row < maxRow) {
-							moveAndMaybeSelect(row + 1, 0)
-						}
-					}
-					break
-				case 'Enter':
-				case 'F2':
-					e.preventDefault()
-					handleCellDoubleClick(row, columns[col].name, rows[row][columns[col].name])
-					break
-				case 'Delete':
-				case 'Backspace':
-					if (!e.ctrlKey && !e.metaKey && onCellEdit) {
-						e.preventDefault()
-						onCellEdit(row, columns[col].name, null)
-					}
-					break
-				case 'Escape':
-					e.preventDefault()
-					if (pendingNavFrameRef.current !== null) {
-						cancelAnimationFrame(pendingNavFrameRef.current)
-						pendingNavFrameRef.current = null
-					}
-					if (selectedCellsSet.size > 1) {
-						updateCellSelection(new Set([getCellKey(row, col)]))
-					} else {
-						setFocusedCell(null)
-						updateCellSelection(new Set())
-					}
-					break
-				case ' ':
-					e.preventDefault()
-					if (e.shiftKey && lastClickedRowRef.current !== null && onRowsSelect) {
-						const start = Math.min(lastClickedRowRef.current, row)
-						const end = Math.max(lastClickedRowRef.current, row)
-						const range = []
-						for (let i = start; i <= end; i++) {
-							range.push(i)
-						}
-						onRowsSelect(range, true)
-					} else {
-						onRowSelect(row, !selectedRows.has(row))
-						lastClickedRowRef.current = row
-					}
-					break
-				case 'a':
-					if (e.ctrlKey || e.metaKey) {
-						e.preventDefault()
-						onSelectAll(!allSelected)
-					}
-					break
-				case 'c':
-					if (e.ctrlKey || e.metaKey) {
-						e.preventDefault()
-						if (selectedCellsSet.size > 0) {
-							const cellsArray = Array.from(selectedCellsSet).map(function (key) {
-								const [r, c] = key.split(':').map(Number)
-								return { row: r, col: c }
-							})
-							cellsArray.sort(function (a, b) {
-								return a.row === b.row ? a.col - b.col : a.row - b.row
-							})
-							const minRow = Math.min(
-								...cellsArray.map(function (c) {
-									return c.row
-								})
-							)
-							const maxRow = Math.max(
-								...cellsArray.map(function (c) {
-									return c.row
-								})
-							)
-							const rowData: string[][] = []
-							for (let r = minRow; r <= maxRow; r++) {
-								const rowCells = cellsArray.filter(function (c) {
-									return c.row === r
-								})
-								const values = rowCells.map(function (cell) {
-									const value = rows[cell.row][columns[cell.col].name]
-									return value === null || value === undefined
-										? ''
-										: String(value)
-								})
-								rowData.push(values)
-							}
-							const clipboardText = rowData
-								.map(function (r) {
-									return r.join('\t')
-								})
-								.join('\n')
-							navigator.clipboard.writeText(clipboardText)
-						} else if (focusedCell) {
-							const value = rows[focusedCell.row][columns[focusedCell.col].name]
-							const text = value === null || value === undefined ? '' : String(value)
-							navigator.clipboard.writeText(text)
-						}
-					}
-					break
-				case 'v':
-					if ((e.ctrlKey || e.metaKey) && focusedCell && onCellEdit) {
-						e.preventDefault()
-						navigator.clipboard
-							.readText()
-							.then(function (clipboardText) {
-								if (!clipboardText || !focusedCell) return
-								const pasteRows = clipboardText.split('\n').map(function (line) {
-									return line.split('\t')
-								})
-								pasteRows.forEach(function (pasteRow, pasteRowIndex) {
-									const targetRow = focusedCell.row + pasteRowIndex
-									if (targetRow >= rows.length) return
-									pasteRow.forEach(function (pasteValue, pasteColIndex) {
-										const targetCol = focusedCell.col + pasteColIndex
-										if (targetCol >= columns.length) return
-										onCellEdit!(targetRow, columns[targetCol].name, pasteValue)
-									})
-								})
-							})
-							.catch(function () {
-								// Clipboard read unavailable — no-op
-							})
-					}
-					break
-				default:
-					// Start typing to edit: single printable character starts editing
-					if (
-						e.key.length === 1 &&
-						!e.ctrlKey &&
-						!e.metaKey &&
-						!e.altKey
-					) {
-						e.preventDefault()
-						setEditingCell({ rowIndex: row, columnName: columns[col].name })
-						setEditValue(e.key)
-					}
-					break
-			}
-		},
-		[
-			focusedCell,
-			editingCell,
-			rows,
-			columns,
-			handleCellDoubleClick,
-			onRowSelect,
-			onRowsSelect,
-			onSelectAll,
-			allSelected,
-			selectedRows,
-			anchorCell,
-			selectedCellsSet,
-			onCellEdit
-		]
-	)
-
-	function handleRightDragValues(e: React.MouseEvent | MouseEvent) {
-		if (!rightDragStartRef.current || !scrollContainerRef.current) return
-
-		const delta = rightDragStartRef.current.x - e.clientX
-		if (Math.abs(delta) > 5) {
-			hasRightDraggedRef.current = true
-		}
-
-		if (hasRightDraggedRef.current) {
-			scrollContainerRef.current.scrollLeft = rightDragStartRef.current.scrollLeft + delta
-		}
-	}
-
-	useEffect(() => {
-		if (!isRightDragging) return
-
-		function handleGlobalMouseMove(e: MouseEvent) {
-			handleRightDragValues(e)
-		}
-
-		function handleGlobalMouseUp(e: MouseEvent) {
-			if (isRightDragging) {
-				setIsRightDragging(false)
-				rightDragStartRef.current = null
-				// We don't reset hasRightDragged yet because we need it for onContextMenu prevention
-				setTimeout(() => {
-					hasRightDraggedRef.current = false
-				}, 50)
-			}
-		}
-
-		document.addEventListener('mousemove', handleGlobalMouseMove)
-		document.addEventListener('mouseup', handleGlobalMouseUp)
-
-		return () => {
-			document.removeEventListener('mousemove', handleGlobalMouseMove)
-			document.removeEventListener('mouseup', handleGlobalMouseUp)
-		}
-	}, [isRightDragging])
+	const handleGridKeyDown = useGridKeyboard({
+		anchorCell,
+		allSelected,
+		columns,
+		editingCell,
+		focusedCell,
+		lastClickedRowRef,
+		onCellEdit,
+		onRowsSelect,
+		onRowSelect,
+		onSelectAll,
+		rows,
+		selectedCellsSet,
+		selectedRows,
+		setAnchorCell,
+		setEditingCell,
+		setEditValue,
+		setFocusedCell,
+		startCellEdit: handleCellDoubleClick,
+		updateCellSelection
+	})
 
 	if (columns.length === 0) {
-		return (
-			<div className='flex flex-col items-center justify-center h-full gap-4 p-8'>
-				<div className='flex h-16 w-16 items-center justify-center rounded-full bg-muted/50'>
-					<svg
-						className='h-8 w-8 text-muted-foreground/60'
-						xmlns='http://www.w3.org/2000/svg'
-						fill='none'
-						viewBox='0 0 24 24'
-						strokeWidth={1.5}
-						stroke='currentColor'
-					>
-						<path
-							strokeLinecap='round'
-							strokeLinejoin='round'
-							d='M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 0 1-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0 1 12 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 1.5v-1.5m0 0c0-.621.504-1.125 1.125-1.125m0 0h7.5'
-						/>
-					</svg>
-				</div>
-				<div className='text-center space-y-1.5'>
-					<h3 className='text-sm font-medium text-foreground'>No columns found</h3>
-					<p className='text-xs text-muted-foreground max-w-[280px]'>
-						This table doesn't have any columns defined yet, or the schema couldn't be
-						loaded.
-					</p>
-				</div>
-			</div>
-		)
+		return <NoColumnsState />
 	}
 
 	return (
@@ -940,17 +286,7 @@ export function DataGrid({
 					handleContextMenuCapture(e)
 				}}
 				onMouseDown={function (e) {
-					if (e.button === 2) {
-						// Right click
-						if (scrollContainerRef.current) {
-							setIsRightDragging(true)
-							rightDragStartRef.current = {
-								x: e.clientX,
-								scrollLeft: scrollContainerRef.current.scrollLeft
-							}
-							hasRightDraggedRef.current = false
-						}
-					}
+					handleRightDragStart(e)
 				}}
 				onWheel={function (e) {
 					if (e.shiftKey) {
@@ -985,591 +321,56 @@ export function DataGrid({
 							)
 						})}
 					</colgroup>
-					<thead className='sticky top-0 bg-sidebar z-10' role='rowgroup'>
-						<tr role='row'>
-							{/* Checkbox column */}
-							<th
-								className='px-4 py-2 text-center border-b border-r border-sidebar-border bg-background sticky left-0 z-30'
-								role='columnheader'
-								aria-label='Select all rows'
-							>
-								<Checkbox
-									checked={someSelected ? 'indeterminate' : allSelected}
-									onCheckedChange={function (checked) {
-										onSelectAll(!!checked)
-									}}
-									className='h-4 w-4'
-									aria-label={
-										allSelected ? 'Deselect all rows' : 'Select all rows'
-									}
-								/>
-							</th>
-							{/* Data columns */}
-							{columns.map(function (col) {
-								const isSorted = sort?.column === col.name
-								const width = getColumnWidth(col.name)
-
-								return (
-									<th
-										key={col.name}
-										className={cn(
-											'text-left font-medium border-b border-r border-sidebar-border bg-sidebar-accent/50 last:border-r-0 h-9 cursor-pointer transition-colors hover:bg-sidebar-accent relative select-none min-w-[60px]',
-											isSorted && 'bg-sidebar-accent',
-											resizingColumn === col.name && 'bg-sidebar-accent'
-										)}
-										style={width ? { width } : undefined}
-										onClick={function () {
-											handleSort(col.name)
-										}}
-									>
-										<div className='flex items-center gap-1.5 justify-between group px-3 py-2 overflow-hidden'>
-											<div className='flex items-center gap-1.5 overflow-hidden min-w-0'>
-												<span className='text-foreground text-xs shrink-0'>
-													{col.name}
-												</span>
-												{col.type && col.type !== 'unknown' && (
-													<span className='text-muted-foreground/50 text-[10px] font-normal font-mono lowercase truncate min-w-0'>
-														{col.type}
-													</span>
-												)}
-											</div>
-											{isSorted && sort ? (
-												sort.direction === 'asc' ? (
-													<ArrowUp className='h-3 w-3 text-primary shrink-0' />
-												) : (
-													<ArrowDown className='h-3 w-3 text-primary shrink-0' />
-												)
-											) : (
-												<ArrowUpDown className='h-3 w-3 text-muted-foreground/0 group-hover:text-muted-foreground/50 transition-colors shrink-0' />
-											)}
-										</div>
-
-										{/* Resize handle */}
-										<div
-											className={cn(
-												'absolute right-0 top-0 w-1.5 h-full cursor-col-resize hover:bg-primary/50 transition-colors',
-												resizingColumn === col.name && 'bg-primary'
-											)}
-											onMouseDown={function (e) {
-												handleResizeStart(e, col.name)
-											}}
-											onDoubleClick={function (e) {
-												handleResizeDoubleClick(e, col.name, col.type)
-											}}
-											onClick={function (e) {
-												e.stopPropagation()
-											}}
-										/>
-									</th>
-								)
-							})}
-						</tr>
-					</thead>
-					<tbody role='rowgroup'>
-						{/* Render draft row at TOP if no specific index is provided (-1 or null) */}
-						{draftRow &&
-							(draftInsertIndex === undefined ||
-								draftInsertIndex === null ||
-								draftInsertIndex === -1) && (
-								<tr className='bg-emerald-500/10 border-l-2 border-l-emerald-500'>
-									<td className='px-1 py-1.5 text-center border-b border-r border-sidebar-border'>
-										<div className='flex items-center justify-center gap-1'>
-											<button
-												onClick={onDraftSave}
-												className='text-emerald-500 hover:text-emerald-400 text-xs font-medium'
-												title='Save (Enter)'
-											>
-												✓
-											</button>
-											<button
-												onClick={onDraftCancel}
-												className='text-muted-foreground hover:text-destructive text-xs'
-												title='Cancel (Escape)'
-											>
-												✕
-											</button>
-										</div>
-									</td>
-									{columns.map(function (col, colIndex) {
-										const width = getColumnWidth(col.name)
-										const isPrimaryKey = col.primaryKey
-
-										return (
-											<td
-												key={col.name}
-												className='border-b border-r border-sidebar-border last:border-r-0 font-mono text-sm px-0 py-0'
-												style={width ? { maxWidth: width } : undefined}
-											>
-												{isPrimaryKey ? (
-													<div className='px-3 py-1.5 text-muted-foreground italic text-xs'>
-														auto
-													</div>
-												) : (
-													<input
-														type='text'
-														autoFocus={
-															colIndex === 0 ||
-															(colIndex === 1 &&
-																columns[0]?.primaryKey)
-														}
-														value={
-															draftRow[col.name] === null
-																? ''
-																: String(draftRow[col.name] ?? '')
-														}
-														onChange={function (e) {
-															onDraftChange?.(
-																col.name,
-																e.target.value
-															)
-														}}
-														onKeyDown={function (e) {
-															if (e.key === 'Enter') {
-																e.preventDefault()
-																onDraftSave?.()
-															} else if (e.key === 'Escape') {
-																e.preventDefault()
-																onDraftCancel?.()
-															} else if (e.key === 'Tab') {
-																const editableCols = columns.filter(function (c) { return !c.primaryKey })
-																const curIdx = editableCols.findIndex(function (c) { return c.name === col.name })
-																if (e.shiftKey) {
-																	if (curIdx > 0) {
-																		e.preventDefault()
-																		const prev = e.currentTarget.closest('tr')?.querySelector<HTMLInputElement>(
-																			`input[data-draft-col="${editableCols[curIdx - 1].name}"]`
-																		)
-																		prev?.focus()
-																	}
-																} else {
-																	if (curIdx < editableCols.length - 1) {
-																		e.preventDefault()
-																		const next = e.currentTarget.closest('tr')?.querySelector<HTMLInputElement>(
-																			`input[data-draft-col="${editableCols[curIdx + 1].name}"]`
-																		)
-																		next?.focus()
-																	} else {
-																		e.preventDefault()
-																		onDraftSave?.()
-																	}
-																}
-															}
-														}}
-														data-draft-col={col.name}
-														data-no-shortcuts='true'
-														className='w-full h-full bg-transparent px-3 py-1.5 outline-none focus:bg-emerald-500/10 font-mono text-sm'
-														placeholder={col.nullable ? 'NULL' : ''}
-													/>
-												)}
-											</td>
-										)
-									})}
-								</tr>
-							)}
-
-						{rows.map(function (row, rowIndex) {
-							const rowBackgroundClasses = selectedRows.has(rowIndex)
-								? 'bg-primary/10'
-								: rowIndex % 2 === 1
-									? 'bg-muted/35 hover:bg-sidebar-accent/30'
-									: 'hover:bg-sidebar-accent/30'
-
-							const rowClasses = cn(
-								'group transition-colors cursor-pointer',
-								rowBackgroundClasses
-							)
-
-							return (
-								<React.Fragment key={rowIndex}>
-									<RowContextMenu
-										row={row}
-										rowIndex={rowIndex}
-										columns={columns}
-										tableName={tableName}
-										onAction={function (action, row, index, batchIndexes) {
-											onRowAction?.(action, row, index, batchIndexes)
-										}}
-										onOpenChange={function (open, row) {
-											if (open) {
-												ensureRowSelectionForContextMenu(row)
-											}
-											handleRowContextMenuChange(open, row)
-										}}
-										selectedRows={effectiveSelectedRows}
-									>
-										<tr
-											className={rowClasses}
-											onClick={function (e) {
-												handleRowClick(e, rowIndex)
-											}}
-											role='row'
-											aria-rowindex={rowIndex + 2}
-											aria-selected={selectedRows.has(rowIndex)}
-										>
-											<td
-												className={cn(
-													'px-4 py-1.5 text-center border-b border-r border-sidebar-border sticky left-0 z-20 transition-colors',
-													rowBackgroundClasses,
-													selectedRows.has(rowIndex) && 'bg-sidebar-accent'
-												)}
-												role='gridcell'
-											>
-												<Checkbox
-													checked={selectedRows.has(rowIndex)}
-													onCheckedChange={function (checked) {
-														onRowSelect(rowIndex, !!checked)
-													}}
-													className='h-4 w-4'
-													aria-label={`Select row ${rowIndex + 1}`}
-												/>
-											</td>
-											{columns.map(function (col, colIndex) {
-												const isEditing =
-													editingCell?.rowIndex === rowIndex &&
-													editingCell?.columnName === col.name
-												const isFocused =
-													focusedCell?.row === rowIndex &&
-													focusedCell?.col === colIndex
-												const rowSelectedCols =
-													selectedCellsByRow.get(rowIndex)
-												const isSelected =
-													rowSelectedCols?.has(colIndex) || false
-												const width = getColumnWidth(col.name)
-
-												// Check if cell has pending edits
-												const isDirty = primaryKeyColumnName
-													? pendingEdits?.has(
-															`${row[primaryKeyColumnName]}:${col.name}`
-														)
-													: false
-
-												return (
-													<CellContextMenu
-														key={col.name}
-														value={row[col.name]}
-														column={col}
-														rowIndex={rowIndex}
-														colIndex={colIndex}
-														selectedRows={effectiveSelectedRows}
-														onAction={function (
-															action,
-															value,
-															column,
-															batchAction
-														) {
-															if (
-																action === 'filter-by-value' &&
-																onFilterAdd
-															) {
-																onFilterAdd({
-																	column: column.name,
-																	operator: 'eq',
-																	value: value
-																})
-															} else if (action === 'edit') {
-																handleCellDoubleClick(
-																	rowIndex,
-																	column.name,
-																	value
-																)
-															} else if (
-																action === 'set-null' &&
-																onCellEdit
-															) {
-																onCellEdit(
-																	rowIndex,
-																	column.name,
-																	null
-																)
-															} else if (
-																action === 'set-null-batch' &&
-																batchAction &&
-																onBatchCellEdit
-															) {
-																onBatchCellEdit(
-																	batchAction.rowIndexes,
-																	column.name,
-																	null
-																)
-															} else {
-																console.log(
-																	'Cell action:',
-																	action,
-																	value,
-																	column.name
-																)
-															}
-														}}
-														onOpenChange={function (open, row, col) {
-															handleCellContextMenuChange(
-																open,
-																row,
-																col
-															)
-														}}
-													>
-														<td
-															className={cn(
-																'border-b border-r border-sidebar-border last:border-r-0 font-mono text-sm overflow-hidden cursor-cell px-3 py-1.5 relative whitespace-nowrap text-ellipsis max-w-[300px]',
-																isSelected &&
-																	!isEditing &&
-																	'bg-muted-foreground/10',
-																isFocused &&
-																	!isEditing &&
-																	'bg-primary/5 ring-2 ring-inset ring-primary/60 z-10',
-																isDirty && 'bg-amber-500/10'
-															)}
-															style={
-																width
-																	? { maxWidth: width }
-																	: undefined
-															}
-															data-cell-key={`${rowIndex}:${colIndex}`}
-															onMouseDown={function (e) {
-																handleCellMouseDown(
-																	e,
-																	rowIndex,
-																	colIndex
-																)
-															}}
-															onMouseEnter={function () {
-																handleCellMouseEnter(
-																	rowIndex,
-																	colIndex
-																)
-															}}
-															onDoubleClick={function () {
-																handleCellDoubleClick(
-																	rowIndex,
-																	col.name,
-																	row[col.name]
-																)
-															}}
-														>
-															{isEditing ? (
-																<input
-																	ref={editInputRef}
-																	type='text'
-																	value={editValue}
-																	onChange={function (e) {
-																		setEditValue(e.target.value)
-																	}}
-																	onBlur={handleSaveEdit}
-																	onKeyDown={handleEditKeyDown}
-																	data-no-shortcuts='true'
-																	className='w-full h-full bg-primary/10 outline outline-1 outline-offset-[-1px] outline-primary font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
-																/>
-															) : (
-																<div className='truncate relative'>
-																	{formatCellValue(
-																		row[col.name],
-																		col
-																	)}
-																	{isDirty && (
-																		<div className='absolute top-0 right-0 -mr-3 -mt-1.5 w-0 h-0 border-t-[6px] border-r-[6px] border-t-transparent border-r-amber-500' />
-																	)}
-																</div>
-															)}
-														</td>
-													</CellContextMenu>
-												)
-											})}
-										</tr>
-									</RowContextMenu>
-									{draftRow && draftInsertIndex === rowIndex + 1 && (
-										<tr className='bg-emerald-500/10 border-b border-sidebar-border group relative'>
-											<td className='w-[30px] border-r border-sidebar-border bg-emerald-500/20 text-center align-middle'>
-												<div className='h-full w-full flex items-center justify-center text-emerald-500 font-bold text-xs'>
-													+
-												</div>
-											</td>
-											{columns.map(function (col, colIndex) {
-												const width = getColumnWidth(col.name)
-												const isPrimaryKey = col.primaryKey
-
-												return (
-													<td
-														key={`draft-${col.name}`}
-														className='border-b border-r border-sidebar-border last:border-r-0 font-mono text-sm px-0 py-0'
-														style={
-															width ? { maxWidth: width } : undefined
-														}
-													>
-														{isPrimaryKey ? (
-															<div className='px-3 py-1.5 text-muted-foreground italic text-xs'>
-																auto
-															</div>
-														) : (
-															<input
-																type='text'
-																autoFocus={
-																	colIndex === 0 ||
-																	(colIndex === 1 &&
-																		columns[0]?.primaryKey)
-																}
-																value={
-																	draftRow[col.name] === null
-																		? ''
-																		: String(
-																				draftRow[
-																					col.name
-																				] ?? ''
-																			)
-																}
-																onChange={function (e) {
-																	onDraftChange?.(
-																		col.name,
-																		e.target.value
-																	)
-																}}
-																onKeyDown={function (e) {
-																	if (e.key === 'Enter') {
-																		e.preventDefault()
-																		onDraftSave?.()
-																	} else if (e.key === 'Escape') {
-																		e.preventDefault()
-																		onDraftCancel?.()
-																	} else if (e.key === 'Tab') {
-																		const editableCols = columns.filter(function (c) { return !c.primaryKey })
-																		const curIdx = editableCols.findIndex(function (c) { return c.name === col.name })
-																		if (e.shiftKey) {
-																			if (curIdx > 0) {
-																				e.preventDefault()
-																				const prev = e.currentTarget.closest('tr')?.querySelector<HTMLInputElement>(
-																					`input[data-draft-col="${editableCols[curIdx - 1].name}"]`
-																				)
-																				prev?.focus()
-																			}
-																		} else {
-																			if (curIdx < editableCols.length - 1) {
-																				e.preventDefault()
-																				const next = e.currentTarget.closest('tr')?.querySelector<HTMLInputElement>(
-																					`input[data-draft-col="${editableCols[curIdx + 1].name}"]`
-																				)
-																				next?.focus()
-																			} else {
-																				e.preventDefault()
-																				onDraftSave?.()
-																			}
-																		}
-																	}
-																}}
-																data-draft-col={col.name}
-																data-no-shortcuts='true'
-																className='w-full h-full bg-transparent px-3 py-1.5 outline-none focus:bg-emerald-500/10 font-mono text-sm'
-																placeholder={
-																	col.nullable ? 'NULL' : ''
-																}
-															/>
-														)}
-													</td>
-												)
-											})}
-											<td className='w-[80px] border-b border-sidebar-border p-0'>
-												<div className='flex items-center justify-center h-full gap-1 px-2'>
-													<button
-														onClick={onDraftSave}
-														className='text-emerald-500 hover:text-emerald-400 text-xs font-medium'
-														title='Save (Enter)'
-													>
-														✓
-													</button>
-													<button
-														onClick={onDraftCancel}
-														className='text-muted-foreground hover:text-destructive text-xs'
-														title='Cancel (Escape)'
-													>
-														✕
-													</button>
-												</div>
-											</td>
-										</tr>
-									)}
-								</React.Fragment>
-							)
-						})}
-						{rows.length === 0 && (
-							<tr>
-								<td
-									colSpan={columns.length + 1}
-									className='h-[400px] text-center text-muted-foreground border-b border-sidebar-border'
-								>
-									<div className='flex flex-col items-center justify-center gap-2'>
-										<div className='p-3 rounded-full bg-sidebar-accent'>
-											<Database className='h-6 w-6 opacity-50' />
-										</div>
-										<p className='font-medium'>No results found</p>
-										<p className='text-sm opacity-80'>
-											Try clearing filters or adding a new record
-										</p>
-									</div>
-								</td>
-							</tr>
-						)}
-					</tbody>
+					<GridHeader
+						allSelected={allSelected}
+						columns={columns}
+						getColumnWidth={getColumnWidth}
+						onResizeDoubleClick={handleResizeDoubleClick}
+						onResizeStart={handleResizeStart}
+						onSelectAll={onSelectAll}
+						onSort={handleSort}
+						resizingColumn={resizingColumn}
+						someSelected={someSelected}
+						sort={sort}
+					/>
+					<GridBody
+						columns={columns}
+						draftInsertIndex={draftInsertIndex}
+						draftRow={draftRow}
+						editInputRef={editInputRef}
+						editingCell={editingCell}
+						editValue={editValue}
+						effectiveSelectedRows={effectiveSelectedRows}
+						focusedCell={focusedCell}
+						getColumnWidth={getColumnWidth}
+						handleCellContextMenuChange={handleCellContextMenuChange}
+						handleCellDoubleClick={handleCellDoubleClick}
+						handleCellMouseDown={handleCellMouseDown}
+						handleCellMouseEnter={handleCellMouseEnter}
+						handleEditKeyDown={handleEditKeyDown}
+						handleRowClick={handleRowClick}
+						handleRowContextMenuChange={handleRowContextMenuChange}
+						handleSaveEdit={handleSaveEdit}
+						onBatchCellEdit={onBatchCellEdit}
+						onCellEdit={onCellEdit}
+						onDraftCancel={onDraftCancel}
+						onDraftChange={onDraftChange}
+						onDraftSave={onDraftSave}
+						onFilterAdd={onFilterAdd}
+						onRowAction={onRowAction}
+						onRowSelect={onRowSelect}
+						pendingEdits={pendingEdits}
+						primaryKeyColumnName={primaryKeyColumnName}
+						rows={rows}
+						selectedCellsByRow={selectedCellsByRow}
+						selectedRows={selectedRows}
+						tableName={tableName}
+						ensureRowSelectionForContextMenu={ensureRowSelectionForContextMenu}
+						setEditValue={setEditValue}
+					/>
 				</table>
 			</div>
 			<ScrollHint containerRef={scrollContainerRef} />
 		</div>
 	)
-}
-
-function formatCellValue(value: unknown, column: ColumnDefinition): React.ReactNode {
-	if (value === null || value === undefined) {
-		return <span className='text-muted-foreground italic'>NULL</span>
-	}
-
-	// Explicit column type handling based on name heuristics or type if available
-	const colName = column.name.toLowerCase()
-
-	// IP Addresses
-	if (colName.includes('ip_address') || colName.includes('ip_addr')) {
-		return <IpCell value={String(value)} />
-	}
-
-	// Tokens / Hashes (long strings)
-	if (
-		(colName.includes('token') ||
-			colName.includes('hash') ||
-			colName.includes('key') ||
-			colName.includes('signature')) &&
-		typeof value === 'string' &&
-		value.length > 20
-	) {
-		return <TokenCell value={value} />
-	}
-
-	// Dates
-	if (
-		colName.endsWith('_at') ||
-		colName.endsWith('_date') ||
-		colName === 'date' ||
-		colName === 'timestamp' ||
-		column.type?.includes('timestamp') ||
-		column.type?.includes('date')
-	) {
-		return <DateCell value={value} columnName={colName} />
-	}
-
-	if (typeof value === 'boolean') {
-		return (
-			<div className='flex items-center justify-center'>
-				{value ? (
-					<Check className='w-3.5 h-3.5 text-emerald-500' />
-				) : (
-					<X className='w-3.5 h-3.5 text-muted-foreground/30' />
-				)}
-			</div>
-		)
-	}
-
-	if (typeof value === 'number') {
-		return <div className='text-right font-mono text-primary w-full'>{value}</div>
-	}
-
-	if (typeof value === 'object') {
-		return <span className='text-warning'>{JSON.stringify(value)}</span>
-	}
-
-	return <span className='text-foreground'>{String(value)}</span>
 }

--- a/apps/desktop/src/features/database-studio/components/data-grid/cell-value.tsx
+++ b/apps/desktop/src/features/database-studio/components/data-grid/cell-value.tsx
@@ -1,0 +1,62 @@
+import { Check, X } from 'lucide-react'
+import React from 'react'
+import { ColumnDefinition } from '../../types'
+import { DateCell } from '../cells/date-cell'
+import { IpCell } from '../cells/ip-cell'
+import { TokenCell } from '../cells/token-cell'
+
+export function formatCellValue(value: unknown, column: ColumnDefinition): React.ReactNode {
+	if (value === null || value === undefined) {
+		return <span className='text-muted-foreground italic'>NULL</span>
+	}
+
+	const colName = column.name.toLowerCase()
+
+	if (colName.includes('ip_address') || colName.includes('ip_addr')) {
+		return <IpCell value={String(value)} />
+	}
+
+	if (
+		(colName.includes('token') ||
+			colName.includes('hash') ||
+			colName.includes('key') ||
+			colName.includes('signature')) &&
+		typeof value === 'string' &&
+		value.length > 20
+	) {
+		return <TokenCell value={value} />
+	}
+
+	if (
+		colName.endsWith('_at') ||
+		colName.endsWith('_date') ||
+		colName === 'date' ||
+		colName === 'timestamp' ||
+		column.type?.includes('timestamp') ||
+		column.type?.includes('date')
+	) {
+		return <DateCell value={value} columnName={colName} />
+	}
+
+	if (typeof value === 'boolean') {
+		return (
+			<div className='flex items-center justify-center'>
+				{value ? (
+					<Check className='w-3.5 h-3.5 text-emerald-500' />
+				) : (
+					<X className='w-3.5 h-3.5 text-muted-foreground/30' />
+				)}
+			</div>
+		)
+	}
+
+	if (typeof value === 'number') {
+		return <div className='text-right font-mono text-primary w-full'>{value}</div>
+	}
+
+	if (typeof value === 'object') {
+		return <span className='text-warning'>{JSON.stringify(value)}</span>
+	}
+
+	return <span className='text-foreground'>{String(value)}</span>
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/draft-row.tsx
+++ b/apps/desktop/src/features/database-studio/components/data-grid/draft-row.tsx
@@ -1,0 +1,221 @@
+import { Check, X } from 'lucide-react'
+import type React from 'react'
+import { matchesShortcut, parseShortcut } from '@/core/shortcuts'
+import { ColumnDefinition } from '../../types'
+
+const enterShortcut = parseShortcut('enter')
+const escapeShortcut = parseShortcut('escape')
+const tabShortcut = parseShortcut('tab')
+const shiftTabShortcut = parseShortcut('shift+tab')
+
+type Props = {
+	columns: ColumnDefinition[]
+	draftRow: Record<string, unknown>
+	getColumnWidth: (columnName: string) => number | undefined
+	onDraftChange?: (columnName: string, value: unknown) => void
+	onDraftSave?: () => void
+	onDraftCancel?: () => void
+	variant: 'top' | 'inline'
+}
+
+export function DraftRow({
+	columns,
+	draftRow,
+	getColumnWidth,
+	onDraftChange,
+	onDraftSave,
+	onDraftCancel,
+	variant
+}: Props) {
+	const isTop = variant === 'top'
+
+	return (
+		<tr
+			className={
+				isTop
+					? 'bg-emerald-500/10 border-l-2 border-l-emerald-500'
+					: 'bg-emerald-500/10 border-b border-sidebar-border group relative'
+			}
+		>
+			<td
+				className={
+					isTop
+						? 'px-1 py-1.5 text-center border-b border-r border-sidebar-border'
+						: 'w-[30px] border-r border-sidebar-border bg-emerald-500/20 text-center align-middle'
+				}
+			>
+				{isTop ? (
+					<DraftActions onDraftSave={onDraftSave} onDraftCancel={onDraftCancel} />
+				) : (
+					<div className='h-full w-full flex items-center justify-center text-emerald-500 font-bold text-xs'>
+						+
+					</div>
+				)}
+			</td>
+			{columns.map(function (col, colIndex) {
+				const width = getColumnWidth(col.name)
+
+				return (
+					<td
+						key={isTop ? col.name : `draft-${col.name}`}
+						className='border-b border-r border-sidebar-border last:border-r-0 font-mono text-sm px-0 py-0'
+						style={width ? { maxWidth: width } : undefined}
+					>
+						{col.primaryKey ? (
+							<div className='px-3 py-1.5 text-muted-foreground italic text-xs'>
+								auto
+							</div>
+						) : (
+							<DraftInput
+								col={col}
+								colIndex={colIndex}
+								columns={columns}
+								draftRow={draftRow}
+								onDraftChange={onDraftChange}
+								onDraftSave={onDraftSave}
+								onDraftCancel={onDraftCancel}
+							/>
+						)}
+					</td>
+				)
+			})}
+			{!isTop && (
+				<td className='w-[80px] border-b border-sidebar-border p-0'>
+					<DraftActions onDraftSave={onDraftSave} onDraftCancel={onDraftCancel} />
+				</td>
+			)}
+		</tr>
+	)
+}
+
+type TProps = {
+	col: ColumnDefinition
+	colIndex: number
+	columns: ColumnDefinition[]
+	draftRow: Record<string, unknown>
+	onDraftChange?: (columnName: string, value: unknown) => void
+	onDraftSave?: () => void
+	onDraftCancel?: () => void
+}
+
+function DraftInput({
+	col,
+	colIndex,
+	columns,
+	draftRow,
+	onDraftChange,
+	onDraftSave,
+	onDraftCancel
+}: TProps) {
+	return (
+		<input
+			type='text'
+			autoFocus={colIndex === 0 || (colIndex === 1 && columns[0]?.primaryKey)}
+			value={draftRow[col.name] === null ? '' : String(draftRow[col.name] ?? '')}
+			onChange={function (e) {
+				onDraftChange?.(col.name, e.target.value)
+			}}
+			onKeyDown={function (e) {
+				handleDraftKeyDown(e, col.name, columns, onDraftSave, onDraftCancel)
+			}}
+			data-draft-col={col.name}
+			data-no-shortcuts='true'
+			className='w-full h-full bg-transparent px-3 py-1.5 outline-none focus:bg-emerald-500/10 font-mono text-sm'
+			placeholder={col.nullable ? 'NULL' : ''}
+		/>
+	)
+}
+
+function handleDraftKeyDown(
+	e: React.KeyboardEvent<HTMLInputElement>,
+	columnName: string,
+	columns: ColumnDefinition[],
+	onDraftSave?: () => void,
+	onDraftCancel?: () => void
+) {
+	const nativeEvent = e.nativeEvent
+
+	if (matchesShortcut(nativeEvent, enterShortcut)) {
+		e.preventDefault()
+		onDraftSave?.()
+		return
+	}
+
+	if (matchesShortcut(nativeEvent, escapeShortcut)) {
+		e.preventDefault()
+		onDraftCancel?.()
+		return
+	}
+
+	const isShiftTab = matchesShortcut(nativeEvent, shiftTabShortcut)
+	const isTab = matchesShortcut(nativeEvent, tabShortcut)
+
+	if (!isShiftTab && !isTab) return
+
+	const editableCols = columns.filter(function (c) {
+		return !c.primaryKey
+	})
+	const curIdx = editableCols.findIndex(function (c) {
+		return c.name === columnName
+	})
+
+	if (isShiftTab) {
+		if (curIdx > 0) {
+			e.preventDefault()
+			const prev = e.currentTarget
+				.closest('tr')
+				?.querySelector<HTMLInputElement>(
+					`input[data-draft-col="${editableCols[curIdx - 1].name}"]`
+				)
+			prev?.focus()
+		}
+		return
+	}
+
+	if (isTab) {
+		if (curIdx < editableCols.length - 1) {
+			e.preventDefault()
+			const next = e.currentTarget
+				.closest('tr')
+				?.querySelector<HTMLInputElement>(
+					`input[data-draft-col="${editableCols[curIdx + 1].name}"]`
+				)
+			next?.focus()
+			return
+		}
+
+		e.preventDefault()
+		onDraftSave?.()
+		return
+	}
+}
+
+type DraftActionsProps = {
+	onDraftSave?: () => void
+	onDraftCancel?: () => void
+}
+
+function DraftActions({ onDraftSave, onDraftCancel }: DraftActionsProps) {
+	return (
+		<div className='flex items-center justify-center h-full gap-1 px-2'>
+			<button
+				type='button'
+				onClick={onDraftSave}
+				className='inline-flex h-6 w-6 items-center justify-center text-emerald-500 hover:text-emerald-400 transition-colors'
+				title='Save (Enter)'
+				aria-label='Save draft row'
+			>
+				<Check className='h-3.5 w-3.5' />
+			</button>
+			<button
+				type='button'
+				onClick={onDraftCancel}
+				className='inline-flex h-6 w-6 items-center justify-center text-muted-foreground hover:text-destructive transition-colors'
+				title='Cancel (Escape)'
+				aria-label='Cancel draft row'
+			>
+				<X className='h-3.5 w-3.5' />
+			</button>
+		</div>
+	)
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/empty-states.tsx
+++ b/apps/desktop/src/features/database-studio/components/data-grid/empty-states.tsx
@@ -1,0 +1,47 @@
+import { Database } from 'lucide-react'
+
+type NoColumnsStateProps = {
+	message?: string
+}
+
+export function NoColumnsState({ message }: NoColumnsStateProps) {
+	return (
+		<div className='flex flex-col items-center justify-center h-full gap-4 p-8'>
+			<div className='flex h-16 w-16 items-center justify-center rounded-full bg-muted/50'>
+				<Database className='h-8 w-8 text-muted-foreground/60' />
+			</div>
+			<div className='text-center space-y-1.5'>
+				<h3 className='text-sm font-medium text-foreground'>No columns found</h3>
+				<p className='text-xs text-muted-foreground max-w-[280px]'>
+					{message ??
+						"This table doesn't have any columns defined yet, or the schema couldn't be loaded."}
+				</p>
+			</div>
+		</div>
+	)
+}
+
+type NoRowsStateProps = {
+	colSpan: number
+}
+
+export function NoRowsState({ colSpan }: NoRowsStateProps) {
+	return (
+		<tr>
+			<td
+				colSpan={colSpan}
+				className='h-[400px] text-center text-muted-foreground border-b border-sidebar-border'
+			>
+				<div className='flex flex-col items-center justify-center gap-2'>
+					<div className='p-3 rounded-full bg-sidebar-accent'>
+						<Database className='h-6 w-6 opacity-50' />
+					</div>
+					<p className='font-medium'>No results found</p>
+					<p className='text-sm opacity-80'>
+						Try clearing filters or adding a new record
+					</p>
+				</div>
+			</td>
+		</tr>
+	)
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/grid-body.tsx
+++ b/apps/desktop/src/features/database-studio/components/data-grid/grid-body.tsx
@@ -1,0 +1,298 @@
+import React from 'react'
+import { Checkbox } from '@/shared/ui/checkbox'
+import { cn } from '@/shared/utils/cn'
+import { ColumnDefinition, FilterDescriptor } from '../../types'
+import { CellContextMenu } from '../cell-context-menu'
+import { RowAction, RowContextMenu } from '../row-context-menu'
+import { formatCellValue } from './cell-value'
+import { DraftRow } from './draft-row'
+import { NoRowsState } from './empty-states'
+import { EditingCell } from './types'
+
+type GridBodyProps = {
+	columns: ColumnDefinition[]
+	draftInsertIndex?: number | null
+	draftRow?: Record<string, unknown> | null
+	editInputRef: React.RefObject<HTMLInputElement>
+	editingCell: EditingCell | null
+	editValue: string
+	effectiveSelectedRows: Set<number>
+	focusedCell: { row: number; col: number } | null
+	getColumnWidth: (columnName: string) => number | undefined
+	handleCellContextMenuChange: (open: boolean, row: number, col: number) => void
+	handleCellDoubleClick: (rowIndex: number, columnName: string, currentValue: unknown) => void
+	handleCellMouseDown: (e: React.MouseEvent, rowIndex: number, colIndex: number) => void
+	handleCellMouseEnter: (rowIndex: number, colIndex: number) => void
+	handleEditKeyDown: (e: React.KeyboardEvent) => void
+	handleSaveEdit: () => void
+	handleRowClick: (e: React.MouseEvent, rowIndex: number) => void
+	handleRowContextMenuChange: (open: boolean, row: number) => void
+	onBatchCellEdit?: (rowIndexes: number[], columnName: string, newValue: unknown) => void
+	onCellEdit?: (rowIndex: number, columnName: string, newValue: unknown) => void
+	onDraftCancel?: () => void
+	onDraftChange?: (columnName: string, value: unknown) => void
+	onDraftSave?: () => void
+	onFilterAdd?: (filter: FilterDescriptor) => void
+	onRowAction?: (
+		action: RowAction,
+		row: Record<string, unknown>,
+		rowIndex: number,
+		batchIndexes?: number[]
+	) => void
+	onRowSelect: (rowIndex: number, checked: boolean) => void
+	pendingEdits?: Set<string>
+	primaryKeyColumnName?: string
+	rows: Record<string, unknown>[]
+	selectedCellsByRow: Map<number, Set<number>>
+	selectedRows: Set<number>
+	tableName?: string
+	ensureRowSelectionForContextMenu: (rowIndex: number) => void
+	setEditValue: (value: string) => void
+}
+
+export function GridBody({
+	columns,
+	draftInsertIndex,
+	draftRow,
+	editInputRef,
+	editingCell,
+	editValue,
+	effectiveSelectedRows,
+	focusedCell,
+	getColumnWidth,
+	handleCellContextMenuChange,
+	handleCellDoubleClick,
+	handleCellMouseDown,
+	handleCellMouseEnter,
+	handleEditKeyDown,
+	handleSaveEdit,
+	handleRowClick,
+	handleRowContextMenuChange,
+	onBatchCellEdit,
+	onCellEdit,
+	onDraftCancel,
+	onDraftChange,
+	onDraftSave,
+	onFilterAdd,
+	onRowAction,
+	onRowSelect,
+	pendingEdits,
+	primaryKeyColumnName,
+	rows,
+	selectedCellsByRow,
+	selectedRows,
+	tableName,
+	ensureRowSelectionForContextMenu,
+	setEditValue
+}: GridBodyProps) {
+	return (
+		<tbody role='rowgroup'>
+			{draftRow &&
+				(draftInsertIndex === undefined ||
+					draftInsertIndex === null ||
+					draftInsertIndex === -1) && (
+					<DraftRow
+						columns={columns}
+						draftRow={draftRow}
+						getColumnWidth={getColumnWidth}
+						onDraftChange={onDraftChange}
+						onDraftSave={onDraftSave}
+						onDraftCancel={onDraftCancel}
+						variant='top'
+					/>
+				)}
+
+			{rows.map(function (row, rowIndex) {
+				const rowBackgroundClasses = selectedRows.has(rowIndex)
+					? 'bg-primary/10'
+					: rowIndex % 2 === 1
+						? 'bg-muted/35 hover:bg-sidebar-accent/30'
+						: 'hover:bg-sidebar-accent/30'
+				const rowClasses = cn(
+					'group transition-colors cursor-pointer',
+					rowBackgroundClasses
+				)
+
+				return (
+					<React.Fragment key={rowIndex}>
+						<RowContextMenu
+							row={row}
+							rowIndex={rowIndex}
+							columns={columns}
+							tableName={tableName}
+							onAction={function (action, row, index, batchIndexes) {
+								onRowAction?.(action, row, index, batchIndexes)
+							}}
+							onOpenChange={function (open, row) {
+								if (open) {
+									ensureRowSelectionForContextMenu(row)
+								}
+								handleRowContextMenuChange(open, row)
+							}}
+							selectedRows={effectiveSelectedRows}
+						>
+							<tr
+								className={rowClasses}
+								onClick={function (e) {
+									handleRowClick(e, rowIndex)
+								}}
+								role='row'
+								aria-rowindex={rowIndex + 2}
+								aria-selected={selectedRows.has(rowIndex)}
+							>
+								<td
+									className={cn(
+										'px-4 py-1.5 text-center border-b border-r border-sidebar-border sticky left-0 z-20 transition-colors',
+										rowBackgroundClasses,
+										selectedRows.has(rowIndex) && 'bg-sidebar-accent'
+									)}
+									role='gridcell'
+								>
+									<Checkbox
+										checked={selectedRows.has(rowIndex)}
+										onCheckedChange={function (checked) {
+											onRowSelect(rowIndex, !!checked)
+										}}
+										className='h-4 w-4'
+										aria-label={`Select row ${rowIndex + 1}`}
+									/>
+								</td>
+								{columns.map(function (col, colIndex) {
+									const isEditing =
+										editingCell?.rowIndex === rowIndex &&
+										editingCell?.columnName === col.name
+									const isFocused =
+										focusedCell?.row === rowIndex &&
+										focusedCell?.col === colIndex
+									const rowSelectedCols = selectedCellsByRow.get(rowIndex)
+									const isSelected = rowSelectedCols?.has(colIndex) || false
+									const width = getColumnWidth(col.name)
+									const isDirty = primaryKeyColumnName
+										? pendingEdits?.has(
+												`${row[primaryKeyColumnName]}:${col.name}`
+											)
+										: false
+
+									return (
+										<CellContextMenu
+											key={col.name}
+											value={row[col.name]}
+											column={col}
+											rowIndex={rowIndex}
+											colIndex={colIndex}
+											selectedRows={effectiveSelectedRows}
+											onAction={function (
+												action,
+												value,
+												column,
+												batchAction
+											) {
+												if (action === 'filter-by-value' && onFilterAdd) {
+													onFilterAdd({
+														column: column.name,
+														operator: 'eq',
+														value
+													})
+												} else if (action === 'edit') {
+													handleCellDoubleClick(
+														rowIndex,
+														column.name,
+														value
+													)
+												} else if (action === 'set-null' && onCellEdit) {
+													onCellEdit(rowIndex, column.name, null)
+												} else if (
+													action === 'set-null-batch' &&
+													batchAction &&
+													onBatchCellEdit
+												) {
+													onBatchCellEdit(
+														batchAction.rowIndexes,
+														column.name,
+														null
+													)
+												} else {
+													console.log(
+														'Cell action:',
+														action,
+														value,
+														column.name
+													)
+												}
+											}}
+											onOpenChange={function (open, row, col) {
+												handleCellContextMenuChange(open, row, col)
+											}}
+										>
+											<td
+												className={cn(
+													'border-b border-r border-sidebar-border last:border-r-0 font-mono text-sm overflow-hidden cursor-cell px-3 py-1.5 relative whitespace-nowrap text-ellipsis max-w-[300px]',
+													isSelected &&
+														!isEditing &&
+														'bg-muted-foreground/10',
+													isFocused &&
+														!isEditing &&
+														'bg-primary/5 ring-2 ring-inset ring-primary/60 z-10',
+													isDirty && 'bg-amber-500/10'
+												)}
+												style={width ? { maxWidth: width } : undefined}
+												data-cell-key={`${rowIndex}:${colIndex}`}
+												onMouseDown={function (e) {
+													handleCellMouseDown(e, rowIndex, colIndex)
+												}}
+												onMouseEnter={function () {
+													handleCellMouseEnter(rowIndex, colIndex)
+												}}
+												onDoubleClick={function () {
+													handleCellDoubleClick(
+														rowIndex,
+														col.name,
+														row[col.name]
+													)
+												}}
+											>
+												{isEditing ? (
+													<input
+														ref={editInputRef}
+														type='text'
+														value={editValue}
+														onChange={function (e) {
+															setEditValue(e.target.value)
+														}}
+														onBlur={handleSaveEdit}
+														onKeyDown={handleEditKeyDown}
+														data-no-shortcuts='true'
+														className='w-full h-full bg-primary/10 outline outline-1 outline-offset-[-1px] outline-primary font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
+													/>
+												) : (
+													<div className='truncate relative'>
+														{formatCellValue(row[col.name], col)}
+														{isDirty && (
+															<div className='absolute top-0 right-0 -mr-3 -mt-1.5 w-0 h-0 border-t-[6px] border-r-[6px] border-t-transparent border-r-amber-500' />
+														)}
+													</div>
+												)}
+											</td>
+										</CellContextMenu>
+									)
+								})}
+							</tr>
+						</RowContextMenu>
+						{draftRow && draftInsertIndex === rowIndex + 1 && (
+							<DraftRow
+								columns={columns}
+								draftRow={draftRow}
+								getColumnWidth={getColumnWidth}
+								onDraftChange={onDraftChange}
+								onDraftSave={onDraftSave}
+								onDraftCancel={onDraftCancel}
+								variant='inline'
+							/>
+						)}
+					</React.Fragment>
+				)
+			})}
+			{rows.length === 0 && <NoRowsState colSpan={columns.length + 1} />}
+		</tbody>
+	)
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/grid-header.tsx
+++ b/apps/desktop/src/features/database-studio/components/data-grid/grid-header.tsx
@@ -1,0 +1,109 @@
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
+import type React from 'react'
+import { Checkbox } from '@/shared/ui/checkbox'
+import { cn } from '@/shared/utils/cn'
+import { ColumnDefinition, SortDescriptor } from '../../types'
+
+type GridHeaderProps = {
+	allSelected: boolean
+	columns: ColumnDefinition[]
+	getColumnWidth: (columnName: string) => number | undefined
+	onResizeDoubleClick: (e: React.MouseEvent, columnName: string, columnType?: string) => void
+	onResizeStart: (e: React.MouseEvent, columnName: string) => void
+	onSelectAll: (checked: boolean) => void
+	onSort: (columnName: string) => void
+	resizingColumn: string | null
+	someSelected: boolean
+	sort?: SortDescriptor
+}
+
+export function GridHeader({
+	allSelected,
+	columns,
+	getColumnWidth,
+	onResizeDoubleClick,
+	onResizeStart,
+	onSelectAll,
+	onSort,
+	resizingColumn,
+	someSelected,
+	sort
+}: GridHeaderProps) {
+	return (
+		<thead className='sticky top-0 bg-sidebar z-10' role='rowgroup'>
+			<tr role='row'>
+				<th
+					className='px-4 py-2 text-center border-b border-r border-sidebar-border bg-background sticky left-0 z-30'
+					role='columnheader'
+					aria-label='Select all rows'
+				>
+					<Checkbox
+						checked={someSelected ? 'indeterminate' : allSelected}
+						onCheckedChange={function (checked) {
+							onSelectAll(!!checked)
+						}}
+						className='h-4 w-4'
+						aria-label={allSelected ? 'Deselect all rows' : 'Select all rows'}
+					/>
+				</th>
+				{columns.map(function (col) {
+					const isSorted = sort?.column === col.name
+					const width = getColumnWidth(col.name)
+
+					return (
+						<th
+							key={col.name}
+							className={cn(
+								'text-left font-medium border-b border-r border-sidebar-border bg-sidebar-accent/50 last:border-r-0 h-9 cursor-pointer transition-colors hover:bg-sidebar-accent relative select-none min-w-[60px]',
+								isSorted && 'bg-sidebar-accent',
+								resizingColumn === col.name && 'bg-sidebar-accent'
+							)}
+							style={width ? { width } : undefined}
+							onClick={function () {
+								onSort(col.name)
+							}}
+						>
+							<div className='flex items-center gap-1.5 justify-between group px-3 py-2 overflow-hidden'>
+								<div className='flex items-center gap-1.5 overflow-hidden min-w-0'>
+									<span className='text-foreground text-xs shrink-0'>
+										{col.name}
+									</span>
+									{col.type && col.type !== 'unknown' && (
+										<span className='text-muted-foreground/50 text-[10px] font-normal font-mono lowercase truncate min-w-0'>
+											{col.type}
+										</span>
+									)}
+								</div>
+								{isSorted && sort ? (
+									sort.direction === 'asc' ? (
+										<ArrowUp className='h-3 w-3 text-primary shrink-0' />
+									) : (
+										<ArrowDown className='h-3 w-3 text-primary shrink-0' />
+									)
+								) : (
+									<ArrowUpDown className='h-3 w-3 text-muted-foreground/0 group-hover:text-muted-foreground/50 transition-colors shrink-0' />
+								)}
+							</div>
+
+							<div
+								className={cn(
+									'absolute right-0 top-0 w-1.5 h-full cursor-col-resize hover:bg-primary/50 transition-colors',
+									resizingColumn === col.name && 'bg-primary'
+								)}
+								onMouseDown={function (e) {
+									onResizeStart(e, col.name)
+								}}
+								onDoubleClick={function (e) {
+									onResizeDoubleClick(e, col.name, col.type)
+								}}
+								onClick={function (e) {
+									e.stopPropagation()
+								}}
+							/>
+						</th>
+					)
+				})}
+			</tr>
+		</thead>
+	)
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/selection.ts
+++ b/apps/desktop/src/features/database-studio/components/data-grid/selection.ts
@@ -1,0 +1,20 @@
+import { CellPosition } from './types'
+
+export function getCellKey(row: number, col: number): string {
+	return `${row}:${col}`
+}
+
+export function getCellsInRectangle(start: CellPosition, end: CellPosition): Set<string> {
+	const minRow = Math.min(start.row, end.row)
+	const maxRow = Math.max(start.row, end.row)
+	const minCol = Math.min(start.col, end.col)
+	const maxCol = Math.max(start.col, end.col)
+
+	const cells = new Set<string>()
+	for (let r = minRow; r <= maxRow; r++) {
+		for (let c = minCol; c <= maxCol; c++) {
+			cells.add(getCellKey(r, c))
+		}
+	}
+	return cells
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/types.ts
+++ b/apps/desktop/src/features/database-studio/components/data-grid/types.ts
@@ -1,0 +1,16 @@
+export type EditingCell = {
+	rowIndex: number
+	columnName: string
+}
+
+export type CellPosition = {
+	row: number
+	col: number
+}
+
+export type ContextMenuState = {
+	kind: 'cell' | 'row'
+	cell: { row: number; col: number }
+	x: number
+	y: number
+} | null

--- a/apps/desktop/src/features/database-studio/components/data-grid/use-cell-editing.ts
+++ b/apps/desktop/src/features/database-studio/components/data-grid/use-cell-editing.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type React from 'react'
+import { ColumnDefinition } from '../../types'
+import { getCellKey } from './selection'
+import { CellPosition, EditingCell } from './types'
+
+type UseCellEditingArgs = {
+	columns: ColumnDefinition[]
+	gridRef: React.RefObject<HTMLTableElement>
+	onCellEdit?: (rowIndex: number, columnName: string, newValue: unknown) => void
+	rows: Record<string, unknown>[]
+	setAnchorCell: (cell: CellPosition | null) => void
+	setFocusedCell: (cell: CellPosition | null) => void
+	updateCellSelection: (cells: Set<string>) => void
+}
+
+export function useCellEditing({
+	columns,
+	gridRef,
+	onCellEdit,
+	rows,
+	setAnchorCell,
+	setFocusedCell,
+	updateCellSelection
+}: UseCellEditingArgs) {
+	const [editingCell, setEditingCell] = useState<EditingCell | null>(null)
+	const [editValue, setEditValue] = useState<string>('')
+	const editInputRef = useRef<HTMLInputElement>(null)
+	const editValueRef = useRef(editValue)
+	editValueRef.current = editValue
+	const editingCellRef = useRef(editingCell)
+	editingCellRef.current = editingCell
+	const skipNextBlurSaveRef = useRef(false)
+
+	const refocusGrid = useCallback(
+		function () {
+			requestAnimationFrame(function () {
+				gridRef.current?.focus()
+			})
+		},
+		[gridRef]
+	)
+
+	const handleCellDoubleClick = useCallback(function (
+		rowIndex: number,
+		columnName: string,
+		currentValue: unknown
+	) {
+		setEditingCell({ rowIndex, columnName })
+		setEditValue(
+			currentValue === null || currentValue === undefined ? '' : String(currentValue)
+		)
+	}, [])
+
+	const handleSaveEdit = useCallback(
+		function () {
+			if (skipNextBlurSaveRef.current) {
+				skipNextBlurSaveRef.current = false
+				return
+			}
+			const cell = editingCellRef.current
+			const value = editValueRef.current
+			if (cell && onCellEdit) {
+				onCellEdit(cell.rowIndex, cell.columnName, value)
+			}
+			editingCellRef.current = null
+			setEditingCell(null)
+			setEditValue('')
+			refocusGrid()
+		},
+		[onCellEdit, refocusGrid]
+	)
+
+	const handleCancelEdit = useCallback(
+		function () {
+			setEditingCell(null)
+			setEditValue('')
+			refocusGrid()
+		},
+		[refocusGrid]
+	)
+
+	const handleSaveEditAndMove = useCallback(
+		function (direction: 'next' | 'prev') {
+			const cell = editingCellRef.current
+			if (!cell) return
+
+			if (onCellEdit) {
+				onCellEdit(cell.rowIndex, cell.columnName, editValueRef.current)
+			}
+
+			skipNextBlurSaveRef.current = true
+
+			const colIndex = columns.findIndex(function (c) {
+				return c.name === cell.columnName
+			})
+			const maxCol = columns.length - 1
+			const maxRow = rows.length - 1
+			let nextRow = cell.rowIndex
+			let nextCol = colIndex
+
+			if (direction === 'next') {
+				if (colIndex < maxCol) {
+					nextCol = colIndex + 1
+				} else if (cell.rowIndex < maxRow) {
+					nextRow = cell.rowIndex + 1
+					nextCol = 0
+				}
+			} else if (colIndex > 0) {
+				nextCol = colIndex - 1
+			} else if (cell.rowIndex > 0) {
+				nextRow = cell.rowIndex - 1
+				nextCol = maxCol
+			}
+
+			const newPos = { row: nextRow, col: nextCol }
+			setFocusedCell(newPos)
+			setAnchorCell(newPos)
+			updateCellSelection(new Set([getCellKey(nextRow, nextCol)]))
+			setEditingCell({ rowIndex: nextRow, columnName: columns[nextCol].name })
+			setEditValue(
+				rows[nextRow][columns[nextCol].name] === null ||
+					rows[nextRow][columns[nextCol].name] === undefined
+					? ''
+					: String(rows[nextRow][columns[nextCol].name])
+			)
+		},
+		[columns, onCellEdit, rows, setAnchorCell, setFocusedCell, updateCellSelection]
+	)
+
+	const handleEditKeyDown = useCallback(
+		function (e: React.KeyboardEvent) {
+			if (e.key === 'Enter') {
+				e.preventDefault()
+				handleSaveEdit()
+			} else if (e.key === 'Escape') {
+				e.preventDefault()
+				handleCancelEdit()
+			} else if (e.key === 'Tab') {
+				e.preventDefault()
+				handleSaveEditAndMove(e.shiftKey ? 'prev' : 'next')
+			}
+		},
+		[handleCancelEdit, handleSaveEdit, handleSaveEditAndMove]
+	)
+
+	useEffect(() => {
+		if (editingCell && editInputRef.current) {
+			const timer = setTimeout(function () {
+				if (editInputRef.current) {
+					editInputRef.current.focus()
+					editInputRef.current.select()
+				}
+			}, 10)
+			return function () {
+				clearTimeout(timer)
+			}
+		}
+	}, [editingCell])
+
+	return {
+		editingCell,
+		setEditingCell,
+		editValue,
+		setEditValue,
+		editInputRef,
+		handleCellDoubleClick,
+		handleSaveEdit,
+		handleEditKeyDown
+	}
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/use-cell-selection.ts
+++ b/apps/desktop/src/features/database-studio/components/data-grid/use-cell-selection.ts
@@ -1,0 +1,35 @@
+import { useMemo, useState } from 'react'
+
+export function useCellSelection(
+	externalSelectedCells?: Set<string>,
+	onCellSelectionChange?: (cells: Set<string>) => void
+) {
+	const [internalSelectedCells, setInternalSelectedCells] = useState<Set<string>>(new Set())
+	const selectedCellsSet = externalSelectedCells ?? internalSelectedCells
+	const selectedCellsByRow = useMemo(() => {
+		const byRow = new Map<number, Set<number>>()
+		for (const key of selectedCellsSet) {
+			const [rowPart, colPart] = key.split(':')
+			const rowIndex = Number(rowPart)
+			const colIndex = Number(colPart)
+			if (Number.isNaN(rowIndex) || Number.isNaN(colIndex)) continue
+			const current = byRow.get(rowIndex)
+			if (current) {
+				current.add(colIndex)
+			} else {
+				byRow.set(rowIndex, new Set([colIndex]))
+			}
+		}
+		return byRow
+	}, [selectedCellsSet])
+
+	function updateCellSelection(cells: Set<string>) {
+		if (onCellSelectionChange) {
+			onCellSelectionChange(cells)
+		} else {
+			setInternalSelectedCells(cells)
+		}
+	}
+
+	return { selectedCellsSet, selectedCellsByRow, updateCellSelection }
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/use-column-resize.ts
+++ b/apps/desktop/src/features/database-studio/components/data-grid/use-column-resize.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type React from 'react'
+
+export const MIN_COLUMN_WIDTH = 100
+export const DEFAULT_COLUMN_WIDTH = 150
+
+export function useColumnResize() {
+	const [columnWidths, setColumnWidths] = useState<Record<string, number>>({})
+	const [resizingColumn, setResizingColumn] = useState<string | null>(null)
+	const startXRef = useRef(0)
+	const startWidthRef = useRef(0)
+
+	const getColumnWidth = useCallback(
+		function (colName: string) {
+			return columnWidths[colName]
+		},
+		[columnWidths]
+	)
+
+	const handleResizeStart = useCallback(
+		function (e: React.MouseEvent, columnName: string) {
+			e.preventDefault()
+			e.stopPropagation()
+
+			setResizingColumn(columnName)
+			startXRef.current = e.clientX
+
+			const currentWidth = columnWidths[columnName]
+			if (typeof currentWidth === 'number') {
+				startWidthRef.current = currentWidth
+			} else {
+				const th = (e.target as HTMLElement).closest('th')
+				startWidthRef.current = th?.getBoundingClientRect().width ?? DEFAULT_COLUMN_WIDTH
+			}
+		},
+		[columnWidths]
+	)
+
+	useEffect(
+		function resizeColumnWhileDragging() {
+			if (!resizingColumn) return
+
+			const handleMouseMove = function (e: MouseEvent) {
+				const delta = e.clientX - startXRef.current
+				const newWidth = Math.max(MIN_COLUMN_WIDTH, startWidthRef.current + delta)
+
+				setColumnWidths(function (prev) {
+					return {
+						...prev,
+						[resizingColumn]: newWidth
+					}
+				})
+			}
+
+			const handleMouseUp = function () {
+				setResizingColumn(null)
+			}
+
+			document.addEventListener('mousemove', handleMouseMove)
+			document.addEventListener('mouseup', handleMouseUp)
+
+			return function () {
+				document.removeEventListener('mousemove', handleMouseMove)
+				document.removeEventListener('mouseup', handleMouseUp)
+			}
+		},
+		[resizingColumn]
+	)
+
+	const handleResizeDoubleClick = useCallback(function (
+		e: React.MouseEvent,
+		columnName: string,
+		columnType?: string
+	) {
+		e.preventDefault()
+		e.stopPropagation()
+
+		const canvas = document.createElement('canvas')
+		const ctx = canvas.getContext('2d')
+		if (!ctx) {
+			setColumnWidths(function (prev) {
+				const next = { ...prev }
+				delete next[columnName]
+				return next
+			})
+			return
+		}
+
+		ctx.font = '12px Inter, system-ui, sans-serif'
+		const nameWidth = ctx.measureText(columnName).width
+
+		let typeWidth = 0
+		if (columnType && columnType !== 'unknown') {
+			ctx.font = "10px 'JetBrains Mono', monospace"
+			typeWidth = ctx.measureText(columnType).width
+		}
+
+		const sortIconWidth = 16
+		const padding = 32
+		const gap = typeWidth > 0 ? 8 : 0
+		const optimalWidth = Math.ceil(nameWidth + typeWidth + sortIconWidth + padding + gap)
+		const finalWidth = Math.max(MIN_COLUMN_WIDTH, optimalWidth)
+
+		setColumnWidths(function (prev) {
+			return { ...prev, [columnName]: finalWidth }
+		})
+	}, [])
+
+	return {
+		resizingColumn,
+		getColumnWidth,
+		handleResizeStart,
+		handleResizeDoubleClick
+	}
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/use-context-menu-reporting.ts
+++ b/apps/desktop/src/features/database-studio/components/data-grid/use-context-menu-reporting.ts
@@ -1,0 +1,45 @@
+import { useRef } from 'react'
+import type React from 'react'
+import { ContextMenuState } from './types'
+
+export function useContextMenuReporting(onContextMenuChange?: (ctx: ContextMenuState) => void) {
+	const lastContextMenuCoordsRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+
+	function handleCellContextMenuChange(open: boolean, row: number, col: number) {
+		if (!onContextMenuChange) return
+		if (open) {
+			onContextMenuChange({
+				kind: 'cell',
+				cell: { row, col },
+				x: lastContextMenuCoordsRef.current.x,
+				y: lastContextMenuCoordsRef.current.y
+			})
+		} else {
+			onContextMenuChange(null)
+		}
+	}
+
+	function handleRowContextMenuChange(open: boolean, row: number) {
+		if (!onContextMenuChange) return
+		if (open) {
+			onContextMenuChange({
+				kind: 'row',
+				cell: { row, col: 0 },
+				x: lastContextMenuCoordsRef.current.x,
+				y: lastContextMenuCoordsRef.current.y
+			})
+		} else {
+			onContextMenuChange(null)
+		}
+	}
+
+	function handleContextMenuCapture(e: React.MouseEvent) {
+		lastContextMenuCoordsRef.current = { x: e.clientX, y: e.clientY }
+	}
+
+	return {
+		handleCellContextMenuChange,
+		handleRowContextMenuChange,
+		handleContextMenuCapture
+	}
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/use-focused-cell.ts
+++ b/apps/desktop/src/features/database-studio/components/data-grid/use-focused-cell.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import { CellPosition } from './types'
+
+export function useFocusedCell(
+	initialFocusedCell: CellPosition | null | undefined,
+	onFocusedCellChange?: (cell: CellPosition | null) => void
+) {
+	const [focusedCell, setFocusedCellInternal] = useState<CellPosition | null>(
+		initialFocusedCell ?? null
+	)
+
+	useEffect(() => {
+		if (
+			initialFocusedCell &&
+			(!focusedCell ||
+				focusedCell.row !== initialFocusedCell.row ||
+				focusedCell.col !== initialFocusedCell.col)
+		) {
+			setFocusedCellInternal(initialFocusedCell)
+			return
+		}
+
+		if (!initialFocusedCell && focusedCell) {
+			setFocusedCellInternal(null)
+		}
+	}, [initialFocusedCell, focusedCell])
+
+	function setFocusedCell(cell: CellPosition | null) {
+		setFocusedCellInternal(cell)
+		onFocusedCellChange?.(cell)
+	}
+
+	return { focusedCell, setFocusedCell }
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/use-grid-keyboard.ts
+++ b/apps/desktop/src/features/database-studio/components/data-grid/use-grid-keyboard.ts
@@ -1,0 +1,319 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type React from 'react'
+import { ColumnDefinition } from '../../types'
+import { getCellKey, getCellsInRectangle } from './selection'
+import { CellPosition, EditingCell } from './types'
+
+type UseGridKeyboardArgs = {
+	anchorCell: CellPosition | null
+	allSelected: boolean
+	columns: ColumnDefinition[]
+	editingCell: EditingCell | null
+	focusedCell: CellPosition | null
+	lastClickedRowRef: React.MutableRefObject<number | null>
+	onCellEdit?: (rowIndex: number, columnName: string, newValue: unknown) => void
+	onRowsSelect?: (rowIndices: number[], checked: boolean) => void
+	onRowSelect: (rowIndex: number, checked: boolean) => void
+	onSelectAll: (checked: boolean) => void
+	rows: Record<string, unknown>[]
+	selectedCellsSet: Set<string>
+	selectedRows: Set<number>
+	setAnchorCell: (cell: CellPosition | null) => void
+	setEditingCell: (cell: EditingCell | null) => void
+	setEditValue: (value: string) => void
+	setFocusedCell: (cell: CellPosition | null) => void
+	startCellEdit: (rowIndex: number, columnName: string, currentValue: unknown) => void
+	updateCellSelection: (cells: Set<string>) => void
+}
+
+export function useGridKeyboard({
+	anchorCell,
+	allSelected,
+	columns,
+	editingCell,
+	focusedCell,
+	lastClickedRowRef,
+	onCellEdit,
+	onRowsSelect,
+	onRowSelect,
+	onSelectAll,
+	rows,
+	selectedCellsSet,
+	selectedRows,
+	setAnchorCell,
+	setEditingCell,
+	setEditValue,
+	setFocusedCell,
+	startCellEdit,
+	updateCellSelection
+}: UseGridKeyboardArgs) {
+	const pendingNavFrameRef = useRef<number | null>(null)
+
+	useEffect(function cleanupPendingFrame() {
+		return function () {
+			if (pendingNavFrameRef.current !== null) {
+				cancelAnimationFrame(pendingNavFrameRef.current)
+			}
+		}
+	}, [])
+
+	return useCallback(
+		function handleGridKeyDown(e: React.KeyboardEvent) {
+			if (!focusedCell) {
+				if (
+					rows.length > 0 &&
+					columns.length > 0 &&
+					(e.key === 'ArrowDown' ||
+						e.key === 'ArrowUp' ||
+						e.key === 'ArrowLeft' ||
+						e.key === 'ArrowRight' ||
+						e.key === 'Tab' ||
+						e.key === 'Enter')
+				) {
+					e.preventDefault()
+					const firstPos = { row: 0, col: 0 }
+					setFocusedCell(firstPos)
+					setAnchorCell(firstPos)
+					updateCellSelection(new Set([getCellKey(0, 0)]))
+				}
+				return
+			}
+			if (editingCell) return
+
+			const { row, col } = focusedCell
+			const maxRow = rows.length - 1
+			const maxCol = columns.length - 1
+
+			function moveAndMaybeSelect(newRow: number, newCol: number) {
+				const newPos: CellPosition = { row: newRow, col: newCol }
+				if (pendingNavFrameRef.current !== null) {
+					cancelAnimationFrame(pendingNavFrameRef.current)
+				}
+				pendingNavFrameRef.current = requestAnimationFrame(function () {
+					setFocusedCell(newPos)
+					if (e.shiftKey && anchorCell) {
+						updateCellSelection(getCellsInRectangle(anchorCell, newPos))
+					} else if (!e.shiftKey) {
+						setAnchorCell(newPos)
+						updateCellSelection(new Set([getCellKey(newRow, newCol)]))
+					}
+					pendingNavFrameRef.current = null
+				})
+			}
+
+			switch (e.key) {
+				case 'ArrowUp':
+					e.preventDefault()
+					if (e.ctrlKey || e.metaKey) {
+						moveAndMaybeSelect(0, col)
+					} else if (row > 0) {
+						moveAndMaybeSelect(row - 1, col)
+					}
+					break
+				case 'ArrowDown':
+					e.preventDefault()
+					if (e.ctrlKey || e.metaKey) {
+						moveAndMaybeSelect(maxRow, col)
+					} else if (row < maxRow) {
+						moveAndMaybeSelect(row + 1, col)
+					}
+					break
+				case 'ArrowLeft':
+					e.preventDefault()
+					if (e.ctrlKey || e.metaKey) {
+						moveAndMaybeSelect(row, 0)
+					} else if (col > 0) {
+						moveAndMaybeSelect(row, col - 1)
+					}
+					break
+				case 'ArrowRight':
+					e.preventDefault()
+					if (e.ctrlKey || e.metaKey) {
+						moveAndMaybeSelect(row, maxCol)
+					} else if (col < maxCol) {
+						moveAndMaybeSelect(row, col + 1)
+					}
+					break
+				case 'Tab':
+					e.preventDefault()
+					if (e.shiftKey) {
+						if (col > 0) {
+							moveAndMaybeSelect(row, col - 1)
+						} else if (row > 0) {
+							moveAndMaybeSelect(row - 1, maxCol)
+						}
+					} else if (col < maxCol) {
+						moveAndMaybeSelect(row, col + 1)
+					} else if (row < maxRow) {
+						moveAndMaybeSelect(row + 1, 0)
+					}
+					break
+				case 'Enter':
+				case 'F2':
+					e.preventDefault()
+					startCellEdit(row, columns[col].name, rows[row][columns[col].name])
+					break
+				case 'Delete':
+				case 'Backspace':
+					if (!e.ctrlKey && !e.metaKey && onCellEdit) {
+						e.preventDefault()
+						onCellEdit(row, columns[col].name, null)
+					}
+					break
+				case 'Escape':
+					e.preventDefault()
+					if (pendingNavFrameRef.current !== null) {
+						cancelAnimationFrame(pendingNavFrameRef.current)
+						pendingNavFrameRef.current = null
+					}
+					if (selectedCellsSet.size > 1) {
+						updateCellSelection(new Set([getCellKey(row, col)]))
+					} else {
+						setFocusedCell(null)
+						updateCellSelection(new Set())
+					}
+					break
+				case ' ':
+					e.preventDefault()
+					if (e.shiftKey && lastClickedRowRef.current !== null && onRowsSelect) {
+						const start = Math.min(lastClickedRowRef.current, row)
+						const end = Math.max(lastClickedRowRef.current, row)
+						const range = []
+						for (let i = start; i <= end; i++) {
+							range.push(i)
+						}
+						onRowsSelect(range, true)
+					} else {
+						onRowSelect(row, !selectedRows.has(row))
+						lastClickedRowRef.current = row
+					}
+					break
+				case 'a':
+					if (e.ctrlKey || e.metaKey) {
+						e.preventDefault()
+						onSelectAll(!allSelected)
+					}
+					break
+				case 'c':
+					if (e.ctrlKey || e.metaKey) {
+						e.preventDefault()
+						copySelectionToClipboard(selectedCellsSet, focusedCell, rows, columns)
+					}
+					break
+				case 'v':
+					if ((e.ctrlKey || e.metaKey) && focusedCell && onCellEdit) {
+						e.preventDefault()
+						pasteClipboardIntoGrid(focusedCell, rows.length, columns, onCellEdit)
+					}
+					break
+				default:
+					if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+						e.preventDefault()
+						setEditingCell({ rowIndex: row, columnName: columns[col].name })
+						setEditValue(e.key)
+					}
+					break
+			}
+		},
+		[
+			anchorCell,
+			allSelected,
+			columns,
+			editingCell,
+			focusedCell,
+			lastClickedRowRef,
+			onCellEdit,
+			onRowsSelect,
+			onRowSelect,
+			onSelectAll,
+			rows,
+			selectedCellsSet,
+			selectedRows,
+			setAnchorCell,
+			setEditingCell,
+			setEditValue,
+			setFocusedCell,
+			startCellEdit,
+			updateCellSelection
+		]
+	)
+}
+
+function copySelectionToClipboard(
+	selectedCellsSet: Set<string>,
+	focusedCell: CellPosition | null,
+	rows: Record<string, unknown>[],
+	columns: ColumnDefinition[]
+) {
+	if (selectedCellsSet.size > 0) {
+		const cellsArray = Array.from(selectedCellsSet).map(function (key) {
+			const [row, col] = key.split(':').map(Number)
+			return { row, col }
+		})
+		cellsArray.sort(function (a, b) {
+			return a.row === b.row ? a.col - b.col : a.row - b.row
+		})
+		const minRow = Math.min(
+			...cellsArray.map(function (cell) {
+				return cell.row
+			})
+		)
+		const maxRow = Math.max(
+			...cellsArray.map(function (cell) {
+				return cell.row
+			})
+		)
+		const rowData: string[][] = []
+		for (let row = minRow; row <= maxRow; row++) {
+			const rowCells = cellsArray.filter(function (cell) {
+				return cell.row === row
+			})
+			const values = rowCells.map(function (cell) {
+				const value = rows[cell.row][columns[cell.col].name]
+				return value === null || value === undefined ? '' : String(value)
+			})
+			rowData.push(values)
+		}
+		navigator.clipboard.writeText(
+			rowData
+				.map(function (row) {
+					return row.join('\t')
+				})
+				.join('\n')
+		)
+		return
+	}
+
+	if (focusedCell) {
+		const value = rows[focusedCell.row][columns[focusedCell.col].name]
+		navigator.clipboard.writeText(value === null || value === undefined ? '' : String(value))
+	}
+}
+
+function pasteClipboardIntoGrid(
+	focusedCell: CellPosition,
+	rowCount: number,
+	columns: ColumnDefinition[],
+	onCellEdit: (rowIndex: number, columnName: string, newValue: unknown) => void
+) {
+	navigator.clipboard
+		.readText()
+		.then(function (clipboardText) {
+			if (!clipboardText) return
+			const pasteRows = clipboardText.split('\n').map(function (line) {
+				return line.split('\t')
+			})
+			pasteRows.forEach(function (pasteRow, pasteRowIndex) {
+				const targetRow = focusedCell.row + pasteRowIndex
+				if (targetRow >= rowCount) return
+				pasteRow.forEach(function (pasteValue, pasteColIndex) {
+					const targetCol = focusedCell.col + pasteColIndex
+					if (targetCol >= columns.length) return
+					onCellEdit(targetRow, columns[targetCol].name, pasteValue)
+				})
+			})
+		})
+		.catch(function () {
+			// Clipboard read unavailable; keep grid interaction silent.
+		})
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/use-right-drag-scroll.ts
+++ b/apps/desktop/src/features/database-studio/components/data-grid/use-right-drag-scroll.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react'
+import type React from 'react'
+
+export function useRightDragScroll(scrollContainerRef: React.RefObject<HTMLDivElement>) {
+	const [isRightDragging, setIsRightDragging] = useState(false)
+	const rightDragStartRef = useRef<{ x: number; scrollLeft: number } | null>(null)
+	const hasRightDraggedRef = useRef(false)
+
+	function handleRightDragValues(e: React.MouseEvent | MouseEvent) {
+		if (!rightDragStartRef.current || !scrollContainerRef.current) return
+
+		const delta = rightDragStartRef.current.x - e.clientX
+		if (Math.abs(delta) > 5) {
+			hasRightDraggedRef.current = true
+		}
+
+		if (hasRightDraggedRef.current) {
+			scrollContainerRef.current.scrollLeft = rightDragStartRef.current.scrollLeft + delta
+		}
+	}
+
+	useEffect(() => {
+		if (!isRightDragging) return
+
+		function handleGlobalMouseMove(e: MouseEvent) {
+			handleRightDragValues(e)
+		}
+
+		function handleGlobalMouseUp() {
+			if (isRightDragging) {
+				setIsRightDragging(false)
+				rightDragStartRef.current = null
+				setTimeout(() => {
+					hasRightDraggedRef.current = false
+				}, 50)
+			}
+		}
+
+		document.addEventListener('mousemove', handleGlobalMouseMove)
+		document.addEventListener('mouseup', handleGlobalMouseUp)
+
+		return () => {
+			document.removeEventListener('mousemove', handleGlobalMouseMove)
+			document.removeEventListener('mouseup', handleGlobalMouseUp)
+		}
+	}, [isRightDragging])
+
+	function handleRightDragStart(e: React.MouseEvent) {
+		if (e.button !== 2 || !scrollContainerRef.current) return
+		setIsRightDragging(true)
+		rightDragStartRef.current = {
+			x: e.clientX,
+			scrollLeft: scrollContainerRef.current.scrollLeft
+		}
+		hasRightDraggedRef.current = false
+	}
+
+	return {
+		hasRightDraggedRef,
+		isRightDragging,
+		handleRightDragStart
+	}
+}

--- a/apps/desktop/src/features/database-studio/components/data-grid/use-row-selection.ts
+++ b/apps/desktop/src/features/database-studio/components/data-grid/use-row-selection.ts
@@ -1,0 +1,53 @@
+import { useCallback } from 'react'
+import type React from 'react'
+
+type UseRowSelectionArgs = {
+	lastClickedRowRef: React.MutableRefObject<number | null>
+	onRowSelect: (rowIndex: number, checked: boolean) => void
+	onRowsSelect?: (rowIndices: number[], checked: boolean) => void
+	onSelectAll: (checked: boolean) => void
+	selectedRows: Set<number>
+}
+
+export function useRowSelection({
+	lastClickedRowRef,
+	onRowSelect,
+	onRowsSelect,
+	onSelectAll,
+	selectedRows
+}: UseRowSelectionArgs) {
+	const handleRowClick = useCallback(
+		function (e: React.MouseEvent, rowIndex: number) {
+			if (e.button !== 0) return
+
+			if (e.shiftKey) {
+				e.preventDefault()
+			}
+
+			if (e.shiftKey && lastClickedRowRef.current !== null && onRowsSelect) {
+				const start = Math.min(lastClickedRowRef.current, rowIndex)
+				const end = Math.max(lastClickedRowRef.current, rowIndex)
+				const range = []
+				for (let i = start; i <= end; i++) {
+					range.push(i)
+				}
+				onRowsSelect(range, true)
+			} else if (e.ctrlKey || e.metaKey) {
+				onRowSelect(rowIndex, !selectedRows.has(rowIndex))
+				lastClickedRowRef.current = rowIndex
+			} else {
+				lastClickedRowRef.current = rowIndex
+			}
+		},
+		[lastClickedRowRef, onRowSelect, onRowsSelect, selectedRows]
+	)
+
+	function ensureRowSelectionForContextMenu(rowIndex: number) {
+		if (selectedRows.has(rowIndex)) return
+		onSelectAll(false)
+		onRowSelect(rowIndex, true)
+		lastClickedRowRef.current = rowIndex
+	}
+
+	return { handleRowClick, ensureRowSelectionForContextMenu }
+}

--- a/apps/desktop/src/features/schema-visualizer/components/table-node.tsx
+++ b/apps/desktop/src/features/schema-visualizer/components/table-node.tsx
@@ -7,129 +7,129 @@ import type { TableNodeData } from '../hooks/use-schema-graph'
 type Props = NodeProps & { data: TableNodeData }
 
 function TableNodeInner({ data, selected }: Props) {
-	const {
-		tableId,
-		tableName,
-		schema,
-		columns,
-		primaryKeyColumns,
-		searchState,
-		matchedColumns,
-	} = data
-	const isMatch = searchState === 'match'
-	const isContext = searchState === 'context'
-	const isDim = searchState === 'dim'
-	const schemaLabel = schema && schema !== 'public' ? schema : null
+    const {
+        tableId,
+        tableName,
+        schema,
+        columns,
+        primaryKeyColumns,
+        searchState,
+        matchedColumns,
+    } = data
+    const isMatch = searchState === 'match'
+    const isContext = searchState === 'context'
+    const isDim = searchState === 'dim'
+    const schemaLabel = schema && schema !== 'public' ? schema : null
 
-	return (
-		<div
-			className={cn(
-				'sv-table-node',
-				selected && 'sv-table-node--selected',
-				isMatch && 'sv-table-node--match',
-				isContext && 'sv-table-node--context',
-				isDim && 'sv-table-node--dim',
-			)}
-		>
-			<div
-				className={cn(
-					'sv-table-node__header',
-					isMatch && 'sv-table-node__header--match',
-					isContext && 'sv-table-node__header--context',
-				)}
-			>
-				<div className='flex-1 min-w-0'>
-					<div className='truncate text-xs font-semibold text-sidebar-foreground'>
-						{tableName}
-					</div>
-					{schemaLabel && (
-						<div className='truncate text-[10px] text-muted-foreground'>
-							{schemaLabel}
-						</div>
-					)}
-				</div>
-				{isMatch && matchedColumns.length > 0 && (
-					<span className='rounded-sm border border-sidebar-border bg-sidebar-accent px-1.5 py-0.5 text-[9px] font-semibold text-muted-foreground'>
-						{matchedColumns.length} col
-					</span>
-				)}
-			</div>
+    return (
+        <div
+            className={cn(
+                'sv-table-node',
+                selected && 'sv-table-node--selected',
+                isMatch && 'sv-table-node--match',
+                isContext && 'sv-table-node--context',
+                isDim && 'sv-table-node--dim',
+            )}
+        >
+            <div
+                className={cn(
+                    'sv-table-node__header',
+                    isMatch && 'sv-table-node__header--match',
+                    isContext && 'sv-table-node__header--context',
+                )}
+            >
+                <div className='flex-1 min-w-0'>
+                    <div className='truncate text-xs font-semibold text-sidebar-foreground'>
+                        {tableName}
+                    </div>
+                    {schemaLabel && (
+                        <div className='truncate text-[10px] text-muted-foreground'>
+                            {schemaLabel}
+                        </div>
+                    )}
+                </div>
+                {isMatch && matchedColumns.length > 0 && (
+                    <span className='rounded-sm border border-sidebar-border bg-sidebar-accent px-1.5 py-0.5 text-[9px] font-semibold text-muted-foreground'>
+                        {matchedColumns.length} col
+                    </span>
+                )}
+            </div>
 
-			<div className='flex flex-col'>
-				{columns.map(function (col) {
-					const isPk =
-						col.is_primary_key || primaryKeyColumns.includes(col.name)
-					const isFk = col.foreign_key !== null
-					const sourceHandleId = `${tableId}__${col.name}__source`
-					const targetHandleId = `${tableId}__${col.name}__target`
-					const isColMatch = matchedColumns.includes(col.name)
+            <div className='flex flex-col'>
+                {columns.map(function (col) {
+                    const isPk =
+                        col.is_primary_key || primaryKeyColumns.includes(col.name)
+                    const isFk = col.foreign_key !== null
+                    const sourceHandleId = `${tableId}__${col.name}__source`
+                    const targetHandleId = `${tableId}__${col.name}__target`
+                    const isColMatch = matchedColumns.includes(col.name)
 
-					return (
-						<div
-							key={col.name}
-							className={cn(
-								'sv-table-node__row',
-								isColMatch && 'sv-table-node__row--match',
-							)}
-						>
-							<Handle
-								type='target'
-								position={Position.Left}
-								id={targetHandleId}
-								className={cn(
-									'sv-handle sv-handle--target',
-									isFk && 'sv-handle--fk',
-									isColMatch && 'sv-handle--active',
-								)}
-							/>
+                    return (
+                        <div
+                            key={col.name}
+                            className={cn(
+                                'sv-table-node__row',
+                                isColMatch && 'sv-table-node__row--match',
+                            )}
+                        >
+                            <Handle
+                                type='target'
+                                position={Position.Left}
+                                id={targetHandleId}
+                                className={cn(
+                                    'sv-handle sv-handle--target',
+                                    isFk && 'sv-handle--fk',
+                                    isColMatch && 'sv-handle--active',
+                                )}
+                            />
 
-							<div className='flex items-center gap-1 shrink-0 w-4'>
-								{isPk && (
-									<Key className='h-2.5 w-2.5 text-[hsl(40_26%_58%)]' />
-								)}
-								{isFk && !isPk && (
-									<LinkIcon className='h-2.5 w-2.5 text-[hsl(214_18%_60%)]' />
-								)}
-							</div>
+                            <div className='flex items-center gap-1 shrink-0 w-4'>
+                                {isPk && (
+                                    <Key className='h-2.5 w-2.5 text-[hsl(40_26%_58%)]' />
+                                )}
+                                {isFk && !isPk && (
+                                    <LinkIcon className='h-2.5 w-2.5 text-[hsl(214_18%_60%)]' />
+                                )}
+                            </div>
 
-							<span
-								className={cn(
-									'flex-1 truncate font-mono',
-									isPk && 'font-semibold text-sidebar-foreground',
-									!isPk && 'text-sidebar-foreground',
-									isColMatch && 'text-sidebar-foreground',
-								)}
-							>
-								{col.name}
-							</span>
+                            <span
+                                className={cn(
+                                    'flex-1 truncate font-mono',
+                                    isPk && 'font-semibold text-sidebar-foreground',
+                                    !isPk && 'text-sidebar-foreground',
+                                    isColMatch && 'text-sidebar-foreground',
+                                )}
+                            >
+                                {col.name}
+                            </span>
 
-							<span
-								className={cn(
-									'font-mono text-[10px] shrink-0',
-									col.is_nullable
-										? 'text-muted-foreground'
-										: 'text-sidebar-foreground/70',
-								)}
-							>
-								{col.data_type}
-							</span>
+                            <span
+                                className={cn(
+                                    'font-mono text-[10px] shrink-0',
+                                    col.is_nullable
+                                        ? 'text-muted-foreground'
+                                        : 'text-sidebar-foreground/70',
+                                )}
+                            >
+                                {col.data_type}
+                            </span>
 
-							<Handle
-								type='source'
-								position={Position.Right}
-								id={sourceHandleId}
-								className={cn(
-									'sv-handle sv-handle--source',
-									isFk && 'sv-handle--fk',
-									isColMatch && 'sv-handle--active',
-								)}
-							/>
-						</div>
-					)
-				})}
-			</div>
-		</div>
-	)
+                            <Handle
+                                type='source'
+                                position={Position.Right}
+                                id={sourceHandleId}
+                                className={cn(
+                                    'sv-handle sv-handle--source',
+                                    isFk && 'sv-handle--fk',
+                                    isColMatch && 'sv-handle--active',
+                                )}
+                            />
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
 }
 
 export const TableNode = memo(TableNodeInner)

--- a/apps/desktop/src/features/sidebar/changelog-data.ts
+++ b/apps/desktop/src/features/sidebar/changelog-data.ts
@@ -8,9 +8,30 @@ export type ChangelogEntry = {
 	details?: string[]
 }
 
-export const CURRENT_VERSION = '0.0.107'
+export const CURRENT_VERSION = '0.0.108'
 
 export const CHANGELOG: ChangelogEntry[] = [
+	{
+		version: '0.0.108',
+		date: '2026-04-24',
+		commit: 'feat/ai-key-store',
+		title: 'AI SQL: Encrypted Key Store, Test, Abort & Insert+Run',
+		description:
+			'In-app encrypted Groq API key management, request abort, JSON-mode streaming, and one-shot Insert + Run for the ⌘I overlay.',
+		type: 'feature',
+		details: [
+			'New Settings → AI Keys (Groq) panel: add, label, enable/disable, test, and delete keys',
+			'AES-256-GCM encryption with the master key stored in the OS keychain (Keychain / libsecret / Credential Manager)',
+			'Env keys (GROQ_API_KEY, GROQ_API_KEY_1..10, GROQ_MODEL) are merged with UI-stored keys and deduplicated',
+			'Per-key test button validates against the Groq API and records the last test status in the row',
+			'⌘I overlay shows a live status badge (N keys / no keys) so misconfiguration is visible before generating',
+			'New Insert + Run action (⌘⏎) pastes generated SQL into the editor and immediately executes it',
+			'Real abort path: closing the overlay or pressing Esc mid-stream cancels the in-flight Groq stream backend-side via ai_abort_stream',
+			'Streaming completions now use response_format: json_object to keep tokens inside a JSON envelope',
+			'Key rotation now also fires on 5xx and 403 errors, not just 429/401',
+			'AI streaming reqwest client bumped to a 60s timeout, 15s for key tests'
+		]
+	},
 	{
 		version: '0.0.107',
 		date: '2026-04-19',

--- a/apps/desktop/src/features/sidebar/changelog-data.ts
+++ b/apps/desktop/src/features/sidebar/changelog-data.ts
@@ -8,9 +8,25 @@ export type ChangelogEntry = {
 	details?: string[]
 }
 
-export const CURRENT_VERSION = '0.0.108'
+export const CURRENT_VERSION = '0.0.109'
 
 export const CHANGELOG: ChangelogEntry[] = [
+	{
+		version: '0.0.109',
+		date: '2026-04-25',
+		commit: 'feat/ai-key-store',
+		title: 'Data Grid Refactor & Schema Visualizer Fix',
+		description:
+			'Split the 1455-line data-grid into 15 focused hook/component modules, fixed broken schema-visualizer imports, and bundled the AI key-store work into a single release.',
+		type: 'refactor',
+		details: [
+			'data-grid.tsx 1455 → 245 lines, with state/keyboard/selection/column-resize hooks each in their own file under data-grid/',
+			'Extracted child components: cell-value, draft-row, empty-states, grid-body, grid-header',
+			'Pure modules: selection.ts (rectangle helpers) and types.ts (CellPosition, ContextMenuState, etc.)',
+			'Restored broken imports in schema-visualizer/components/table-node.tsx — tsc -b is now clean',
+			'Bundles AI encrypted key store, abort, JSON-mode streaming, and Insert + Run from the same branch into 0.0.109'
+		]
+	},
 	{
 		version: '0.0.108',
 		date: '2026-04-24',

--- a/apps/desktop/src/features/sidebar/components/ai-keys-section.tsx
+++ b/apps/desktop/src/features/sidebar/components/ai-keys-section.tsx
@@ -1,0 +1,227 @@
+import { Check, Loader2, Plus, Trash2, X, Zap } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { commands, type AiApiKeyRecord } from '@/lib/bindings'
+import { Button } from '@/shared/ui/button'
+import { Input } from '@/shared/ui/input'
+import { cn } from '@/shared/utils/cn'
+import { SidebarSection } from './sidebar-panel'
+
+const PROVIDER = 'groq'
+
+type TestState = { id: number; ok?: boolean; message?: string; testing: boolean }
+
+function formatStatus(rec: AiApiKeyRecord): string {
+	if (!rec.last_status) return 'untested'
+	const ts = rec.last_tested ? new Date(rec.last_tested * 1000).toLocaleString() : ''
+	return `${rec.last_status}${ts ? ' · ' + ts : ''}`
+}
+
+export function AiKeysSection() {
+	const [keys, setKeys] = useState<AiApiKeyRecord[]>([])
+	const [loading, setLoading] = useState(false)
+	const [showAdd, setShowAdd] = useState(false)
+	const [label, setLabel] = useState('')
+	const [apiKey, setApiKey] = useState('')
+	const [testNew, setTestNew] = useState<{ ok?: boolean; message?: string; testing: boolean }>({
+		testing: false,
+	})
+	const [tests, setTests] = useState<Record<number, TestState>>({})
+
+	const load = useCallback(async function load() {
+		setLoading(true)
+		try {
+			const res = await commands.aiKeysList(PROVIDER)
+			if (res.status === 'ok') setKeys(res.data)
+		} finally {
+			setLoading(false)
+		}
+	}, [])
+
+	useEffect(
+		function loadOnMount() {
+			load()
+		},
+		[load]
+	)
+
+	async function handleTestRaw() {
+		if (!apiKey.trim()) return
+		setTestNew({ testing: true })
+		const res = await commands.aiKeysTestRaw(apiKey.trim())
+		if (res.status === 'ok') setTestNew({ testing: false, ok: res.data.ok, message: res.data.message })
+		else setTestNew({ testing: false, ok: false, message: 'Failed to test' })
+	}
+
+	async function handleAdd() {
+		if (!apiKey.trim()) return
+		const res = await commands.aiKeysAdd(PROVIDER, label.trim() || 'unnamed', apiKey.trim())
+		if (res.status === 'ok') {
+			setApiKey('')
+			setLabel('')
+			setTestNew({ testing: false })
+			setShowAdd(false)
+			await load()
+		}
+	}
+
+	async function handleDelete(id: number) {
+		const res = await commands.aiKeysDelete(id)
+		if (res.status === 'ok') await load()
+	}
+
+	async function handleTest(id: number) {
+		setTests((p) => ({ ...p, [id]: { id, testing: true } }))
+		const res = await commands.aiKeysTest(id)
+		if (res.status === 'ok') {
+			setTests((p) => ({ ...p, [id]: { id, testing: false, ok: res.data.ok, message: res.data.message } }))
+			await load()
+		} else {
+			setTests((p) => ({ ...p, [id]: { id, testing: false, ok: false, message: 'Test failed' } }))
+		}
+	}
+
+	async function handleToggleActive(id: number, next: boolean) {
+		const res = await commands.aiKeysSetActive(id, next)
+		if (res.status === 'ok') await load()
+	}
+
+	return (
+		<SidebarSection title='AI Keys (Groq)'>
+			<div className='space-y-2'>
+				<div className='text-xs text-muted-foreground leading-tight'>
+					Encrypted with AES-256-GCM. The master key lives in your OS keychain. Keys from{' '}
+					<code className='font-mono'>GROQ_API_KEY</code> env vars are merged in automatically.
+				</div>
+
+				{loading && (
+					<div className='flex items-center gap-2 text-xs text-muted-foreground'>
+						<Loader2 className='h-3 w-3 animate-spin' /> Loading…
+					</div>
+				)}
+
+				{keys.length === 0 && !loading && (
+					<div className='text-xs text-muted-foreground italic'>
+						No saved keys. Add one below or set <code className='font-mono'>GROQ_API_KEY_1</code>.
+					</div>
+				)}
+
+				{keys.map(function (k) {
+					const t = tests[k.id]
+					return (
+						<div
+							key={k.id}
+							className='flex items-center gap-2 rounded-md border border-sidebar-border bg-background px-2 py-1.5'
+						>
+							<button
+								type='button'
+								onClick={() => handleToggleActive(k.id, !k.is_active)}
+								className={cn(
+									'h-2 w-2 rounded-full flex-shrink-0',
+									k.is_active ? 'bg-emerald-500' : 'bg-muted-foreground/30'
+								)}
+								title={k.is_active ? 'Active — click to disable' : 'Disabled — click to enable'}
+							/>
+							<div className='min-w-0 flex-1'>
+								<div className='text-xs font-medium text-sidebar-foreground truncate'>
+									{k.label}
+								</div>
+								<div className='text-[10px] text-muted-foreground truncate'>
+									{t && !t.testing
+										? `${t.ok ? '✓' : '✗'} ${t.message}`
+										: formatStatus(k)}
+								</div>
+							</div>
+							<Button
+								variant='ghost'
+								size='sm'
+								className='h-6 px-2 text-[10px]'
+								onClick={() => handleTest(k.id)}
+								disabled={t?.testing}
+							>
+								{t?.testing ? <Loader2 className='h-3 w-3 animate-spin' /> : <Zap className='h-3 w-3' />}
+							</Button>
+							<Button
+								variant='ghost'
+								size='sm'
+								className='h-6 px-2 text-[10px] text-destructive hover:text-destructive'
+								onClick={() => handleDelete(k.id)}
+							>
+								<Trash2 className='h-3 w-3' />
+							</Button>
+						</div>
+					)
+				})}
+
+				{!showAdd ? (
+					<Button
+						variant='outline'
+						size='sm'
+						className='h-7 w-full text-xs'
+						onClick={() => setShowAdd(true)}
+					>
+						<Plus className='h-3 w-3 mr-1' /> Add Groq key
+					</Button>
+				) : (
+					<div className='space-y-2 rounded-md border border-sidebar-border bg-background p-2'>
+						<Input
+							value={label}
+							onChange={(e) => setLabel(e.target.value)}
+							placeholder='Label (e.g. personal-free)'
+							className='h-7 text-xs'
+						/>
+						<Input
+							value={apiKey}
+							onChange={(e) => setApiKey(e.target.value)}
+							placeholder='gsk_...'
+							type='password'
+							className='h-7 font-mono text-xs'
+						/>
+						{testNew.message && (
+							<div
+								className={cn(
+									'text-[10px] font-mono',
+									testNew.ok ? 'text-emerald-500' : 'text-destructive'
+								)}
+							>
+								{testNew.ok ? '✓' : '✗'} {testNew.message}
+							</div>
+						)}
+						<div className='flex items-center gap-1'>
+							<Button
+								variant='ghost'
+								size='sm'
+								className='h-6 px-2 text-[10px]'
+								onClick={handleTestRaw}
+								disabled={testNew.testing || !apiKey.trim()}
+							>
+								{testNew.testing ? <Loader2 className='h-3 w-3 animate-spin' /> : 'Test'}
+							</Button>
+							<Button
+								variant='default'
+								size='sm'
+								className='h-6 px-2 text-[10px] ml-auto'
+								onClick={handleAdd}
+								disabled={!apiKey.trim()}
+							>
+								<Check className='h-3 w-3 mr-1' /> Save
+							</Button>
+							<Button
+								variant='ghost'
+								size='sm'
+								className='h-6 px-2 text-[10px]'
+								onClick={() => {
+									setShowAdd(false)
+									setApiKey('')
+									setLabel('')
+									setTestNew({ testing: false })
+								}}
+							>
+								<X className='h-3 w-3' />
+							</Button>
+						</div>
+					</div>
+				)}
+			</div>
+		</SidebarSection>
+	)
+}

--- a/apps/desktop/src/features/sidebar/components/settings-panel.tsx
+++ b/apps/desktop/src/features/sidebar/components/settings-panel.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/shared/ui/select'
 import { Slider } from '@/shared/ui/slider'
 import { Switch } from '@/shared/ui/switch'
+import { AiKeysSection } from './ai-keys-section'
 import { ShortcutRecorder } from './shortcut-recorder'
 import { PopoverClose } from '@/shared/ui/popover'
 import { X } from 'lucide-react'
@@ -151,6 +152,8 @@ export function SettingsPanel() {
 							})}
 						</div>
 					</SidebarSection>
+
+					<AiKeysSection />
 
 					<SidebarSection title='Safety'>
 						<div className='flex items-start justify-between gap-4'>

--- a/apps/desktop/src/features/sql-console/components/ai-cmd-k.tsx
+++ b/apps/desktop/src/features/sql-console/components/ai-cmd-k.tsx
@@ -2,14 +2,14 @@ import { Channel } from '@tauri-apps/api/core'
 import { Loader2, Sparkles, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { commands } from '@/lib/bindings'
-import type { AiStreamEvent } from '@/lib/bindings'
+import type { AiStreamEvent, GroqStatus } from '@/lib/bindings'
 import { Button } from '@/shared/ui/button'
 import { cn } from '@/shared/utils/cn'
 
 type Props = {
 	open: boolean
 	onClose: () => void
-	onApplySql: (sql: string, explanation: string, warnings: string[]) => void
+	onApplySql: (sql: string, explanation: string, warnings: string[], execute: boolean) => void
 	activeConnectionId: string | undefined
 	isTauri: boolean
 }
@@ -21,22 +21,10 @@ type ParsedResult = {
 }
 
 function parseLlmJson(raw: string): ParsedResult {
-	// Attempt strict JSON parse first
 	const trimmed = raw.trim()
-	try {
-		const parsed = JSON.parse(trimmed)
-		return {
-			sql: String(parsed.sql ?? '').trim(),
-			explanation: String(parsed.explanation ?? '').trim(),
-			warnings: Array.isArray(parsed.warnings)
-				? parsed.warnings.map((w: unknown) => String(w))
-				: [],
-		}
-	} catch {
-		// Fallback: strip leading ``` fences if model disobeyed and returned a fence
-		const fenced = trimmed.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/i, '')
+	const tryParse = (s: string): ParsedResult | null => {
 		try {
-			const parsed = JSON.parse(fenced)
+			const parsed = JSON.parse(s)
 			return {
 				sql: String(parsed.sql ?? '').trim(),
 				explanation: String(parsed.explanation ?? '').trim(),
@@ -45,10 +33,19 @@ function parseLlmJson(raw: string): ParsedResult {
 					: [],
 			}
 		} catch {
-			// Last-resort: return raw as SQL, no explanation
-			return { sql: trimmed, explanation: '', warnings: ['Response was not valid JSON.'] }
+			return null
 		}
 	}
+	const direct = tryParse(trimmed)
+	if (direct) return direct
+	const fenced = trimmed.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/i, '')
+	const fencedParsed = tryParse(fenced)
+	if (fencedParsed) return fencedParsed
+	return { sql: trimmed, explanation: '', warnings: ['Response was not valid JSON.'] }
+}
+
+function makeRequestId() {
+	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
 }
 
 export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri }: Props) {
@@ -57,8 +54,12 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 	const [streamedContent, setStreamedContent] = useState('')
 	const [error, setError] = useState<string | null>(null)
 	const [lastResult, setLastResult] = useState<ParsedResult | null>(null)
+	const [groqStatus, setGroqStatus] = useState<GroqStatus | null>(null)
 	const promptRef = useRef<HTMLTextAreaElement | null>(null)
-	const abortRef = useRef<{ cancelled: boolean }>({ cancelled: false })
+	const abortRef = useRef<{ cancelled: boolean; requestId: string | null }>({
+		cancelled: false,
+		requestId: null,
+	})
 
 	useEffect(
 		function resetOnOpen() {
@@ -68,19 +69,36 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 				setLastResult(null)
 				setIsGenerating(false)
 				abortRef.current.cancelled = false
+				abortRef.current.requestId = null
 				setTimeout(() => promptRef.current?.focus(), 30)
+				if (isTauri) {
+					commands
+						.aiGroqStatus()
+						.then((res) => {
+							if (res.status === 'ok') setGroqStatus(res.data)
+						})
+						.catch(() => {})
+				}
 			}
 		},
-		[open]
+		[open, isTauri]
 	)
+
+	const abortInFlight = useCallback(function abortInFlight() {
+		const id = abortRef.current.requestId
+		abortRef.current.cancelled = true
+		if (id) {
+			commands.aiAbortStream(id).catch(() => {})
+		}
+	}, [])
 
 	const handleClose = useCallback(
 		function handleClose() {
-			abortRef.current.cancelled = true
+			abortInFlight()
 			setIsGenerating(false)
 			onClose()
 		},
-		[onClose]
+		[onClose, abortInFlight]
 	)
 
 	const generate = useCallback(
@@ -90,12 +108,20 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 				setError('AI generation is only available in the desktop app.')
 				return
 			}
+			if (groqStatus && !groqStatus.available) {
+				setError(
+					'No Groq API keys configured. Open Settings → AI Keys to add one, or set GROQ_API_KEY in your environment.'
+				)
+				return
+			}
 
 			setError(null)
 			setStreamedContent('')
 			setLastResult(null)
 			setIsGenerating(true)
 			abortRef.current.cancelled = false
+			const requestId = makeRequestId()
+			abortRef.current.requestId = requestId
 
 			const channel = new Channel<AiStreamEvent>()
 			let accumulated = ''
@@ -121,6 +147,7 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 
 			try {
 				const result = await commands.aiCompleteStream(
+					requestId,
 					prompt,
 					activeConnectionId ?? null,
 					null,
@@ -141,15 +168,16 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 				if (!abortRef.current.cancelled) {
 					setIsGenerating(false)
 				}
+				abortRef.current.requestId = null
 			}
 		},
-		[prompt, isGenerating, activeConnectionId, isTauri]
+		[prompt, isGenerating, activeConnectionId, isTauri, groqStatus]
 	)
 
 	const accept = useCallback(
-		function accept() {
+		function accept(execute: boolean) {
 			if (!lastResult || !lastResult.sql) return
-			onApplySql(lastResult.sql, lastResult.explanation, lastResult.warnings)
+			onApplySql(lastResult.sql, lastResult.explanation, lastResult.warnings, execute)
 			onClose()
 		},
 		[lastResult, onApplySql, onClose]
@@ -163,9 +191,8 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 				return
 			}
 			if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-				// Not wired to execute yet; treat same as Enter for now
 				e.preventDefault()
-				if (lastResult) accept()
+				if (lastResult) accept(true)
 				else generate()
 				return
 			}
@@ -176,7 +203,7 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 			}
 			if (e.key === 'Enter' && !e.shiftKey) {
 				e.preventDefault()
-				if (lastResult) accept()
+				if (lastResult) accept(false)
 				else generate()
 			}
 		},
@@ -184,6 +211,12 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 	)
 
 	if (!open) return null
+
+	const statusLabel = groqStatus
+		? groqStatus.available
+			? `${groqStatus.key_count} key${groqStatus.key_count === 1 ? '' : 's'}`
+			: 'no keys'
+		: '…'
 
 	return (
 		<div
@@ -196,22 +229,24 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 			>
 				<div className='flex items-center gap-2 border-b border-sidebar-border px-3 py-2'>
 					<Sparkles className='h-4 w-4 text-primary' />
-					<span className='text-xs font-semibold text-sidebar-foreground'>
-						AI SQL
-					</span>
-					<span className='text-[10px] text-muted-foreground'>
-						schema-grounded · via Groq
+					<span className='text-xs font-semibold text-sidebar-foreground'>AI SQL</span>
+					<span className='text-[10px] text-muted-foreground'>schema-grounded · via Groq</span>
+					<span
+						className={cn(
+							'text-[10px] rounded px-1.5 py-0.5',
+							groqStatus?.available
+								? 'bg-emerald-500/10 text-emerald-500'
+								: 'bg-amber-500/10 text-amber-500'
+						)}
+						title='Configured Groq API keys (env + Settings)'
+					>
+						{statusLabel}
 					</span>
 					<div className='ml-auto flex items-center gap-1'>
 						{isGenerating && (
 							<Loader2 className='h-3.5 w-3.5 animate-spin text-muted-foreground' />
 						)}
-						<Button
-							variant='ghost'
-							size='icon'
-							className='h-6 w-6'
-							onClick={handleClose}
-						>
+						<Button variant='ghost' size='icon' className='h-6 w-6' onClick={handleClose}>
 							<X className='h-3.5 w-3.5' />
 						</Button>
 					</div>
@@ -230,8 +265,9 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 					/>
 					<div className='mt-1 flex items-center justify-between text-[10px] text-muted-foreground'>
 						<span>
-							Enter to {lastResult ? 'accept' : 'generate'}
-							{' · '}⌘R to regenerate{' · '}Esc to close
+							{lastResult
+								? 'Enter to insert · ⌘⏎ to insert + run · ⌘R to regenerate · Esc to close'
+								: 'Enter to generate · ⌘R to regenerate · Esc to close'}
 						</span>
 						{!activeConnectionId && (
 							<span className='text-amber-500'>
@@ -264,12 +300,20 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 										Regenerate
 									</Button>
 									<Button
+										variant='ghost'
+										size='sm'
+										className='h-6 px-2 text-[10px]'
+										onClick={() => accept(false)}
+									>
+										Insert
+									</Button>
+									<Button
 										variant='default'
 										size='sm'
 										className='h-6 px-2 text-[10px]'
-										onClick={accept}
+										onClick={() => accept(true)}
 									>
-										Accept
+										Insert + Run
 									</Button>
 								</div>
 							)}

--- a/apps/desktop/src/features/sql-console/sql-console.tsx
+++ b/apps/desktop/src/features/sql-console/sql-console.tsx
@@ -912,11 +912,18 @@ export function SqlConsole({ onToggleSidebar: _onToggleSidebar, activeConnection
 				onClose={() => setShowAiCmdK(false)}
 				activeConnectionId={activeConnectionId}
 				isTauri={isTauri}
-				onApplySql={function (sql) {
+				onApplySql={function (sql, _explanation, _warnings, execute) {
 					if (mode === 'sql') {
 						setCurrentSqlQuery(sql)
 					} else {
 						setCurrentDrizzleQuery(sql)
+					}
+					if (execute) {
+						requestAnimationFrame(function () {
+							handleExecute(sql, mode).catch(function (e) {
+								console.error('AI insert+run failed:', e)
+							})
+						})
 					}
 				}}
 			/>

--- a/apps/desktop/src/lib/bindings.ts
+++ b/apps/desktop/src/lib/bindings.ts
@@ -542,9 +542,9 @@ async aiComplete(prompt: string, connectionId: string | null, maxTokens: number 
     else return { status: "error", error: e  as any };
 }
 },
-async aiCompleteStream(prompt: string, connectionId: string | null, maxTokens: number | null, onEvent: TAURI_CHANNEL<AiStreamEvent>) : Promise<Result<null, { kind: string; detail: string }>> {
+async aiCompleteStream(requestId: string, prompt: string, connectionId: string | null, maxTokens: number | null, onEvent: TAURI_CHANNEL<AiStreamEvent>) : Promise<Result<null, { kind: string; detail: string }>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("ai_complete_stream", { prompt, connectionId, maxTokens, onEvent }) };
+    return { status: "ok", data: await TAURI_INVOKE("ai_complete_stream", { requestId, prompt, connectionId, maxTokens, onEvent }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -591,12 +591,71 @@ async aiListOllamaModels() : Promise<Result<string[], { kind: string; detail: st
 }
 },
 /**
- * Check whether Groq provider is usable (env keys present).
+ * Check whether Groq provider is usable (env or DB keys present).
  * Returns key count detected. Never exposes the key values.
  */
 async aiGroqStatus() : Promise<Result<GroqStatus, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("ai_groq_status") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async aiAbortStream(requestId: string) : Promise<Result<boolean, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_abort_stream", { requestId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async aiKeysList(provider: string) : Promise<Result<AiApiKeyRecord[], { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_keys_list", { provider }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async aiKeysAdd(provider: string, label: string, apiKey: string) : Promise<Result<number, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_keys_add", { provider, label, apiKey }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async aiKeysDelete(id: number) : Promise<Result<null, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_keys_delete", { id }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async aiKeysSetActive(id: number, active: boolean) : Promise<Result<null, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_keys_set_active", { id, active }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async aiKeysTest(id: number) : Promise<Result<AiKeyTestResult, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_keys_test", { id }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Test an unsaved key (used by the "Test before save" button).
+ */
+async aiKeysTestRaw(apiKey: string) : Promise<Result<AiKeyTestResult, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_keys_test_raw", { apiKey }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -615,6 +674,8 @@ async aiGroqStatus() : Promise<Result<GroqStatus, { kind: string; detail: string
 /** user-defined types **/
 
 export type AIResponse = { content: string; suggested_queries: string[] | null; tokens_used: number | null; provider: string }
+export type AiApiKeyRecord = { id: number; provider: string; label: string; is_active: boolean; last_tested: number | null; last_status: string | null; created_at: number; updated_at: number }
+export type AiKeyTestResult = { ok: boolean; message: string }
 export type AiStreamEvent = { type: "token"; text: string } | { type: "final"; content: string } | { type: "error"; message: string }
 export type ColumnInfo = { name: string; data_type: string; is_nullable: boolean; default_value: string | null; 
 /**


### PR DESCRIPTION
## Summary

Two complementary changes shipped under one release tag (**0.0.109**):

### 1. AI SQL Generator: Encrypted Key Store

- New Settings → AI Keys (Groq) panel — add/label/test/enable+disable/delete encrypted Groq API keys.
- Ciphertext is AES-256-GCM via the existing `security::encrypt`; the master key lives in the OS keychain (Keychain / libsecret / Credential Manager).
- Env keys (`GROQ_API_KEY`, `GROQ_API_KEY_1..10`, `GROQ_MODEL`) are merged with UI-stored keys at runtime, with duplicates removed.
- New per-key Test action validates against Groq with a 4-token ping (15s timeout) and records last status in the row.
- `⌘I` overlay shows a live status badge (`N keys` / `no keys`).
- New **Insert + Run** action (`⌘⏎`) accepts a suggestion and immediately executes it.
- Real abort path: closing the overlay or pressing Esc mid-stream cancels the in-flight Groq stream backend-side via `ai_abort_stream`.
- Streaming completions now request `response_format: json_object` so deltas stay inside a JSON envelope.
- Key rotation also fires on 5xx and 403 (was 429/401 only).

### 2. Data Grid Refactor

- Split `data-grid.tsx` (1455 lines) into a focused shell (245 lines) plus 15 sibling modules under `data-grid/`:
  - **Hooks:** use-cell-editing, use-cell-selection, use-row-selection, use-grid-keyboard, use-column-resize, use-focused-cell, use-context-menu-reporting, use-right-drag-scroll
  - **Components:** cell-value, draft-row, empty-states, grid-body, grid-header
  - **Pure modules:** selection.ts (rectangle helpers), types.ts (CellPosition, ContextMenuState)
- Restored broken imports in `schema-visualizer/components/table-node.tsx` (Handle, Position, NodeProps, Key, LinkIcon) — `tsc -b` is now clean across the workspace.

## Migrations

- 008: `ai_api_keys (id, provider, label, ciphertext, is_active, last_tested, last_status, created_at, updated_at)`

## New Tauri commands

`ai_abort_stream`, `ai_keys_list`, `ai_keys_add`, `ai_keys_delete`, `ai_keys_set_active`, `ai_keys_test`, `ai_keys_test_raw`

## Verification

- [x] `cargo check` clean
- [x] `bunx tsc -b` clean
- [ ] Manual: add a Groq key in Settings → use ⌘I → stream tokens → Insert + Run
- [ ] Manual: revoke key in Settings → ⌘I shows "no keys"
- [ ] Manual: data grid keyboard navigation, cell editing, row selection, context menu, column resize all behave as before
- [ ] Manual: schema visualizer renders nodes correctly

## Out of scope (deferred)

`database-studio.tsx` (2337 LOC), `code-editor.tsx` (1900 LOC), `command-palette.tsx` (1837 LOC), `database-sidebar.tsx` (990 LOC) — these are next on the refactor backlog. Splitting them safely needs its own PR cycle to keep release risk contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop: in-app encrypted AI API key store with add/list/delete, per-key test/status, and UI for activating keys
  * Refactored database grid into smaller, focused components and hooks

* **Bug Fixes**
  * Fixed schema visualizer table node import/display issue

* **Improvements**
  * Extended key-rotation triggers (429/401/403/5xx), streaming JSON responses, abortable streaming, and Insert+Run execution flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->