### PR TITLE
Fix Flatpak frozen lockfile install

### DIFF
--- a/packaging/flatpak/io.github.remcostoeten.dora.yml
+++ b/packaging/flatpak/io.github.remcostoeten.dora.yml
@@ -17,6 +17,15 @@ finish-args:
   - --env=WEBKIT_DISABLE_DMABUF_RENDERER=1
 
 modules:
+  - name: bun-install
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://github.com/oven-sh/bun/releases/download/bun-v1.1.38/bun-linux-x64-baseline.zip
+        sha256: 353e2e6d4086a09eeee984d2ed61736dcd905838ede51b82689fd7b3e95def90
+    build-commands:
+      - install -Dm755 bun /app/bin/bun-install
+
   - name: bun
     buildsystem: simple
     sources:
@@ -36,7 +45,7 @@ modules:
         CARGO_HOME: /run/build/dora/cargo
         RUSTUP_HOME: /run/build/dora/rustup
     build-commands:
-      - bun install --frozen-lockfile
+      - bun-install install --frozen-lockfile
       - bun run --cwd apps/desktop build
       - cargo build --manifest-path apps/desktop/src-tauri/Cargo.toml --release
       - install -Dm755 apps/desktop/src-tauri/target/release/dora /app/bin/dora


### PR DESCRIPTION
## Summary
- add a pinned Bun v1.1.38 helper for the Flatpak dependency install step so the existing frozen lockfile remains valid
- keep pinned Bun v1.3.13 as the runtime used for the Vite build
- avoid committing a broad root lockfile rewrite caused by the stale apps/db-tester gitlink workspace

## Validation
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/flatpak.yml
- reproduced the frozen-lockfile failure locally with Bun v1.3.13

## Summary by Sourcery

Pin a separate Bun version for Flatpak dependency installation while keeping the existing runtime version for the Vite build, ensuring the frozen lockfile remains valid.

Bug Fixes:
- Resolve Flatpak frozen-lockfile failures by running dependency installation with a Bun version compatible with the existing lockfile.

Enhancements:
- Introduce a dedicated Flatpak module providing a pinned Bun binary specifically for dependency installation to avoid unintended lockfile rewrites.