### PR TITLE
feat(docker): show all by default, move logs/terminal to bottom panel…

### DIFF
--- a/apps/desktop/src/features/docker-manager/api/container-service.ts
+++ b/apps/desktop/src/features/docker-manager/api/container-service.ts
@@ -267,10 +267,11 @@ export async function getContainerLogs(
 export async function streamContainerLogs(
 	containerId: string,
 	onLog: (line: string) => void,
-	onError: (error: string) => void
+	onError: (error: string) => void,
+	tail: number = 100
 ): Promise<() => void> {
-	if (!isTauri) return demoService.streamContainerLogs(containerId, onLog, onError)
-	return clientStream(containerId, onLog, onError)
+	if (!isTauri) return demoService.streamContainerLogs(containerId, onLog, onError, tail)
+	return clientStream(containerId, onLog, onError, tail)
 }
 
 export async function openContainerTerminal(

--- a/apps/desktop/src/features/docker-manager/api/demo-service.ts
+++ b/apps/desktop/src/features/docker-manager/api/demo-service.ts
@@ -245,7 +245,8 @@ export async function getContainerLogs(
 export async function streamContainerLogs(
 	_containerId: string,
 	onLog: (line: string) => void,
-	_onError: (error: string) => void
+	_onError: (error: string) => void,
+	_tail?: number
 ): Promise<() => void> {
 	const lines = [
 		'LOG:  database system is ready to accept connections',

--- a/apps/desktop/src/features/docker-manager/api/docker-client.ts
+++ b/apps/desktop/src/features/docker-manager/api/docker-client.ts
@@ -298,14 +298,15 @@ export async function getContainerLogs(
 export async function streamContainerLogs(
 	containerId: string,
 	onLog: (line: string) => void,
-	onError: (error: string) => void
+	onError: (error: string) => void,
+	tail: number = 100
 ): Promise<() => void> {
 	if (
 		typeof window !== 'undefined' &&
 		('__TAURI__' in window || '__TAURI_INTERNALS__' in window)
 	) {
 		const { Command } = await import('@tauri-apps/plugin-shell')
-		const command = Command.create('docker', ['logs', '-f', '--tail', '100', containerId])
+		const command = Command.create('docker', ['logs', '-f', '--tail', String(tail), containerId])
 
 		command.on('close', (data) => {
 			console.log(`command finished with code ${data.code} and signal ${data.signal}`)

--- a/apps/desktop/src/features/docker-manager/api/queries/use-container-logs.ts
+++ b/apps/desktop/src/features/docker-manager/api/queries/use-container-logs.ts
@@ -11,7 +11,7 @@ export function useContainerLogs(
 	containerId: string | null,
 	options: UseContainerLogsOptions = {}
 ) {
-	const { enabled = true } = options
+	const { tail = 100, enabled = true } = options
 	const [logs, setLogs] = useState<string>('')
 	const [isLoading, setIsLoading] = useState(false)
 	const [error, setError] = useState<string | null>(null)
@@ -42,21 +42,21 @@ export function useContainerLogs(
 					containerId!,
 					(line) => {
 						if (isMounted) {
-							setLogs((prev) => prev + line) // Append logs (Note: might need buffering for perf)
+							setLogs((prev) => prev + line)
 						}
 					},
 					(err) => {
 						if (isMounted) {
 							console.error('Stream error:', err)
 						}
-					}
+					},
+					tail
 				)
 
 				if (isMounted) {
 					activeStreamRef.current = cleanup
 					setIsLoading(false)
 				} else {
-					// If unmounted during setup, clean up immediately
 					void cleanup()
 				}
 			} catch (e) {
@@ -75,7 +75,7 @@ export function useContainerLogs(
 				activeStreamRef.current()
 			}
 		}
-	}, [containerId, enabled])
+	}, [containerId, enabled, tail])
 
 	return {
 		data: logs,

--- a/apps/desktop/src/features/docker-manager/api/queries/use-container-logs.ts
+++ b/apps/desktop/src/features/docker-manager/api/queries/use-container-logs.ts
@@ -11,7 +11,7 @@ export function useContainerLogs(
 	containerId: string | null,
 	options: UseContainerLogsOptions = {}
 ) {
-	const { tail = 100, enabled = true } = options
+	const { tail, enabled = true } = options
 	const [logs, setLogs] = useState<string>('')
 	const [isLoading, setIsLoading] = useState(false)
 	const [error, setError] = useState<string | null>(null)

--- a/apps/desktop/src/features/docker-manager/components/container-details-panel.tsx
+++ b/apps/desktop/src/features/docker-manager/components/container-details-panel.tsx
@@ -10,14 +10,10 @@ import {
 import { Package } from 'lucide-react'
 import { useState } from 'react'
 import { Button } from '@/shared/ui/button'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/shared/ui/tabs'
 import { useContainerActions, useRemoveContainer } from '../api/mutations/use-container-actions'
-import { useContainerLogs } from '../api/queries/use-container-logs'
-import { DEFAULT_LOG_TAIL } from '../constants'
 import type { DockerContainer } from '../types'
 import { ConnectionDetails } from './connection-details'
 import { ContainerMetrics } from './container-metrics'
-import { LogsViewer } from './logs-viewer'
 import { SeedView } from './seed-view'
 import { StatusBadge } from './status-badge'
 import { ComposeExportDialog } from './compose-export-dialog'
@@ -37,15 +33,8 @@ export function ContainerDetailsPanel({
 	onOpenTerminal,
 	onRemoveComplete
 }: Props) {
-	const [tailLines, setTailLines] = useState(DEFAULT_LOG_TAIL)
-	const [activeTab, setActiveTab] = useState('logs')
 	const [showExportDialog, setShowExportDialog] = useState(false)
 	const [showRemoveDialog, setShowRemoveDialog] = useState(false)
-
-	const { data: logs, isLoading: logsLoading } = useContainerLogs(container?.id ?? null, {
-		tail: tailLines,
-		enabled: activeTab === 'logs'
-	})
 
 	const containerActions = useContainerActions()
 	const removeContainer = useRemoveContainer({
@@ -218,34 +207,11 @@ export function ContainerDetailsPanel({
 				</Button>
 			</div>
 
-			<div className='flex-1 flex flex-col min-h-0 p-4'>
-				<Tabs
-					value={activeTab}
-					onValueChange={setActiveTab}
-					className='flex-1 flex flex-col'
-				>
-					<TabsList className='w-full'>
-						<TabsTrigger value='logs' className='flex-1'>
-							Logs
-						</TabsTrigger>
-						<TabsTrigger value='seed' className='flex-1'>
-							Seed
-						</TabsTrigger>
-					</TabsList>
-
-					<TabsContent value='logs' className='flex-1 mt-3'>
-						<LogsViewer
-							logs={logs || ''}
-							isLoading={logsLoading}
-							tailLines={tailLines}
-							onTailLinesChange={setTailLines}
-						/>
-					</TabsContent>
-
-					<TabsContent value='seed' className='flex-1 mt-3'>
-						<SeedView container={container} />
-					</TabsContent>
-				</Tabs>
+			<div className='p-4 border-t border-border'>
+				<h4 className='text-xs font-medium text-muted-foreground uppercase tracking-wide mb-3'>
+					Seed Data
+				</h4>
+				<SeedView container={container} />
 			</div>
 
 			<ComposeExportDialog

--- a/apps/desktop/src/features/docker-manager/components/docker-view.tsx
+++ b/apps/desktop/src/features/docker-manager/components/docker-view.tsx
@@ -7,7 +7,6 @@ import {
 	ArrowUp,
 	Activity,
 	HeartPulse,
-	TerminalSquare,
 	X
 } from 'lucide-react'
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react'
@@ -32,8 +31,10 @@ import type { PostgresContainerConfig, DockerContainer } from '../types'
 import { ContainerDetailsPanel } from './container-details-panel'
 import { ContainerList } from './container-list'
 import { ContainerTerminal } from './container-terminal'
+import { LogsViewer } from './logs-viewer'
+import { useContainerLogs } from '../api/queries/use-container-logs'
+import { DEFAULT_LOG_TAIL } from '../constants'
 import { CreateContainerDialog } from './create-container-dialog'
-import { SandboxIndicator } from './sandbox-indicator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select'
 import { cn } from '@/shared/utils/cn'
 
@@ -54,7 +55,7 @@ const STATUS_FILTER_OPTIONS: ReadonlyArray<{ value: StatusFilter; label: string 
 
 export function DockerView({ onOpenInDataViewer }: Props) {
 	const [searchQuery, setSearchQuery] = useState('')
-	const [showExternal, setShowExternal] = useState(false)
+	const [showExternal, setShowExternal] = useState(true)
 	const [selectedContainerId, setSelectedContainerId] = useState<string | null>(null)
 	const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
 	const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
@@ -62,6 +63,8 @@ export function DockerView({ onOpenInDataViewer }: Props) {
 	const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
 	const [terminalContainerId, setTerminalContainerId] = useState<string | null>(null)
 	const [isTerminalPanelOpen, setIsTerminalPanelOpen] = useState(false)
+	const [activeBottomTab, setActiveBottomTab] = useState<'logs' | 'terminal'>('logs')
+	const [tailLines, setTailLines] = useState(DEFAULT_LOG_TAIL)
 
 	const searchInputRef = useRef<HTMLInputElement>(null)
 	const { toast } = useToast()
@@ -191,6 +194,14 @@ export function DockerView({ onOpenInDataViewer }: Props) {
 		[allContainers, terminalContainerId]
 	)
 
+	const { data: logs = '', isLoading: logsLoading } = useContainerLogs(
+		selectedContainerId,
+		{
+			tail: tailLines,
+			enabled: activeBottomTab === 'logs' && !!selectedContainerId
+		}
+	)
+
 	const containerSummary = useMemo(
 		function () {
 			const runningCount = visibleContainers.filter(function (container) {
@@ -263,16 +274,20 @@ export function DockerView({ onOpenInDataViewer }: Props) {
 
 	function handleSelectContainer(id: string) {
 		setSelectedContainerId(id)
+		setActiveBottomTab('logs')
+		setIsTerminalPanelOpen(false)
 	}
 
 	function handleOpenTerminal(container: DockerContainer) {
 		setSelectedContainerId(container.id)
 		setTerminalContainerId(container.id)
 		setIsTerminalPanelOpen(true)
+		setActiveBottomTab('terminal')
 	}
 
 	function handleCloseTerminalPanel() {
 		setIsTerminalPanelOpen(false)
+		setActiveBottomTab('logs')
 	}
 
 	function handleRemoveComplete() {
@@ -343,8 +358,10 @@ export function DockerView({ onOpenInDataViewer }: Props) {
 				}
 
 				if (detail.type === 'open-terminal') {
+					setSelectedContainerId(container.id)
 					setTerminalContainerId(container.id)
 					setIsTerminalPanelOpen(true)
+					setActiveBottomTab('terminal')
 				}
 			}
 
@@ -415,7 +432,6 @@ export function DockerView({ onOpenInDataViewer }: Props) {
 							</p>
 						</div>
 					</div>
-					<SandboxIndicator />
 				</div>
 
 				<div className='px-4 pb-3'>
@@ -589,31 +605,83 @@ export function DockerView({ onOpenInDataViewer }: Props) {
 					/>
 				</div>
 
-				{isTerminalPanelOpen && terminalContainer && (
+				{selectedContainer && (
 					<div className='h-72 border-t border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/70'>
 						<div className='h-9 border-b border-border px-3 flex items-center justify-between'>
-							<div className='flex items-center gap-2 min-w-0'>
-								<TerminalSquare className='h-4 w-4 text-muted-foreground' />
-								<span className='text-sm font-medium'>Terminal</span>
-								<span className='text-xs text-muted-foreground truncate'>
-									{terminalContainer.name}
-								</span>
+							<div className='flex items-center gap-2'>
+								<div className='flex items-center gap-1 bg-muted rounded-lg p-0.5'>
+									<button
+										type='button'
+										onClick={function () { setActiveBottomTab('logs') }}
+										className={cn(
+											'px-3 py-1 text-xs font-medium rounded-md transition-colors',
+											activeBottomTab === 'logs'
+												? 'bg-background text-foreground shadow-sm'
+												: 'text-muted-foreground hover:text-foreground'
+										)}
+									>
+										Logs
+									</button>
+									<button
+										type='button'
+										onClick={function () {
+											if (terminalContainerId !== selectedContainer.id) {
+												setTerminalContainerId(selectedContainer.id)
+											}
+											setIsTerminalPanelOpen(true)
+											setActiveBottomTab('terminal')
+										}}
+										disabled={selectedContainer.state !== 'running'}
+										className={cn(
+											'px-3 py-1 text-xs font-medium rounded-md transition-colors',
+											activeBottomTab === 'terminal'
+												? 'bg-background text-foreground shadow-sm'
+												: 'text-muted-foreground hover:text-foreground',
+											selectedContainer.state !== 'running' && 'opacity-50 cursor-not-allowed'
+										)}
+									>
+										Terminal
+									</button>
+								</div>
+								{activeBottomTab === 'terminal' && terminalContainer && (
+									<span className='text-xs text-muted-foreground truncate max-w-[200px]'>
+										{terminalContainer.name}
+									</span>
+								)}
 							</div>
 							<Button
 								type='button'
 								size='icon-sm'
 								variant='ghost'
-								onClick={handleCloseTerminalPanel}
-								aria-label='Close terminal panel'
+								onClick={function () {
+									setSelectedContainerId(null)
+									setIsTerminalPanelOpen(false)
+								}}
+								aria-label='Close panel'
 							>
 								<X className='h-4 w-4' />
 							</Button>
 						</div>
 						<div className='h-[calc(100%-2.25rem)] p-3'>
-							<ContainerTerminal
-								container={terminalContainer}
-								enabled={isTerminalPanelOpen}
-							/>
+							{activeBottomTab === 'logs' && (
+								<LogsViewer
+									logs={logs}
+									isLoading={logsLoading}
+									tailLines={tailLines}
+									onTailLinesChange={setTailLines}
+								/>
+							)}
+							{activeBottomTab === 'terminal' && terminalContainer && (
+								<ContainerTerminal
+									container={terminalContainer}
+									enabled={isTerminalPanelOpen}
+								/>
+							)}
+							{activeBottomTab === 'terminal' && !terminalContainer && (
+								<div className='flex h-full items-center justify-center text-sm text-muted-foreground'>
+									Container must be running to open a terminal.
+								</div>
+							)}
 						</div>
 					</div>
 				)}


### PR DESCRIPTION
…, pass tail param through

## Summary by Sourcery

Unify container logs and terminal into a shared bottom panel while wiring the configurable log tail length through to the Docker log streaming API.

New Features:
- Show external Docker containers by default in the Docker manager view.
- Add a bottom panel with tabs to switch between container logs and terminal for the selected container, including disabling the terminal when the container is not running.
- Expose log tail length controls in the bottom logs viewer for the selected container.

Enhancements:
- Simplify the container details panel to focus on seed data, moving logs out to the shared bottom panel.
- Extend the useContainerLogs hook and log streaming services to accept a tail parameter and pass it through to the underlying Docker command and demo service.