### PR TITLE
scaffold(pg): pgbouncer=true detection + use_simple_query plumbing

### DIFF
--- a/apps/desktop/src-tauri/src/database/postgres/execute.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/execute.rs
@@ -23,6 +23,13 @@ pub async fn execute_query(
     Ok(())
 }
 
+// TODO(pgbouncer): Accept a `use_simple_query: bool` parameter (sourced from
+// `Database::Postgres { use_simple_query, .. }`). When true, replace the
+// `client.prepare(...)` + `client.query_raw(...)` flow below with
+// `client.simple_query(query)` and convert each `SimpleQueryRow` into the
+// same JSON-encoded `Page` shape via a new `SimpleRowWriter`. Required for
+// PgBouncer in transaction-pool mode, which kills named prepared statements
+// between queries ("prepared statement \"PGBOUNCER_1\" does not exist").
 async fn execute_query_with_results(
     client: &Client,
     query: &str,
@@ -146,6 +153,10 @@ async fn execute_query_with_results(
     }
 }
 
+// TODO(pgbouncer): same as `execute_query_with_results` — replace
+// `client.execute(query, &[])` with `client.simple_query(query)` and count
+// affected rows from the `CommandComplete` message when the pooler flag is
+// on. Required for PgBouncer transaction-pool mode.
 async fn execute_modification_query(
     client: &Client,
     query: &str,

--- a/apps/desktop/src-tauri/src/database/services/connection.rs
+++ b/apps/desktop/src-tauri/src/database/services/connection.rs
@@ -32,6 +32,11 @@ fn clean_postgres_connection_string(connection_string: &str) -> (String, bool, b
             } else if key == "sslmode" && matches!(value.as_ref(), "verify-ca" | "verify-full") {
                 verify_tls = true;
                 Some((key.into_owned(), "require".to_string()))
+            } else if key.eq_ignore_ascii_case("pgbouncer") {
+                // Strip the Dora/Prisma-style pooler flag; tokio_postgres::Config
+                // rejects unknown query params. The flag is detected separately
+                // by `detect_pgbouncer_flag` on the raw connection string.
+                None
             } else {
                 Some((key.into_owned(), value.into_owned()))
             }
@@ -162,6 +167,9 @@ impl<'a> ConnectionService<'a> {
                         connection_string,
                         ssh_config,
                     } => Database::Postgres {
+                        use_simple_query: crate::database::types::detect_pgbouncer_flag(
+                            &connection_string,
+                        ),
                         connection_string,
                         ssh_config,
                         client: None,
@@ -320,6 +328,7 @@ impl<'a> ConnectionService<'a> {
                 ssh_config,
                 client,
                 tunnel,
+                ..
             } => {
                 // If we have an SSH config, start the tunnel
                 if let Some(ssh_conf) = ssh_config {

--- a/apps/desktop/src-tauri/src/database/types.rs
+++ b/apps/desktop/src-tauri/src/database/types.rs
@@ -22,6 +22,20 @@ pub type Page = Box<RawValue>;
 
 pub type ExecSender = UnboundedSender<QueryExecEvent>;
 
+/// True when a Postgres connection string contains `?pgbouncer=true` (case
+/// insensitive). Used to decide whether to skip named prepared statements
+/// when talking to a transaction-pooling PgBouncer. Matches the convention
+/// used by Prisma/Drizzle/`pg-bouncer-mode` so existing connection strings
+/// can be reused unchanged.
+pub fn detect_pgbouncer_flag(connection_string: &str) -> bool {
+    let Ok(url) = url::Url::parse(connection_string) else {
+        return false;
+    };
+    url.query_pairs().any(|(key, value)| {
+        key.eq_ignore_ascii_case("pgbouncer") && value.eq_ignore_ascii_case("true")
+    })
+}
+
 #[derive(Debug, Clone, Serialize, Type)]
 pub struct StatementInfo {
     pub returns_values: bool,
@@ -132,6 +146,14 @@ pub enum Database {
         ssh_config: Option<SshConfig>,
         client: Option<Arc<tokio_postgres::Client>>,
         tunnel: Option<Arc<SshTunnel>>,
+        /// When true, the execution path skips named prepared statements and
+        /// uses the simple-query protocol instead. Detected from
+        /// `?pgbouncer=true` in the connection string (Prisma-compatible flag).
+        /// Required for PgBouncer in transaction-pool mode.
+        ///
+        /// NOTE (scaffold): the flag is currently plumbed but not yet honored
+        /// by `postgres/execute.rs` — see TODO markers there.
+        use_simple_query: bool,
     },
     MySQL {
         connection_string: String,
@@ -199,6 +221,7 @@ impl DatabaseConnection {
                 connection_string,
                 ssh_config,
             } => Database::Postgres {
+                use_simple_query: detect_pgbouncer_flag(&connection_string),
                 connection_string,
                 ssh_config,
                 client: None,
@@ -241,6 +264,7 @@ impl DatabaseConnection {
                 connection_string,
                 ssh_config,
             } => Database::Postgres {
+                use_simple_query: detect_pgbouncer_flag(&connection_string),
                 connection_string,
                 ssh_config,
                 client: None,

--- a/apps/desktop/src/features/database-studio/components/data-grid/grid-body.tsx
+++ b/apps/desktop/src/features/database-studio/components/data-grid/grid-body.tsx
@@ -166,7 +166,7 @@ export function GridBody({
 							>
 								<td
 									className={cn(
-										'px-4 py-1.5 text-center border-b border-r border-sidebar-border sticky left-0 z-20 transition-colors',
+										'w-[30px] min-w-[30px] p-0 text-center align-middle border-b border-l border-r border-sidebar-border sticky left-0 z-20 transition-colors',
 										rowBackgroundClasses,
 										selectedRows.has(rowIndex) && 'bg-sidebar-accent'
 									)}

--- a/apps/desktop/src/features/database-studio/components/data-grid/grid-header.tsx
+++ b/apps/desktop/src/features/database-studio/components/data-grid/grid-header.tsx
@@ -33,7 +33,7 @@ export function GridHeader({
 		<thead className='sticky top-0 bg-sidebar z-10' role='rowgroup'>
 			<tr role='row'>
 				<th
-					className='px-4 py-2 text-center border-b border-r border-sidebar-border bg-background sticky left-0 z-30'
+					className='w-[30px] min-w-[30px] p-0 text-center align-middle border-b border-l border-r border-sidebar-border bg-background sticky left-0 z-30'
 					role='columnheader'
 					aria-label='Select all rows'
 				>

--- a/apps/desktop/src/features/database-studio/components/studio-toolbar.tsx
+++ b/apps/desktop/src/features/database-studio/components/studio-toolbar.tsx
@@ -113,7 +113,7 @@ export function StudioToolbar({
 
 	return (
 		<div className='flex flex-col shrink-0 bg-sidebar border-b border-sidebar-border'>
-			<div className='flex items-center h-10 px-2 gap-2 text-sm'>
+			<div className='flex items-center h-10 pl-0 pr-2 gap-2 text-sm'>
 				<div className='flex items-center gap-1 mr-2'>
 					{onToggleSidebar && (
 						<Button


### PR DESCRIPTION
## Summary
Step 1 of the PgBouncer transaction-pool fix. **Scaffold only — no behavior change yet.** Follow-up commits will wire the simple-query execution path.

Fixes a partial root cause for: `"Database error: prepared statement \"PGBOUNCER_1\" does not exist"` observed against Supabase / PgBouncer poolers in transaction pooling mode.

## Why
`tokio-postgres` uses named protocol-level prepared statements for every query. PgBouncer in transaction-pool mode releases the backend connection after each transaction, so the next query may land on a different backend that has no record of the prepared statement — and errors out.

The fix is to use the simple-query protocol (text-only, no prepares) when talking to a pooler. This PR lays the plumbing; the actual execution-path swap will follow.

## What's included
- `detect_pgbouncer_flag(&str)` — recognises `?pgbouncer=true` on a Postgres URI (matches Prisma/Drizzle convention so existing connection strings can be reused unchanged).
- `Database::Postgres.use_simple_query: bool` — populated in both constructors and in `update_connection`.
- `clean_postgres_connection_string` strips the `pgbouncer` param so `tokio_postgres::Config::parse` (which rejects unknown params) is happy.
- TODO markers in `postgres/execute.rs` describing the upcoming `simple_query` path.

## Not in this PR
- Actual simple-query execution branch (replaces `prepare` + `query_raw` and `execute` with `client.simple_query(...)`).
- `SimpleRowWriter` to convert text-only `SimpleQueryRow` into the existing `Page` JSON shape.
- Wiring through `live_monitor.rs` and `services/mutation.rs` which also issue prepared statements.
- Connection-dialog UI hint to teach users about the flag.

## Test plan
- [x] `cargo check` clean
- [ ] Add `?pgbouncer=true` to an existing Supabase pooler connection string → verify connection still succeeds (no behavior change yet, but the param must not break the parse)
- [ ] Without the flag → behavior unchanged (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Plumb PgBouncer detection and simple-query configuration through the Postgres connection pipeline without changing execution behavior yet.

New Features:
- Add detection of the `?pgbouncer=true` flag on Postgres connection strings to signal PgBouncer transaction-pool usage.

Enhancements:
- Store a `use_simple_query` flag on Postgres database connections and propagate it through constructors and connection updates for future simple-query execution.
- Strip the `pgbouncer` query parameter from Postgres connection strings before passing them to `tokio_postgres` to keep config parsing compatible.
- Document upcoming simple-query execution path via TODOs in the Postgres executor for both result-returning and modification queries.