### PR TITLE
Fix Flatpak release upload handling

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -98,9 +98,14 @@ jobs:
         with:
           name: dora-flatpak-repo-${{ steps.meta.outputs.version }}
           path: ${{ steps.build.outputs.repo }}
+          include-hidden-files: true
 
       - name: Upload Flatpak to GitHub release
         if: ${{ steps.meta.outputs.tag != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.meta.outputs.tag }} ${{ steps.build.outputs.bundle }} --clobber
+        shell: bash
+        run: |
+          if ! gh release upload "${{ steps.meta.outputs.tag }}" "${{ steps.build.outputs.bundle }}" --clobber; then
+            echo "::warning::Flatpak bundle was built and uploaded as a workflow artifact, but GitHub rejected the release asset upload. Existing published releases can be immutable, so rerun without a tag for artifact-only builds or attach the bundle before publishing the release."
+          fi


### PR DESCRIPTION
## Summary
- make Flatpak release asset upload best-effort so immutable published releases do not fail an otherwise successful build
- include hidden files when uploading the generated Flatpak repo artifact

## Validation
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/flatpak.yml
- confirmed run 25977956689 built the Flatpak bundle and only failed on GitHub immutable release upload

## Summary by Sourcery

Relax Flatpak GitHub release upload handling in the workflow while ensuring the generated Flatpak repo artifact includes hidden files.

Build:
- Include hidden files when uploading the Flatpak repo artifact in the Flatpak GitHub Actions workflow.
- Make Flatpak bundle upload to GitHub releases best-effort by warning instead of failing the workflow when the release asset upload is rejected.