### PR TITLE
Fix Flatpak Bun archive install path

### DIFF
--- a/packaging/flatpak/io.github.remcostoeten.dora.yml
+++ b/packaging/flatpak/io.github.remcostoeten.dora.yml
@@ -24,7 +24,7 @@ modules:
         url: https://github.com/oven-sh/bun/releases/download/bun-v1.1.38/bun-linux-x64-baseline.zip
         sha256: 353e2e6d4086a09eeee984d2ed61736dcd905838ede51b82689fd7b3e95def90
     build-commands:
-      - install -Dm755 bun-linux-x64-baseline/bun /app/bin/bun
+      - install -Dm755 bun /app/bin/bun
 
   - name: dora
     buildsystem: simple


### PR DESCRIPTION
## Summary
- use the Bun binary path that flatpak-builder exposes after extracting the pinned archive

## Validation
- git diff --check
- actionlint on flatpak workflow

## Summary by Sourcery

Bug Fixes:
- Fix Bun installation in the Flatpak manifest by installing from the extracted Bun binary name rather than a hard-coded subdirectory path.