### PR TITLE
feat: multi-connection, EXPLAIN panel, dialect detection + studio polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- keep multiple database connections open at once, each with its own isolated tab group; a connection tab bar above the table tabs switches between them (with status dots and per-connection close), and switching preserves each connection's open tabs, active tab, filters and scroll state. Cycle connections with `Ctrl+Shift+[` / `Ctrl+Shift+]` (#96)
+
+### Bug Fixes
+
+- AI provider errors now use clear, consistent copy across all providers (Groq, OpenAI, Anthropic, Gemini, Ollama): rate limits, invalid keys, missing models, and an offline Ollama daemon each surface an actionable message instead of a raw HTTP status and response body (#82)
+- the AI rate-limit message includes a retry hint so the user knows to wait and try again (#82)
+
+### Documentation
+
+- AI Keys settings now spell out that Groq/OpenAI/Anthropic/Gemini need an API key while Ollama runs locally with no key, pointing to `docs/ai-providers.md` for setup (#82)
+
 ## [v0.28.0] - 2026-06-14
 
 ### Features

--- a/apps/desktop/src-tauri/src/bindings.rs
+++ b/apps/desktop/src-tauri/src/bindings.rs
@@ -63,6 +63,7 @@ pub fn generate_bindings() -> Builder<tauri::Wry> {
         db_commands::set_setting,
         db_commands::insert_row,
         db_commands::update_cell,
+        db_commands::get_blob_bytes,
         db_commands::delete_rows,
         db_commands::duplicate_row,
         db_commands::export_table,

--- a/apps/desktop/src-tauri/src/database.rs
+++ b/apps/desktop/src-tauri/src/database.rs
@@ -12,6 +12,7 @@ pub use postgres::tls::Certificates;
 pub mod commands;
 mod connection_monitor;
 pub mod contract;
+pub mod dialect;
 mod live_monitor;
 pub mod maintenance;
 pub mod metadata;

--- a/apps/desktop/src-tauri/src/database/adapter/write.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write.rs
@@ -86,6 +86,26 @@ pub trait WriteAdapter: Send + Sync {
     async fn dump_database(&self, output_path: String) -> Result<DumpResult, Error>;
 
     async fn execute_batch(&self, statements: Vec<String>) -> Result<MutationResult, Error>;
+
+    /// Re-select a single binary cell and return its raw bytes.
+    ///
+    /// The data grid renders blobs as a display string (`describe_blob`), which
+    /// discards the original bytes; "Copy as base64" / "Save to file" need them
+    /// back. The cell is addressed by primary key, reusing the same parameter
+    /// binding as the other write methods so the lookup is injection-safe.
+    ///
+    /// Drivers without a meaningful binary type (or not yet wired) return
+    /// [`Error::NotImplemented`].
+    async fn get_blob_bytes(
+        &self,
+        _table: String,
+        _schema: Option<String>,
+        _pk_column: String,
+        _pk_value: serde_json::Value,
+        _column: String,
+    ) -> Result<Vec<u8>, Error> {
+        Err(Error::NotImplemented("WriteAdapter::get_blob_bytes"))
+    }
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/desktop/src-tauri/src/database/adapter/write_libsql.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write_libsql.rs
@@ -174,6 +174,47 @@ impl WriteAdapter for LibSqlAdapter {
         self.insert_row(table, schema, data).await
     }
 
+    async fn get_blob_bytes(
+        &self,
+        table: String,
+        _schema: Option<String>,
+        pk_column: String,
+        pk_value: serde_json::Value,
+        column: String,
+    ) -> Result<Vec<u8>, Error> {
+        let query = format!(
+            "SELECT \"{}\" FROM \"{}\" WHERE \"{}\" = ? LIMIT 1",
+            column, table, pk_column
+        );
+        let params = vec![json_to_libsql_value(&pk_value)];
+        let mut rows = self
+            .connection()
+            .query(&query, params)
+            .await
+            .map_err(|e| Error::Any(anyhow!("LibSQL blob lookup failed: {}", e)))?;
+        let row = rows
+            .next()
+            .await
+            .map_err(|e| Error::Any(anyhow!("LibSQL blob fetch failed: {}", e)))?
+            .ok_or_else(|| {
+                Error::Any(anyhow!(
+                    "No row found in \"{}\" where {} matches the provided primary key",
+                    table,
+                    pk_column
+                ))
+            })?;
+        match row.get_value(0) {
+            Ok(libsql::Value::Blob(b)) => Ok(b),
+            Ok(libsql::Value::Null) => Ok(Vec::new()),
+            Ok(libsql::Value::Text(s)) => Ok(s.into_bytes()),
+            Ok(_) => Err(Error::Any(anyhow!(
+                "Column \"{}\" is not a binary value",
+                column
+            ))),
+            Err(e) => Err(Error::Any(anyhow!("LibSQL blob read failed: {}", e))),
+        }
+    }
+
     async fn truncate_table(
         &self,
         table: String,

--- a/apps/desktop/src-tauri/src/database/adapter/write_postgres.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write_postgres.rs
@@ -206,6 +206,36 @@ impl WriteAdapter for PostgresAdapter {
         self.insert_row(table, schema, data).await
     }
 
+    async fn get_blob_bytes(
+        &self,
+        table: String,
+        schema: Option<String>,
+        pk_column: String,
+        pk_value: serde_json::Value,
+        column: String,
+    ) -> Result<Vec<u8>, Error> {
+        let query = format!(
+            "SELECT \"{}\" FROM {} WHERE \"{}\" = $1 LIMIT 1",
+            column,
+            qualified_table_name(&table, schema.as_deref()),
+            pk_column
+        );
+        let pk_param = json_to_pg_param(&pk_value);
+        let row = self
+            .client()
+            .query_opt(&query, &[pk_param.as_ref()])
+            .await?
+            .ok_or_else(|| {
+                Error::Any(anyhow!(
+                    "No row found in {} where {} matches the provided primary key",
+                    qualified_table_name(&table, schema.as_deref()),
+                    pk_column
+                ))
+            })?;
+        let bytes: Option<Vec<u8>> = row.try_get(0)?;
+        Ok(bytes.unwrap_or_default())
+    }
+
     async fn truncate_table(
         &self,
         table: String,

--- a/apps/desktop/src-tauri/src/database/adapter/write_sqlite.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write_sqlite.rs
@@ -188,6 +188,40 @@ impl WriteAdapter for SqliteAdapter {
         self.insert_row(table, schema, row_data).await
     }
 
+    async fn get_blob_bytes(
+        &self,
+        table: String,
+        _schema: Option<String>,
+        pk_column: String,
+        pk_value: serde_json::Value,
+        column: String,
+    ) -> Result<Vec<u8>, Error> {
+        let conn = self
+            .connection()
+            .lock()
+            .map_err(|_| Error::Internal("Mutex poisoned".into()))?;
+        let query = format!(
+            "SELECT \"{}\" FROM \"{}\" WHERE \"{}\" = ? LIMIT 1",
+            column, table, pk_column
+        );
+        let pk_val = json_to_sqlite_value(&pk_value);
+        let bytes = conn.query_row(
+            &query,
+            [&pk_val as &dyn rusqlite::ToSql],
+            |row| row.get::<_, Option<Vec<u8>>>(0),
+        );
+        match bytes {
+            Ok(Some(b)) => Ok(b),
+            Ok(None) => Ok(Vec::new()),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Err(Error::Any(anyhow!(
+                "No row found in \"{}\" where {} matches the provided primary key",
+                table,
+                pk_column
+            ))),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     async fn truncate_table(
         &self,
         table: String,

--- a/apps/desktop/src-tauri/src/database/commands/mutation.rs
+++ b/apps/desktop/src-tauri/src/database/commands/mutation.rs
@@ -58,6 +58,29 @@ pub async fn update_cell(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn get_blob_bytes(
+    connection_id: Uuid,
+    table_name: String,
+    schema_name: Option<String>,
+    primary_key_column: String,
+    primary_key_value: serde_json::Value,
+    column_name: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<u8>, Error> {
+    let svc = mutation_service(state.inner());
+    svc.get_blob_bytes(
+        connection_id,
+        table_name,
+        schema_name,
+        primary_key_column,
+        primary_key_value,
+        column_name,
+    )
+    .await
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn delete_rows(
     connection_id: Uuid,
     table_name: String,
@@ -106,11 +129,21 @@ pub async fn export_table(
     schema_name: Option<String>,
     format: ExportFormat,
     limit: Option<u32>,
+    where_clause: Option<String>,
+    order_by: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<String, Error> {
     let svc = mutation_service(state.inner());
-    svc.export_table(connection_id, table_name, schema_name, format, limit)
-        .await
+    svc.export_table(
+        connection_id,
+        table_name,
+        schema_name,
+        format,
+        limit,
+        where_clause,
+        order_by,
+    )
+    .await
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/database/dialect.rs
+++ b/apps/desktop/src-tauri/src/database/dialect.rs
@@ -1,0 +1,212 @@
+//! Runtime SQL dialect detection and source capability gating.
+//!
+//! Dora routes CockroachDB through the Postgres wire protocol and MariaDB
+//! through the MySQL wire protocol. The two engines are wire-compatible but
+//! differ in features (e.g. CockroachDB has no `LISTEN`/`NOTIFY`). At connect
+//! time we run a `version()` query and detect the *true* engine so that the
+//! rest of the app can branch where it matters.
+//!
+//! The detection functions here are intentionally pure (string -> enum) so they
+//! can be unit-tested without a live database. Everything that needs a live
+//! cluster (schema introspection, type mapping) is explicitly deferred — see
+//! the `TODO(dialect-parity)` markers.
+
+use serde::Serialize;
+use specta::Type;
+
+/// Concrete engine behind a Postgres-wire connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum PgDialect {
+    /// Vanilla PostgreSQL (the default / safe path).
+    Postgres,
+    /// CockroachDB speaking the Postgres wire protocol.
+    CockroachDb,
+}
+
+/// Concrete engine behind a MySQL-wire connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum MySqlDialect {
+    /// Vanilla MySQL (the default / safe path).
+    MySql,
+    /// MariaDB speaking the MySQL wire protocol.
+    MariaDb,
+}
+
+/// A unified, runtime-detected dialect tag stored on a connection.
+///
+/// `None` of these is fabricated: each is set only after a successful
+/// `version()` query against the live server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum DetectedDialect {
+    Postgres,
+    CockroachDb,
+    MySql,
+    MariaDb,
+}
+
+impl From<PgDialect> for DetectedDialect {
+    fn from(value: PgDialect) -> Self {
+        match value {
+            PgDialect::Postgres => DetectedDialect::Postgres,
+            PgDialect::CockroachDb => DetectedDialect::CockroachDb,
+        }
+    }
+}
+
+impl From<MySqlDialect> for DetectedDialect {
+    fn from(value: MySqlDialect) -> Self {
+        match value {
+            MySqlDialect::MySql => DetectedDialect::MySql,
+            MySqlDialect::MariaDb => DetectedDialect::MariaDb,
+        }
+    }
+}
+
+/// Detect the real engine from a Postgres `SELECT version()` string.
+///
+/// CockroachDB returns strings like `CockroachDB CCL v23.1.0 (...)`, whereas
+/// PostgreSQL returns `PostgreSQL 16.1 on x86_64-pc-linux-gnu ...`. The match is
+/// case-insensitive and substring-based so it survives build-info noise.
+pub fn detect_pg_dialect(version_str: &str) -> PgDialect {
+    if version_str.to_ascii_lowercase().contains("cockroach") {
+        PgDialect::CockroachDb
+    } else {
+        PgDialect::Postgres
+    }
+}
+
+/// Detect the real engine from a MySQL `SELECT VERSION()` string.
+///
+/// MariaDB embeds `MariaDB` in the version banner (e.g. `11.4.2-MariaDB`),
+/// while MySQL returns a bare version like `8.0.36`. Case-insensitive substring
+/// match.
+pub fn detect_mysql_dialect(version_str: &str) -> MySqlDialect {
+    if version_str.to_ascii_lowercase().contains("mariadb") {
+        MySqlDialect::MariaDb
+    } else {
+        MySqlDialect::MySql
+    }
+}
+
+/// Feature flags that gate behaviour per detected dialect.
+///
+/// This is the "source caps" layer: code that wants to know "can I use
+/// LISTEN/NOTIFY here?" asks the caps, not the raw enum, so the answer is
+/// derived from the *runtime-detected* engine rather than the user's pick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceCaps {
+    /// True when the engine supports Postgres `LISTEN`/`NOTIFY`, which the live
+    /// monitor uses for push-based change notifications. CockroachDB does NOT
+    /// support it, so live monitoring must fall back to polling (or be hidden).
+    pub supports_listen_notify: bool,
+}
+
+impl SourceCaps {
+    /// Capabilities for a Postgres-wire connection whose dialect is not yet
+    /// known. Assumes vanilla Postgres (the safe, existing behaviour).
+    pub const fn postgres_default() -> Self {
+        Self {
+            supports_listen_notify: true,
+        }
+    }
+
+    /// Capabilities for a MySQL-wire connection whose dialect is not yet known.
+    /// MySQL/MariaDB have no Postgres-style LISTEN/NOTIFY; the live monitor
+    /// already polls for these engines.
+    pub const fn mysql_default() -> Self {
+        Self {
+            supports_listen_notify: false,
+        }
+    }
+
+    /// Derive capabilities from a concretely detected dialect.
+    pub const fn for_dialect(dialect: DetectedDialect) -> Self {
+        match dialect {
+            // Vanilla Postgres: full LISTEN/NOTIFY support.
+            DetectedDialect::Postgres => Self {
+                supports_listen_notify: true,
+            },
+            // CockroachDB intentionally does not implement LISTEN/NOTIFY.
+            // https://github.com/cockroachdb/cockroach/issues/41522
+            DetectedDialect::CockroachDb => Self {
+                supports_listen_notify: false,
+            },
+            // MySQL/MariaDB: polling-based monitoring only.
+            DetectedDialect::MySql | DetectedDialect::MariaDb => Self {
+                supports_listen_notify: false,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_cockroachdb_from_version_string() {
+        let v = "CockroachDB CCL v23.1.0 (x86_64-pc-linux-gnu, built 2023/05/15 ...)";
+        assert_eq!(detect_pg_dialect(v), PgDialect::CockroachDb);
+    }
+
+    #[test]
+    fn detects_vanilla_postgres_from_version_string() {
+        let v = "PostgreSQL 16.1 on x86_64-pc-linux-gnu, compiled by gcc ...";
+        assert_eq!(detect_pg_dialect(v), PgDialect::Postgres);
+    }
+
+    #[test]
+    fn detects_cockroachdb_case_insensitively() {
+        assert_eq!(detect_pg_dialect("cockroachdb v22.2"), PgDialect::CockroachDb);
+    }
+
+    #[test]
+    fn detects_mariadb_from_version_string() {
+        let v = "11.4.2-MariaDB-1:11.4.2+maria~ubu2404";
+        assert_eq!(detect_mysql_dialect(v), MySqlDialect::MariaDb);
+    }
+
+    #[test]
+    fn detects_vanilla_mysql_from_version_string() {
+        assert_eq!(detect_mysql_dialect("8.0.36"), MySqlDialect::MySql);
+    }
+
+    #[test]
+    fn detects_mariadb_case_insensitively() {
+        assert_eq!(detect_mysql_dialect("10.11.8-mariadb"), MySqlDialect::MariaDb);
+    }
+
+    #[test]
+    fn cockroach_caps_disable_listen_notify() {
+        let caps = SourceCaps::for_dialect(DetectedDialect::CockroachDb);
+        assert!(!caps.supports_listen_notify);
+    }
+
+    #[test]
+    fn postgres_caps_enable_listen_notify() {
+        let caps = SourceCaps::for_dialect(DetectedDialect::Postgres);
+        assert!(caps.supports_listen_notify);
+    }
+
+    #[test]
+    fn mysql_and_mariadb_caps_disable_listen_notify() {
+        assert!(!SourceCaps::for_dialect(DetectedDialect::MySql).supports_listen_notify);
+        assert!(!SourceCaps::for_dialect(DetectedDialect::MariaDb).supports_listen_notify);
+    }
+
+    #[test]
+    fn dialect_conversions_are_consistent() {
+        assert_eq!(
+            DetectedDialect::from(PgDialect::CockroachDb),
+            DetectedDialect::CockroachDb
+        );
+        assert_eq!(
+            DetectedDialect::from(MySqlDialect::MariaDb),
+            DetectedDialect::MariaDb
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/database/live_monitor.rs
+++ b/apps/desktop/src-tauri/src/database/live_monitor.rs
@@ -292,6 +292,20 @@ async fn create_postgres_notification_receiver(
     };
 
     let connection_entry = state.connections.get(&connection_id)?;
+
+    // Gate LISTEN/NOTIFY on detected capabilities. CockroachDB speaks the
+    // Postgres wire protocol but does not implement LISTEN/NOTIFY, so attempting
+    // to install the notify trigger/LISTEN would fail. When the engine does not
+    // support it we return None and the monitor loop falls back to polling.
+    if !connection_entry.value().source_caps().supports_listen_notify {
+        log::debug!(
+            "Live monitor: LISTEN/NOTIFY unsupported for connection {} (dialect {:?}); using polling",
+            connection_id,
+            connection_entry.value().detected_dialect
+        );
+        return None;
+    }
+
     let (mut connection_string, tunnel_local_port) = match &connection_entry.value().database {
         Database::CockroachDB {
             connection_string,

--- a/apps/desktop/src-tauri/src/database/postgres/row_writer.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/row_writer.rs
@@ -236,6 +236,14 @@ impl RowWriter {
                 self.buf.push_str(&value.json);
             }
 
+            Type::BYTEA => {
+                // Binary column: render via the shared blob describer so small
+                // values show inline hex and larger ones a `<type — size>`
+                // summary with magic-byte detection.
+                let bytes = row.try_get::<_, PgBytes>(column_index)?;
+                self.write_json_string(&crate::database::blob_display::describe_blob(bytes.bytes));
+            }
+
             // TODO(vini): BPCHAR and NAME are correct here?
             Type::TEXT | Type::VARCHAR | Type::BPCHAR | Type::NAME => {
                 let value: &str = row.try_get(column_index)?;

--- a/apps/desktop/src-tauri/src/database/services/ai/anthropic.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/anthropic.rs
@@ -271,9 +271,7 @@ impl AnthropicClient {
                 {
                     Ok(response) => response,
                     Err(error) => {
-                        last_err = Some(Error::Any(anyhow::anyhow!(
-                            "Anthropic request failed: {error}"
-                        )));
+                        last_err = Some(super::errors::request_error("Anthropic", &error));
                         continue;
                     }
                 };
@@ -281,17 +279,17 @@ impl AnthropicClient {
             let status = response.status();
             if Self::should_rotate(status) {
                 let body_text = response.text().await.unwrap_or_default();
-                last_err = Some(Error::Any(anyhow::anyhow!(
-                    "Anthropic key/provider error (status {status}): {body_text}"
-                )));
+                last_err = Some(super::errors::http_error(
+                    "Anthropic", &self.model, status, &body_text,
+                ));
                 continue;
             }
 
             if !status.is_success() {
                 let body_text = response.text().await.unwrap_or_default();
-                return Err(Error::Any(anyhow::anyhow!(
-                    "Anthropic API error ({status}): {body_text}"
-                )));
+                return Err(super::errors::http_error(
+                    "Anthropic", &self.model, status, &body_text,
+                ));
             }
 
             let parsed: AnthropicResponse = response.json().await.map_err(|error| {
@@ -347,9 +345,7 @@ impl AnthropicClient {
                 {
                     Ok(response) => response,
                     Err(error) => {
-                        last_err = Some(Error::Any(anyhow::anyhow!(
-                            "Anthropic request failed: {error}"
-                        )));
+                        last_err = Some(super::errors::request_error("Anthropic", &error));
                         continue;
                     }
                 };
@@ -357,17 +353,17 @@ impl AnthropicClient {
             let status = response.status();
             if Self::should_rotate(status) {
                 let body_text = response.text().await.unwrap_or_default();
-                last_err = Some(Error::Any(anyhow::anyhow!(
-                    "Anthropic key/provider error (status {status}): {body_text}"
-                )));
+                last_err = Some(super::errors::http_error(
+                    "Anthropic", &self.model, status, &body_text,
+                ));
                 continue;
             }
 
             if !status.is_success() {
                 let body_text = response.text().await.unwrap_or_default();
-                return Err(Error::Any(anyhow::anyhow!(
-                    "Anthropic API error ({status}): {body_text}"
-                )));
+                return Err(super::errors::http_error(
+                    "Anthropic", &self.model, status, &body_text,
+                ));
             }
 
             let mut stream = response.bytes_stream();

--- a/apps/desktop/src-tauri/src/database/services/ai/errors.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/errors.rs
@@ -1,0 +1,118 @@
+//! Unified, user-facing error messages for AI providers.
+//!
+//! Each provider used to surface raw `"<Provider> API error (<status>): <body>"`
+//! strings straight to the UI. This module maps the handful of error classes a
+//! user can actually act on into clear, consistent copy so the message reads the
+//! same regardless of which provider produced it:
+//!
+//! - rate limit (HTTP 429)
+//! - invalid key (HTTP 401 / 403)
+//! - model not found (HTTP 404, or a 400/422 whose body mentions the model)
+//! - Ollama offline (connection refused to the local daemon)
+//!
+//! Anything that doesn't match a known class falls back to the raw status/body
+//! so we never hide a useful detail.
+
+use crate::error::Error;
+
+/// Build a friendly message for an HTTP error returned by a cloud provider.
+///
+/// `provider` is the human label (e.g. "Groq", "OpenAI"). `model` is the model
+/// id that was requested. `status` and `body` come straight from the response.
+pub fn http_error_message(
+    provider: &str,
+    model: &str,
+    status: reqwest::StatusCode,
+    body: &str,
+) -> String {
+    match status {
+        reqwest::StatusCode::TOO_MANY_REQUESTS => {
+            format!("Rate limit reached for {provider}. Wait a moment and retry.")
+        }
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+            format!("Invalid API key for {provider}. Check it in Settings → AI.")
+        }
+        reqwest::StatusCode::NOT_FOUND => {
+            format!("Model '{model}' not found for {provider}. Pick a different model.")
+        }
+        // Some providers return 400/422 for an unknown model rather than 404.
+        // Detect that from the body so the user still gets the model hint.
+        _ if body_mentions_model(body) => {
+            format!("Model '{model}' not found for {provider}. Pick a different model.")
+        }
+        _ => format!("{provider} request failed ({status}): {}", trim_body(body)),
+    }
+}
+
+/// Build a friendly message for an HTTP error as an [`Error`].
+pub fn http_error(
+    provider: &str,
+    model: &str,
+    status: reqwest::StatusCode,
+    body: &str,
+) -> Error {
+    Error::Any(anyhow::anyhow!(http_error_message(
+        provider, model, status, body
+    )))
+}
+
+/// Build a friendly message for a transport-level failure (the request never
+/// got an HTTP response — DNS, TLS, connection refused, timeout, etc.).
+///
+/// For Ollama a refused connection almost always means the daemon isn't running,
+/// so we special-case that into actionable copy.
+pub fn request_error(provider: &str, error: &reqwest::Error) -> Error {
+    if is_ollama(provider) && is_connection_refused(error) {
+        return Error::Any(anyhow::anyhow!(
+            "Ollama isn't running. Start it with `ollama serve`."
+        ));
+    }
+    Error::Any(anyhow::anyhow!("{provider} request failed: {error}"))
+}
+
+fn is_ollama(provider: &str) -> bool {
+    provider.eq_ignore_ascii_case("ollama")
+}
+
+/// reqwest doesn't expose a typed "connection refused" variant across versions,
+/// so we walk the error source chain and match the OS error string. This also
+/// catches the generic "tcp connect error" wrapper reqwest emits.
+fn is_connection_refused(error: &reqwest::Error) -> bool {
+    if error.is_connect() {
+        return true;
+    }
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(error);
+    while let Some(err) = source {
+        let text = err.to_string().to_lowercase();
+        if text.contains("connection refused")
+            || text.contains("connect error")
+            || text.contains("os error 111")
+        {
+            return true;
+        }
+        source = err.source();
+    }
+    false
+}
+
+fn body_mentions_model(body: &str) -> bool {
+    let lower = body.to_lowercase();
+    (lower.contains("model") && (lower.contains("not found") || lower.contains("does not exist")))
+        || lower.contains("model_not_found")
+        || lower.contains("unknown model")
+        || lower.contains("invalid model")
+}
+
+/// Keep raw bodies from flooding the UI while still surfacing useful detail.
+fn trim_body(body: &str) -> String {
+    const LIMIT: usize = 300;
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "no response body".to_string();
+    }
+    if trimmed.chars().count() <= LIMIT {
+        return trimmed.to_string();
+    }
+    let shortened: String = trimmed.chars().take(LIMIT).collect();
+    format!("{shortened}…")
+}

--- a/apps/desktop/src-tauri/src/database/services/ai/gemini.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/gemini.rs
@@ -250,9 +250,7 @@ impl GeminiClient {
             let response = match self.client.post(&url).json(&body).send().await {
                 Ok(response) => response,
                 Err(error) => {
-                    last_err = Some(Error::Any(anyhow::anyhow!(
-                        "Gemini request failed: {error}"
-                    )));
+                    last_err = Some(super::errors::request_error("Gemini", &error));
                     continue;
                 }
             };
@@ -260,17 +258,17 @@ impl GeminiClient {
             let status = response.status();
             if Self::should_rotate(status) {
                 let body_text = response.text().await.unwrap_or_default();
-                last_err = Some(Error::Any(anyhow::anyhow!(
-                    "Gemini key/provider error (status {status}): {body_text}"
-                )));
+                last_err = Some(super::errors::http_error(
+                    "Gemini", &self.model, status, &body_text,
+                ));
                 continue;
             }
 
             if !status.is_success() {
                 let body_text = response.text().await.unwrap_or_default();
-                return Err(Error::Any(anyhow::anyhow!(
-                    "Gemini API error ({status}): {body_text}"
-                )));
+                return Err(super::errors::http_error(
+                    "Gemini", &self.model, status, &body_text,
+                ));
             }
 
             let gemini_response: GeminiResponse = response.json().await.map_err(|error| {
@@ -327,9 +325,7 @@ impl GeminiClient {
             let response = match self.client.post(&url).json(&body).send().await {
                 Ok(response) => response,
                 Err(error) => {
-                    last_err = Some(Error::Any(anyhow::anyhow!(
-                        "Gemini request failed: {error}"
-                    )));
+                    last_err = Some(super::errors::request_error("Gemini", &error));
                     continue;
                 }
             };
@@ -337,17 +333,17 @@ impl GeminiClient {
             let status = response.status();
             if Self::should_rotate(status) {
                 let body_text = response.text().await.unwrap_or_default();
-                last_err = Some(Error::Any(anyhow::anyhow!(
-                    "Gemini key/provider error (status {status}): {body_text}"
-                )));
+                last_err = Some(super::errors::http_error(
+                    "Gemini", &self.model, status, &body_text,
+                ));
                 continue;
             }
 
             if !status.is_success() {
                 let body_text = response.text().await.unwrap_or_default();
-                return Err(Error::Any(anyhow::anyhow!(
-                    "Gemini API error ({status}): {body_text}"
-                )));
+                return Err(super::errors::http_error(
+                    "Gemini", &self.model, status, &body_text,
+                ));
             }
 
             let mut stream = response.bytes_stream();

--- a/apps/desktop/src-tauri/src/database/services/ai/groq.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/groq.rs
@@ -311,7 +311,7 @@ impl GroqClient {
             {
                 Ok(r) => r,
                 Err(e) => {
-                    last_err = Some(Error::Any(anyhow::anyhow!("Groq request failed: {}", e)));
+                    last_err = Some(super::errors::request_error("Groq", &e));
                     continue;
                 }
             };
@@ -319,21 +319,15 @@ impl GroqClient {
             let status = response.status();
             if Self::should_rotate(status) {
                 let body_text = response.text().await.unwrap_or_default();
-                last_err = Some(Error::Any(anyhow::anyhow!(
-                    "Groq key/provider error (status {}): {}",
-                    status,
-                    body_text
-                )));
+                last_err = Some(super::errors::http_error("Groq", &self.model, status, &body_text));
                 continue;
             }
 
             if !status.is_success() {
                 let body_text = response.text().await.unwrap_or_default();
-                return Err(Error::Any(anyhow::anyhow!(
-                    "Groq API error ({}): {}",
-                    status,
-                    body_text
-                )));
+                return Err(super::errors::http_error(
+                    "Groq", &self.model, status, &body_text,
+                ));
             }
 
             let parsed: GroqResponse = response
@@ -396,7 +390,7 @@ impl GroqClient {
             {
                 Ok(r) => r,
                 Err(e) => {
-                    last_err = Some(Error::Any(anyhow::anyhow!("Groq request failed: {}", e)));
+                    last_err = Some(super::errors::request_error("Groq", &e));
                     continue;
                 }
             };
@@ -404,21 +398,15 @@ impl GroqClient {
             let status = response.status();
             if Self::should_rotate(status) {
                 let body_text = response.text().await.unwrap_or_default();
-                last_err = Some(Error::Any(anyhow::anyhow!(
-                    "Groq key/provider error (status {}): {}",
-                    status,
-                    body_text
-                )));
+                last_err = Some(super::errors::http_error("Groq", &self.model, status, &body_text));
                 continue;
             }
 
             if !status.is_success() {
                 let body_text = response.text().await.unwrap_or_default();
-                return Err(Error::Any(anyhow::anyhow!(
-                    "Groq API error ({}): {}",
-                    status,
-                    body_text
-                )));
+                return Err(super::errors::http_error(
+                    "Groq", &self.model, status, &body_text,
+                ));
             }
 
             let mut stream = response.bytes_stream();

--- a/apps/desktop/src-tauri/src/database/services/ai/mod.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/mod.rs
@@ -1,4 +1,5 @@
 mod anthropic;
+mod errors;
 mod gemini;
 mod groq;
 mod models;

--- a/apps/desktop/src-tauri/src/database/services/ai/ollama.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/ollama.rs
@@ -453,18 +453,12 @@ impl OllamaClient {
             .json(&chat_request)
             .send()
             .await
-            .map_err(|error| {
-                Error::Any(anyhow::anyhow!(
-                    "Ollama request failed: {error}. Is Ollama running?"
-                ))
-            })?;
+            .map_err(|error| super::errors::request_error("Ollama", &error))?;
 
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(Error::Any(anyhow::anyhow!(
-                "Ollama API error ({status}): {body}"
-            )));
+            return Err(super::errors::http_error("Ollama", &self.model, status, &body));
         }
 
         let parsed: OllamaChatResponse = response.json().await.map_err(|error| {
@@ -501,14 +495,12 @@ impl OllamaClient {
             .json(&chat_request)
             .send()
             .await
-            .map_err(|error| Error::Any(anyhow::anyhow!("Ollama request failed: {error}")))?;
+            .map_err(|error| super::errors::request_error("Ollama", &error))?;
 
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(Error::Any(anyhow::anyhow!(
-                "Ollama API error ({status}): {body}"
-            )));
+            return Err(super::errors::http_error("Ollama", &self.model, status, &body));
         }
 
         let mut stream = response.bytes_stream();

--- a/apps/desktop/src-tauri/src/database/services/ai/openai.rs
+++ b/apps/desktop/src-tauri/src/database/services/ai/openai.rs
@@ -301,9 +301,7 @@ impl OpenAiClient {
             {
                 Ok(response) => response,
                 Err(error) => {
-                    last_err = Some(Error::Any(anyhow::anyhow!(
-                        "OpenAI request failed: {error}"
-                    )));
+                    last_err = Some(super::errors::request_error("OpenAI", &error));
                     continue;
                 }
             };
@@ -311,17 +309,17 @@ impl OpenAiClient {
             let status = response.status();
             if Self::should_rotate(status) {
                 let body_text = response.text().await.unwrap_or_default();
-                last_err = Some(Error::Any(anyhow::anyhow!(
-                    "OpenAI key/provider error (status {status}): {body_text}"
-                )));
+                last_err = Some(super::errors::http_error(
+                    "OpenAI", &self.model, status, &body_text,
+                ));
                 continue;
             }
 
             if !status.is_success() {
                 let body_text = response.text().await.unwrap_or_default();
-                return Err(Error::Any(anyhow::anyhow!(
-                    "OpenAI API error ({status}): {body_text}"
-                )));
+                return Err(super::errors::http_error(
+                    "OpenAI", &self.model, status, &body_text,
+                ));
             }
 
             let parsed: OpenAiResponse = response.json().await.map_err(|error| {
@@ -380,9 +378,7 @@ impl OpenAiClient {
             {
                 Ok(response) => response,
                 Err(error) => {
-                    last_err = Some(Error::Any(anyhow::anyhow!(
-                        "OpenAI request failed: {error}"
-                    )));
+                    last_err = Some(super::errors::request_error("OpenAI", &error));
                     continue;
                 }
             };
@@ -390,17 +386,17 @@ impl OpenAiClient {
             let status = response.status();
             if Self::should_rotate(status) {
                 let body_text = response.text().await.unwrap_or_default();
-                last_err = Some(Error::Any(anyhow::anyhow!(
-                    "OpenAI key/provider error (status {status}): {body_text}"
-                )));
+                last_err = Some(super::errors::http_error(
+                    "OpenAI", &self.model, status, &body_text,
+                ));
                 continue;
             }
 
             if !status.is_success() {
                 let body_text = response.text().await.unwrap_or_default();
-                return Err(Error::Any(anyhow::anyhow!(
-                    "OpenAI API error ({status}): {body_text}"
-                )));
+                return Err(super::errors::http_error(
+                    "OpenAI", &self.model, status, &body_text,
+                ));
             }
 
             let mut stream = response.bytes_stream();

--- a/apps/desktop/src-tauri/src/database/services/connection.rs
+++ b/apps/desktop/src-tauri/src/database/services/connection.rs
@@ -531,8 +531,24 @@ impl<'a> ConnectionService<'a> {
 
                 match connect(&config, certificates, verify_tls).await {
                     Ok((pg_client, conn_check)) => {
+                        // Detect the real engine (Postgres vs CockroachDB) so
+                        // capability gating (e.g. LISTEN/NOTIFY) is based on the
+                        // server, not the user's variant choice. Detection
+                        // failures are non-fatal: we keep the safe Postgres
+                        // default.
+                        let detected = match pg_client.query_one("SELECT version()", &[]).await {
+                            Ok(row) => row.try_get::<usize, String>(0).ok().map(|version| {
+                                crate::database::dialect::detect_pg_dialect(&version).into()
+                            }),
+                            Err(e) => {
+                                log::warn!("Failed to detect Postgres dialect via version(): {}", e);
+                                None
+                            }
+                        };
+
                         *client = Some(Arc::new(pg_client));
                         connection.connected = true;
+                        connection.detected_dialect = detected;
 
                         if let Err(e) = self.storage.update_last_connected(&connection_id) {
                             log::warn!("Failed to update last connected timestamp: {}", e);
@@ -609,8 +625,27 @@ impl<'a> ConnectionService<'a> {
                 match mysql_pool.get_conn().await {
                     Ok(mut conn) => {
                         conn.ping().await?;
+
+                        // Detect the real engine (MySQL vs MariaDB). Non-fatal:
+                        // on failure we keep the safe MySQL default.
+                        let detected = match conn
+                            .query_first::<String, _>("SELECT VERSION()")
+                            .await
+                        {
+                            Ok(Some(version)) => Some(
+                                crate::database::dialect::detect_mysql_dialect(&version).into(),
+                            ),
+                            Ok(None) => None,
+                            Err(e) => {
+                                log::warn!("Failed to detect MySQL dialect via VERSION(): {}", e);
+                                None
+                            }
+                        };
+                        drop(conn);
+
                         *pool = Some(Arc::new(mysql_pool));
                         connection.connected = true;
+                        connection.detected_dialect = detected;
 
                         if let Err(e) = self.storage.update_last_connected(&connection_id) {
                             log::warn!("Failed to update last connected timestamp: {}", e);

--- a/apps/desktop/src-tauri/src/database/services/metadata.rs
+++ b/apps/desktop/src-tauri/src/database/services/metadata.rs
@@ -34,6 +34,11 @@ impl<'a> MetadataService<'a> {
         let connection = connection_entry.value();
 
         let schema = match &connection.database {
+            // TODO(dialect-parity, #89): CockroachDB shares the Postgres
+            // introspection path. Some Postgres catalog queries differ on
+            // CockroachDB; branch here on `connection.detected_dialect` once a
+            // live CockroachDB cluster is available to verify a Cockroach-specific
+            // query. Until then the vanilla Postgres query is the safe default.
             Database::CockroachDB {
                 client: Some(client),
                 ..
@@ -69,6 +74,12 @@ impl<'a> MetadataService<'a> {
             Database::LibSQL {
                 connection: None, ..
             } => return Err(Error::Any(anyhow!("LibSQL connection not active"))),
+            // TODO(dialect-parity, #88): MariaDB shares the MySQL introspection
+            // path. MariaDB-specific types (UUID, INET4/INET6) and some
+            // information_schema differences need a dialect branch on
+            // `connection.detected_dialect`, plus row-writer type mapping in the
+            // write path. Deferred until a live MariaDB cluster is available; the
+            // vanilla MySQL query remains the safe default.
             Database::MariaDB {
                 pool: Some(pool), ..
             }

--- a/apps/desktop/src-tauri/src/database/services/mutation.rs
+++ b/apps/desktop/src-tauri/src/database/services/mutation.rs
@@ -77,6 +77,31 @@ impl<'a> MutationService<'a> {
         Ok(result)
     }
 
+    /// Re-select a single binary cell and return its raw bytes (for
+    /// "Copy as base64" / "Save to file", which need the original bytes the
+    /// rendered display string no longer carries).
+    #[instrument(skip(self, primary_key_value), fields(connection_id = %connection_id, table = %table_name))]
+    pub async fn get_blob_bytes(
+        &self,
+        connection_id: Uuid,
+        table_name: String,
+        schema_name: Option<String>,
+        primary_key_column: String,
+        primary_key_value: serde_json::Value,
+        column_name: String,
+    ) -> Result<Vec<u8>, Error> {
+        let (adapter, _cid) = self.write_adapter(connection_id)?;
+        adapter
+            .get_blob_bytes(
+                table_name,
+                schema_name,
+                primary_key_column,
+                primary_key_value,
+                column_name,
+            )
+            .await
+    }
+
     #[instrument(skip(self, primary_key_values), fields(connection_id = %connection_id, table = %table_name))]
     pub async fn delete_rows(
         &self,
@@ -136,6 +161,15 @@ impl<'a> MutationService<'a> {
         Ok(result)
     }
 
+    /// Exports a table's rows in the requested format.
+    ///
+    /// `where_clause` and `order_by` are optional SQL fragments (WITHOUT the
+    /// leading `WHERE` / `ORDER BY` keywords) produced by the same trusted
+    /// frontend filter/sort builder used for the normal data fetch
+    /// (`filter-sql.ts`). They are appended verbatim so export honors active
+    /// filters and sort (#99); when omitted the full table is exported as
+    /// before. No new escaping path is introduced here — value escaping happens
+    /// in the shared frontend builder.
     pub async fn export_table(
         &self,
         connection_id: Uuid,
@@ -143,8 +177,25 @@ impl<'a> MutationService<'a> {
         schema_name: Option<String>,
         format: ExportFormat,
         limit: Option<u32>,
+        where_clause: Option<String>,
+        order_by: Option<String>,
     ) -> Result<String, Error> {
         let client = self.connection_repo.get_client(connection_id)?;
+
+        // Shared optional clause fragments. Empty/blank inputs are ignored so a
+        // caller passing `Some("")` behaves like `None`.
+        let where_sql = where_clause
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| format!(" WHERE {}", s))
+            .unwrap_or_default();
+        let order_sql = order_by
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| format!(" ORDER BY {}", s))
+            .unwrap_or_default();
 
         let (query, db_type) = match &client {
             DatabaseClient::Postgres { .. } => {
@@ -155,8 +206,8 @@ impl<'a> MutationService<'a> {
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
                     format!(
-                        "SELECT * FROM {}\"{}\"{}",
-                        schema_prefix, table_name, limit_clause
+                        "SELECT * FROM {}\"{}\"{}{}{}",
+                        schema_prefix, table_name, where_sql, order_sql, limit_clause
                     ),
                     "postgres",
                 )
@@ -164,7 +215,10 @@ impl<'a> MutationService<'a> {
             DatabaseClient::SQLite { .. } => {
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
-                    format!("SELECT * FROM \"{}\"{}", table_name, limit_clause),
+                    format!(
+                        "SELECT * FROM \"{}\"{}{}{}",
+                        table_name, where_sql, order_sql, limit_clause
+                    ),
                     "sqlite",
                 )
             }
@@ -176,8 +230,8 @@ impl<'a> MutationService<'a> {
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
                     format!(
-                        "SELECT * FROM {}\"{}\"{}",
-                        schema_prefix, table_name, limit_clause
+                        "SELECT * FROM {}\"{}\"{}{}{}",
+                        schema_prefix, table_name, where_sql, order_sql, limit_clause
                     ),
                     "duckdb",
                 )
@@ -185,14 +239,20 @@ impl<'a> MutationService<'a> {
             DatabaseClient::LibSQL { .. } => {
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
-                    format!("SELECT * FROM `{}`{}", table_name, limit_clause),
+                    format!(
+                        "SELECT * FROM `{}`{}{}{}",
+                        table_name, where_sql, order_sql, limit_clause
+                    ),
                     "libsql",
                 )
             }
             DatabaseClient::MySQL { .. } => {
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
-                    format!("SELECT * FROM `{}`{}", table_name, limit_clause),
+                    format!(
+                        "SELECT * FROM `{}`{}{}{}",
+                        table_name, where_sql, order_sql, limit_clause
+                    ),
                     "mysql",
                 )
             }

--- a/apps/desktop/src-tauri/src/database/types.rs
+++ b/apps/desktop/src-tauri/src/database/types.rs
@@ -177,6 +177,11 @@ pub struct DatabaseConnection {
     pub updated_at: i64,
     pub pin_hash: Option<String>,
     pub database: Database,
+    /// Engine detected at connect time via `version()`. `None` until the
+    /// connection has been opened and probed. This is *runtime-confirmed*
+    /// information, distinct from the user's `Database` variant choice, and is
+    /// the source of truth for dialect-specific capability gating.
+    pub detected_dialect: Option<crate::database::dialect::DetectedDialect>,
 }
 
 #[derive(Clone)]
@@ -386,6 +391,7 @@ impl DatabaseConnection {
             updated_at: chrono::Utc::now().timestamp_millis(),
             pin_hash: None,
             database,
+            detected_dialect: None,
         }
     }
 
@@ -461,6 +467,27 @@ impl DatabaseConnection {
                 .unwrap_or_else(|| chrono::Utc::now().timestamp_millis()),
             pin_hash: info.pin_hash,
             database,
+            detected_dialect: None,
+        }
+    }
+
+    /// Source capabilities for this connection, derived from the
+    /// runtime-detected dialect when available, otherwise from a safe default
+    /// based on the wire protocol (the existing vanilla behaviour).
+    pub fn source_caps(&self) -> crate::database::dialect::SourceCaps {
+        use crate::database::dialect::SourceCaps;
+        if let Some(dialect) = self.detected_dialect {
+            return SourceCaps::for_dialect(dialect);
+        }
+        match &self.database {
+            Database::Postgres { .. } | Database::CockroachDB { .. } => {
+                SourceCaps::postgres_default()
+            }
+            Database::MySQL { .. } | Database::MariaDB { .. } => SourceCaps::mysql_default(),
+            // Non Postgres/MySQL engines do not use LISTEN/NOTIFY live monitoring.
+            _ => SourceCaps {
+                supports_listen_notify: false,
+            },
         }
     }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -192,6 +192,7 @@ pub fn run() {
             database::commands::get_connection_history,
             // Mutation API commands
             database::commands::update_cell,
+            database::commands::get_blob_bytes,
             database::commands::delete_rows,
             database::commands::insert_row,
             database::commands::duplicate_row,

--- a/apps/desktop/src/lib/bindings.ts
+++ b/apps/desktop/src/lib/bindings.ts
@@ -463,6 +463,14 @@ async updateCell(connectionId: string, tableName: string, schemaName: string | n
     else return { status: "error", error: e  as any };
 }
 },
+async getBlobBytes(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValue: JsonValue, columnName: string) : Promise<Result<number[], { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_blob_bytes", { connectionId, tableName, schemaName, primaryKeyColumn, primaryKeyValue, columnName }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async deleteRows(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValues: JsonValue[]) : Promise<Result<MutationResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("delete_rows", { connectionId, tableName, schemaName, primaryKeyColumn, primaryKeyValues }) };
@@ -479,9 +487,9 @@ async duplicateRow(connectionId: string, tableName: string, schemaName: string |
     else return { status: "error", error: e  as any };
 }
 },
-async exportTable(connectionId: string, tableName: string, schemaName: string | null, format: ExportFormat, limit: number | null) : Promise<Result<string, { kind: string; detail: string }>> {
+async exportTable(connectionId: string, tableName: string, schemaName: string | null, format: ExportFormat, limit: number | null, whereClause: string | null, orderBy: string | null) : Promise<Result<string, { kind: string; detail: string }>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("export_table", { connectionId, tableName, schemaName, format, limit }) };
+    return { status: "ok", data: await TAURI_INVOKE("export_table", { connectionId, tableName, schemaName, format, limit, whereClause, orderBy }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/apps/marketing/src/core/content/changelog-data.ts
+++ b/apps/marketing/src/core/content/changelog-data.ts
@@ -21,7 +21,19 @@ export const CHANGELOG_RELEASES: ChangelogRelease[] = [
 		date: "2026-06-14",
 		tagUrl: "https://github.com/remcostoeten/dora/releases/tag/vUnreleased",
 		groups: [
-
+			{
+				name: "Bug Fixes",
+				items: [
+				"AI provider errors now use clear, consistent copy across all providers (Groq, OpenAI, Anthropic, Gemini, Ollama): rate limits, invalid keys, missing models, and an offline Ollama daemon each surface an actionable message instead of a raw HTTP status and response body (#82)",
+				"the AI rate-limit message includes a retry hint so the user knows to wait and try again (#82)",
+				]
+			},
+			{
+				name: "Documentation",
+				items: [
+				"AI Keys settings now spell out that Groq/OpenAI/Anthropic/Gemini need an API key while Ollama runs locally with no key, pointing to `docs/ai-providers.md` for setup (#82)",
+				]
+			}
 		]
 	},
 	{

--- a/docker-compose.databases.yml
+++ b/docker-compose.databases.yml
@@ -27,8 +27,9 @@ services:
     command:
       - start-single-node
       - --insecure
-      - --listen-addr=0.0.0.0:26257
-      - --http-addr=0.0.0.0:8080
+      # CockroachDB v24+ rejects an explicit 0.0.0.0 host; ":port" binds all interfaces.
+      - --listen-addr=:26257
+      - --http-addr=:8080
       - --advertise-addr=cockroach:26257
       - --store=/cockroach-data
     ports:

--- a/packages/studio/src/core/data-provider/adapters/mock.ts
+++ b/packages/studio/src/core/data-provider/adapters/mock.ts
@@ -1,9 +1,13 @@
 import type {
 	TableData,
 	SortDescriptor,
+	FilterCondition,
+	FilterConjunction,
 	FilterDescriptor,
+	FilterGroup,
 	ColumnDefinition
 } from '@studio/features/database-studio/types'
+import { isFilterGroup } from '@studio/features/database-studio/types'
 import type {
 	ConnectionInfo,
 	DatabaseSchema,
@@ -165,6 +169,61 @@ function delay(ms: number): Promise<void> {
 
 function randomDelay(): Promise<void> {
 	return delay(50 + Math.random() * 100)
+}
+
+/** Evaluates a single leaf condition against a row (mock in-memory filtering). */
+function evalCondition(row: Record<string, unknown>, f: FilterCondition): boolean {
+	const val = row[f.column]
+	const target = f.value
+	switch (f.operator) {
+		case 'eq':
+			return val === target
+		case 'neq':
+			return val !== target
+		case 'gt':
+			return Number(val) > Number(target)
+		case 'gte':
+			return Number(val) >= Number(target)
+		case 'lt':
+			return Number(val) < Number(target)
+		case 'lte':
+			return Number(val) <= Number(target)
+		case 'contains':
+		case 'ilike':
+			return String(val).toLowerCase().includes(String(target).toLowerCase())
+		default:
+			return true
+	}
+}
+
+/** Recursively evaluates a structured filter group against a row. */
+function evalGroup(row: Record<string, unknown>, group: FilterGroup): boolean {
+	const results = group.conditions
+		.map(function (node) {
+			return isFilterGroup(node) ? evalGroup(row, node) : evalCondition(row, node)
+		})
+	if (results.length === 0) return true
+	return group.logic === 'OR' ? results.some(Boolean) : results.every(Boolean)
+}
+
+/** Builds a row predicate from either a structured group or a legacy flat list. */
+function buildRowPredicate(
+	filterGroup: FilterGroup | undefined,
+	filters: FilterDescriptor[] | undefined,
+	conjunction: FilterConjunction
+): ((row: Record<string, unknown>) => boolean) | null {
+	if (filterGroup && filterGroup.conditions.length > 0) {
+		return function (row) {
+			return evalGroup(row, filterGroup)
+		}
+	}
+	if (filters && filters.length > 0) {
+		const group: FilterGroup = { logic: conjunction, conditions: filters }
+		return function (row) {
+			return evalGroup(row, group)
+		}
+	}
+	return null
 }
 
 function getTableLookupCandidates(tableName: string): string[] {
@@ -446,7 +505,9 @@ CREATE TABLE posts (
 			page: number,
 			pageSize: number,
 			sort?: SortDescriptor,
-			filters?: FilterDescriptor[]
+			filters?: FilterDescriptor[],
+			conjunction?: FilterConjunction,
+			filterGroup?: FilterGroup
 		): Promise<AdapterResult<TableData>> {
 			await randomDelay()
 
@@ -460,35 +521,9 @@ CREATE TABLE posts (
 
 			let filtered = rows.slice()
 
-			if (filters && filters.length > 0) {
-				filtered = filtered.filter(function (row) {
-					return filters.every(function (f) {
-						const val = row[f.column]
-						const target = f.value
-
-						switch (f.operator) {
-							case 'eq':
-								return val === target
-							case 'neq':
-								return val !== target
-							case 'gt':
-								return Number(val) > Number(target)
-							case 'gte':
-								return Number(val) >= Number(target)
-							case 'lt':
-								return Number(val) < Number(target)
-							case 'lte':
-								return Number(val) <= Number(target)
-							case 'contains':
-							case 'ilike':
-								return String(val)
-									.toLowerCase()
-									.includes(String(target).toLowerCase())
-							default:
-								return true
-						}
-					})
-				})
+			const predicate = buildRowPredicate(filterGroup, filters, conjunction ?? 'AND')
+			if (predicate) {
+				filtered = filtered.filter(predicate)
 			}
 
 			if (sort) {

--- a/packages/studio/src/core/data-provider/adapters/tauri.ts
+++ b/packages/studio/src/core/data-provider/adapters/tauri.ts
@@ -3,9 +3,10 @@ import type {
 	SortDescriptor,
 	FilterDescriptor,
 	FilterConjunction,
+	FilterGroup,
 	ColumnDefinition
 } from '@studio/features/database-studio/types'
-import { buildWhereClause } from '../filter-sql'
+import { buildWhereClauseFrom } from '../filter-sql'
 import type {
 	ConnectionInfo,
 	DatabaseSchema,
@@ -244,13 +245,14 @@ export function createTauriAdapter(): DataAdapter {
 			pageSize: number,
 			sort?: SortDescriptor,
 			filters?: FilterDescriptor[],
-			conjunction?: FilterConjunction
+			conjunction?: FilterConjunction,
+			filterGroup?: FilterGroup
 		): Promise<AdapterResult<TableData>> {
 			const startTime = performance.now()
 			const dialect = await resolveConnectionDialect(connectionId)
 			let query = `SELECT * FROM ${getTableSqlIdentifier(tableName, dialect)}`
 
-			const whereClause = buildWhereClause(filters, conjunction)
+			const whereClause = buildWhereClauseFrom(filterGroup, filters, conjunction)
 			if (whereClause) {
 				query += ' WHERE ' + whereClause
 			}

--- a/packages/studio/src/core/data-provider/filter-sql.ts
+++ b/packages/studio/src/core/data-provider/filter-sql.ts
@@ -1,8 +1,11 @@
 import type {
+	FilterCondition,
 	FilterConjunction,
 	FilterDescriptor,
+	FilterGroup,
 	FilterOperator
 } from '@studio/features/database-studio/types'
+import { isFilterGroup } from '@studio/features/database-studio/types'
 
 /** Maps a filter operator to its SQL representation. */
 export function operatorToSql(op: FilterOperator | string): string {
@@ -40,4 +43,80 @@ export function buildWhereClause(
 ): string {
 	if (!filters || filters.length === 0) return ''
 	return filters.map(buildFilterCondition).join(` ${conjunction} `)
+}
+
+/** Returns true when a leaf condition is complete enough to emit SQL. */
+function isUsableCondition(node: FilterCondition): boolean {
+	return Boolean(node.column) && Boolean(node.operator)
+}
+
+/**
+ * Builds a parenthesised WHERE clause body (without the leading `WHERE`) from a
+ * structured {@link FilterGroup}, recursing over nested groups. Empty groups and
+ * incomplete conditions are skipped. Value escaping reuses
+ * {@link buildFilterCondition}, exactly mirroring the flat-list path, so no new
+ * (less safe) escaping is introduced.
+ */
+export function buildWhereClauseFromGroup(group: FilterGroup | undefined): string {
+	if (!group) return ''
+	const parts: string[] = []
+	for (const node of group.conditions) {
+		if (isFilterGroup(node)) {
+			const nested = buildWhereClauseFromGroup(node)
+			if (nested) parts.push(`(${nested})`)
+		} else if (isUsableCondition(node)) {
+			parts.push(buildFilterCondition(node))
+		}
+	}
+	return parts.join(` ${group.logic} `)
+}
+
+/**
+ * Backward-compatible bridge: builds a WHERE clause body from either a
+ * structured group (preferred) or a legacy flat filter list. When a group is
+ * provided it takes precedence.
+ */
+export function buildWhereClauseFrom(
+	group: FilterGroup | undefined,
+	filters: FilterDescriptor[] | undefined,
+	conjunction: FilterConjunction = 'AND'
+): string {
+	if (group && group.conditions.length > 0) return buildWhereClauseFromGroup(group)
+	return buildWhereClause(filters, conjunction)
+}
+
+/**
+ * Lifts a legacy flat filter list into the root {@link FilterGroup} model so the
+ * rest of the app can work with a single representation. Persisted flat lists
+ * (#98) remain readable through this.
+ */
+export function flatFiltersToGroup(
+	filters: FilterDescriptor[] | undefined,
+	conjunction: FilterConjunction = 'AND'
+): FilterGroup {
+	return {
+		logic: conjunction,
+		conditions: (filters ?? []).map(function (f) {
+			return { column: f.column, operator: f.operator, value: f.value }
+		})
+	}
+}
+
+/**
+ * Flattens the root group back to a legacy flat filter list, ignoring nested
+ * groups. Used to keep the old `filters`/`conjunction` props populated for any
+ * consumer (or persisted state) that still reads them.
+ */
+export function groupToFlatFilters(group: FilterGroup | undefined): {
+	filters: FilterDescriptor[]
+	conjunction: FilterConjunction
+} {
+	if (!group) return { filters: [], conjunction: 'AND' }
+	const filters: FilterDescriptor[] = []
+	for (const node of group.conditions) {
+		if (!isFilterGroup(node)) {
+			filters.push({ column: node.column, operator: node.operator, value: node.value })
+		}
+	}
+	return { filters, conjunction: group.logic }
 }

--- a/packages/studio/src/core/data-provider/types.ts
+++ b/packages/studio/src/core/data-provider/types.ts
@@ -3,6 +3,7 @@ import type {
 	SortDescriptor,
 	FilterDescriptor,
 	FilterConjunction,
+	FilterGroup,
 	ColumnDefinition
 } from '@studio/features/database-studio/types'
 import {
@@ -86,7 +87,8 @@ export type DataAdapter = {
 		pageSize: number,
 		sort?: SortDescriptor,
 		filters?: FilterDescriptor[],
-		conjunction?: FilterConjunction
+		conjunction?: FilterConjunction,
+		filterGroup?: FilterGroup
 	): Promise<AdapterResult<TableData>>
 
 	executeQuery(connectionId: string, query: string): Promise<AdapterResult<QueryResult>>

--- a/packages/studio/src/core/settings/settings-store.tsx
+++ b/packages/studio/src/core/settings/settings-store.tsx
@@ -18,6 +18,7 @@ export type SettingsState = {
 	editorTheme: EditorTheme
 	enableVimMode: boolean
 	restoreLastConnection: boolean
+	restoreTabsOnLaunch: boolean
 	startupConnectionMode: 'auto' | 'empty'
 	lastConnectionId: string | null
 	lastTableId: string | null
@@ -32,6 +33,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
 	editorTheme: 'auto',
 	enableVimMode: false,
 	restoreLastConnection: true,
+	restoreTabsOnLaunch: true,
 	startupConnectionMode: 'auto',
 	lastConnectionId: null,
 	lastTableId: null,
@@ -112,6 +114,10 @@ export function sanitizeSettings(value: unknown): SettingsState {
 				? value.enableVimMode
 				: DEFAULT_SETTINGS.enableVimMode,
 		restoreLastConnection: startupConnectionMode === 'auto',
+		restoreTabsOnLaunch:
+			typeof value.restoreTabsOnLaunch === 'boolean'
+				? value.restoreTabsOnLaunch
+				: DEFAULT_SETTINGS.restoreTabsOnLaunch,
 		startupConnectionMode,
 		lastConnectionId: optionalString(value.lastConnectionId),
 		lastTableId: optionalString(value.lastTableId),

--- a/packages/studio/src/core/shortcuts/shortcuts.ts
+++ b/packages/studio/src/core/shortcuts/shortcuts.ts
@@ -84,6 +84,8 @@ export const APP_SHORTCUTS = {
 	switchConnection7: { combo: 'mod+7', description: 'Switch to connection 7', scope: 'global' },
 	switchConnection8: { combo: 'mod+8', description: 'Switch to connection 8', scope: 'global' },
 	switchConnection9: { combo: 'mod+9', description: 'Switch to connection 9', scope: 'global' },
+	prevConnection: { combo: 'ctrl+shift+bracketleft', description: 'Previous open connection', scope: 'global' },
+	nextConnection: { combo: 'ctrl+shift+bracketright', description: 'Next open connection', scope: 'global' },
 
 	// ── Go-To chords (G → key) ───────────────────────────────────────────────
 	gotoDashboard:   { combo: 'g d', description: 'Go to dashboard',   scope: 'global' },
@@ -243,6 +245,7 @@ export const SHORTCUT_CATEGORIES: Record<string, ShortcutName[]> = {
 		'switchConnection1', 'switchConnection2', 'switchConnection3',
 		'switchConnection4', 'switchConnection5', 'switchConnection6',
 		'switchConnection7', 'switchConnection8', 'switchConnection9',
+		'prevConnection', 'nextConnection',
 	],
 	'Go To (G → key)': [
 		'gotoDashboard', 'gotoSettings', 'gotoConnections', 'gotoEditor', 'gotoDocker',

--- a/packages/studio/src/core/tabs/session-persistence.ts
+++ b/packages/studio/src/core/tabs/session-persistence.ts
@@ -1,0 +1,195 @@
+import type { Tab } from './tabs-store'
+
+// Tab session persistence (issue #98).
+//
+// We persist the open tabs so Dora reopens where you left off. localStorage is
+// reused here because it already backs tab state in this codebase, works in
+// both the Tauri webview and the web build, and needs no async plumbing — so
+// hydration is synchronous and never blocks cold start. Only serializable tab
+// identity is stored; live result data lives outside the Tab and repopulates
+// lazily on reconnect.
+
+export const SESSION_STORAGE_KEY = 'dora-session'
+
+// v2 adds multi-connection session state (issue #96): the active connection and
+// the set of open connections. v1 payloads (tabs only) are tolerated and
+// upgraded on read by deriving the connection fields from the tabs.
+const SESSION_VERSION = 2
+
+// A Tab today carries only serializable identity (connection + table + label +
+// pinned). If richer kinds (sql-console query text, filter/sort config) are
+// added to Tab later, list them here so they round-trip through persistence.
+export type SerializedTab = {
+	id: string
+	connectionId: string
+	tableId: string
+	tableName: string
+	label: string
+	pinned: boolean
+}
+
+export type SerializedSession = {
+	version: number
+	tabs: SerializedTab[]
+	activeTabId: string | null
+	// Multi-connection session (issue #96).
+	activeConnectionId: string
+	openConnectionIds: string[]
+	// Per-connection active tab id so each connection restores its focused tab.
+	activeTabByConnection: Record<string, string>
+}
+
+export type SessionInput = {
+	tabs: Tab[]
+	activeConnectionId: string
+	openConnectionIds: string[]
+	activeTabByConnection: Record<string, string>
+}
+
+function toSerializedTab(tab: Tab): SerializedTab {
+	return {
+		id: tab.id,
+		connectionId: tab.connectionId,
+		tableId: tab.tableId,
+		tableName: tab.tableName,
+		label: tab.label,
+		pinned: Boolean(tab.pinned)
+	}
+}
+
+export function serializeTabs(input: SessionInput): SerializedSession {
+	const activeTabId = input.activeTabByConnection[input.activeConnectionId] ?? null
+	return {
+		version: SESSION_VERSION,
+		tabs: input.tabs.map(toSerializedTab),
+		activeTabId,
+		activeConnectionId: input.activeConnectionId,
+		openConnectionIds: input.openConnectionIds,
+		activeTabByConnection: input.activeTabByConnection
+	}
+}
+
+function isSerializedTab(value: unknown): value is SerializedTab {
+	if (!value || typeof value !== 'object') return false
+	const tab = value as Record<string, unknown>
+	return (
+		typeof tab.id === 'string' &&
+		typeof tab.connectionId === 'string' &&
+		typeof tab.tableId === 'string' &&
+		typeof tab.tableName === 'string' &&
+		typeof tab.label === 'string'
+	)
+}
+
+function emptySession(): SerializedSession {
+	return {
+		version: SESSION_VERSION,
+		tabs: [],
+		activeTabId: null,
+		activeConnectionId: '',
+		openConnectionIds: [],
+		activeTabByConnection: {}
+	}
+}
+
+// Validate a raw persisted payload. Tolerates v1 (tabs-only) payloads by
+// deriving the multi-connection fields from the tabs. Returns an empty session
+// on any unknown version or shape error so a stale/corrupt blob can never break
+// startup.
+export function deserializeTabs(raw: unknown): SerializedSession {
+	if (!raw || typeof raw !== 'object') return emptySession()
+	const parsed = raw as Record<string, unknown>
+	// Accept v1 and v2; anything else is treated as unknown/corrupt.
+	if (parsed.version !== 1 && parsed.version !== SESSION_VERSION) return emptySession()
+	if (!Array.isArray(parsed.tabs)) return emptySession()
+
+	const tabs: SerializedTab[] = parsed.tabs.filter(isSerializedTab).map((tab) => ({
+		id: tab.id,
+		connectionId: tab.connectionId,
+		tableId: tab.tableId,
+		tableName: tab.tableName,
+		label: tab.label,
+		pinned: Boolean(tab.pinned)
+	}))
+
+	const activeTabId =
+		typeof parsed.activeTabId === 'string' && tabs.some((t) => t.id === parsed.activeTabId)
+			? parsed.activeTabId
+			: (tabs[tabs.length - 1]?.id ?? null)
+
+	// Open connections: from payload (v2), filtered to those still referenced by
+	// a tab; otherwise derived from the tabs in first-seen order (v1 upgrade).
+	const tabConnectionIds: string[] = []
+	for (const tab of tabs) {
+		if (!tabConnectionIds.includes(tab.connectionId)) tabConnectionIds.push(tab.connectionId)
+	}
+
+	const rawOpen = Array.isArray(parsed.openConnectionIds)
+		? (parsed.openConnectionIds.filter((id) => typeof id === 'string') as string[])
+		: null
+	const openConnectionIds = (rawOpen ?? tabConnectionIds).filter((id) =>
+		tabConnectionIds.includes(id)
+	)
+
+	// Per-connection active tab: from payload (v2) validated against surviving
+	// tabs; otherwise derive each connection's last tab (or the global active
+	// tab) for v1 upgrade.
+	const activeTabByConnection: Record<string, string> = {}
+	const rawMap =
+		parsed.activeTabByConnection && typeof parsed.activeTabByConnection === 'object'
+			? (parsed.activeTabByConnection as Record<string, unknown>)
+			: {}
+	for (const connectionId of openConnectionIds) {
+		const own = tabs.filter((t) => t.connectionId === connectionId)
+		if (own.length === 0) continue
+		const candidate = rawMap[connectionId]
+		const valid = typeof candidate === 'string' && own.some((t) => t.id === candidate)
+		if (valid) {
+			activeTabByConnection[connectionId] = candidate as string
+		} else if (activeTabId && own.some((t) => t.id === activeTabId)) {
+			activeTabByConnection[connectionId] = activeTabId
+		} else {
+			activeTabByConnection[connectionId] = own[own.length - 1].id
+		}
+	}
+
+	const rawActiveConnection =
+		typeof parsed.activeConnectionId === 'string' ? parsed.activeConnectionId : ''
+	const activeConnectionId = openConnectionIds.includes(rawActiveConnection)
+		? rawActiveConnection
+		: (openConnectionIds[openConnectionIds.length - 1] ?? '')
+
+	return {
+		version: SESSION_VERSION,
+		tabs,
+		activeTabId,
+		activeConnectionId,
+		openConnectionIds,
+		activeTabByConnection
+	}
+}
+
+export function readSession(): SerializedSession {
+	if (typeof window === 'undefined') {
+		return emptySession()
+	}
+	try {
+		const raw = window.localStorage.getItem(SESSION_STORAGE_KEY)
+		if (!raw) return emptySession()
+		return deserializeTabs(JSON.parse(raw))
+	} catch {
+		return emptySession()
+	}
+}
+
+export function writeSession(input: SessionInput): void {
+	if (typeof window === 'undefined') return
+	try {
+		window.localStorage.setItem(
+			SESSION_STORAGE_KEY,
+			JSON.stringify(serializeTabs(input))
+		)
+	} catch {
+		// Best-effort: ignore quota/serialization errors.
+	}
+}

--- a/packages/studio/src/core/tabs/tabs-store.tsx
+++ b/packages/studio/src/core/tabs/tabs-store.tsx
@@ -1,4 +1,5 @@
-import { createContext, useCallback, useContext, useEffect, useReducer, ReactNode } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useReducer, ReactNode } from 'react'
+import { readSession, writeSession } from './session-persistence'
 
 export type Tab = {
   id: string
@@ -12,8 +13,17 @@ export type Tab = {
 type OpenTabArgs = Omit<Tab, 'id'>
 
 type TabsContextValue = {
+  // All tabs across every open connection (flat). Most consumers want the tabs
+  // scoped to the active connection — use `visibleTabs` for that.
   tabs: Tab[]
+  // Tabs belonging to the active connection only (issue #96). The table TabBar
+  // renders these so each connection keeps its own isolated tab group.
+  visibleTabs: Tab[]
   activeTabId: string | null
+  // The connection whose tab group is currently shown. Empty string means none.
+  activeConnectionId: string
+  // Connections the user has open (one connection tab each, in open order).
+  openConnectionIds: string[]
   openTab: (args: OpenTabArgs) => void
   closeTab: (id: string) => void
   closeOtherTabs: (id: string) => void
@@ -23,6 +33,20 @@ type TabsContextValue = {
   togglePinTab: (id: string) => void
   reorderTab: (fromId: string, toId: string) => void
   closeTabsForConnection: (connectionId: string) => void
+  hydrateSession: (args: HydrateSessionArgs) => void
+  // Multi-connection (issue #96).
+  setActiveConnection: (connectionId: string) => void
+  openConnection: (connectionId: string) => void
+  closeConnection: (connectionId: string) => void
+}
+
+// Applied once the data needed to validate the restored session is available
+// (the user's "restore tabs" preference and the set of connections that still
+// exist). Pinned tabs always restore; unpinned tabs only when restoreUnpinned
+// is true. Tabs whose connection no longer exists are dropped.
+type HydrateSessionArgs = {
+  restoreUnpinned: boolean
+  knownConnectionIds: ReadonlySet<string>
 }
 
 const TabsContext = createContext<TabsContextValue | null>(null)
@@ -30,8 +54,17 @@ const TabsContext = createContext<TabsContextValue | null>(null)
 const MAX_TABS = 12
 
 type State = {
+  // Flat list of every tab across all open connections. Per-connection grouping
+  // is derived by filtering on `Tab.connectionId` (issue #96) — keeping the list
+  // flat preserves drag-reorder (#105) and session persistence (#98) unchanged.
   tabs: Tab[]
-  activeTabId: string | null
+  // The connection whose tab group is visible. '' means none selected yet.
+  activeConnectionId: string
+  // Open connections in the order their connection tabs appear.
+  openConnectionIds: string[]
+  // Per-connection active tab id, so switching connections restores the tab the
+  // user last had focused there. Keyed by connectionId.
+  activeTabByConnection: Record<string, string>
 }
 
 type Action =
@@ -44,6 +77,10 @@ type Action =
   | { type: 'TOGGLE_PIN_TAB'; id: string }
   | { type: 'MOVE_TAB'; fromId: string; toId: string }
   | { type: 'CLOSE_FOR_CONNECTION'; connectionId: string }
+  | { type: 'HYDRATE_SESSION'; args: HydrateSessionArgs }
+  | { type: 'SET_ACTIVE_CONNECTION'; connectionId: string }
+  | { type: 'OPEN_CONNECTION'; connectionId: string }
+  | { type: 'CLOSE_CONNECTION'; connectionId: string }
 
 function resolveActiveTabId(
   tabs: Tab[],
@@ -83,63 +120,181 @@ function appendWithTabLimit(tabs: Tab[], newTab: Tab): Tab[] {
   return [...tabs.slice(0, removeIndex), ...tabs.slice(removeIndex + 1), newTab]
 }
 
+// Active tab id of the currently active connection (the "single" active tab the
+// rest of the UI cares about). Derived from the per-connection map.
+function activeTabIdOf(state: State): string | null {
+  return state.activeTabByConnection[state.activeConnectionId] ?? null
+}
+
+function tabsForConnection(tabs: Tab[], connectionId: string): Tab[] {
+  return tabs.filter((t) => t.connectionId === connectionId)
+}
+
+// Update the active-tab map for a single connection. Passing null removes the
+// entry so an orphaned id is never left behind.
+function withActiveTab(
+  map: Record<string, string>,
+  connectionId: string,
+  tabId: string | null
+): Record<string, string> {
+  const next = { ...map }
+  if (tabId === null) delete next[connectionId]
+  else next[connectionId] = tabId
+  return next
+}
+
+// Ensure a connection is registered as open and active. Used whenever a tab is
+// opened or selected so the connection tab bar always reflects reality.
+function ensureOpenAndActive(state: State, connectionId: string): State {
+  const openConnectionIds = state.openConnectionIds.includes(connectionId)
+    ? state.openConnectionIds
+    : [...state.openConnectionIds, connectionId]
+  return { ...state, openConnectionIds, activeConnectionId: connectionId }
+}
+
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'OPEN_TAB': {
+      const connectionId = action.args.connectionId
+      const base = ensureOpenAndActive(state, connectionId)
       const existing = state.tabs.find(
-        (t) => t.connectionId === action.args.connectionId && t.tableId === action.args.tableId
+        (t) => t.connectionId === connectionId && t.tableId === action.args.tableId
       )
       if (existing) {
-        return { ...state, activeTabId: existing.id }
+        return {
+          ...base,
+          activeTabByConnection: withActiveTab(
+            base.activeTabByConnection,
+            connectionId,
+            existing.id
+          ),
+        }
       }
       const newTab: Tab = { ...action.args, id: crypto.randomUUID() }
-      const tabs = appendWithTabLimit(state.tabs, newTab)
-      return { tabs, activeTabId: newTab.id }
+      // Apply the tab limit per-connection so one connection can't evict another
+      // connection's tabs.
+      const others = state.tabs.filter((t) => t.connectionId !== connectionId)
+      const own = tabsForConnection(state.tabs, connectionId)
+      const ownWithNew = appendWithTabLimit(own, newTab)
+      const tabs = [...others, ...ownWithNew]
+      return {
+        ...base,
+        tabs,
+        activeTabByConnection: withActiveTab(
+          base.activeTabByConnection,
+          connectionId,
+          newTab.id
+        ),
+      }
     }
     case 'CLOSE_TAB': {
-      const idx = state.tabs.findIndex((t) => t.id === action.id)
-      if (idx === -1) return state
+      const target = state.tabs.find((t) => t.id === action.id)
+      if (!target) return state
+      const connectionId = target.connectionId
+      const own = tabsForConnection(state.tabs, connectionId)
+      const idxInOwn = own.findIndex((t) => t.id === action.id)
       const tabs = state.tabs.filter((t) => t.id !== action.id)
-      let activeTabId = state.activeTabId
-      if (state.activeTabId === action.id) {
-        activeTabId = tabs.length === 0 ? null : tabs[Math.min(idx, tabs.length - 1)].id
+      let activeTabByConnection = state.activeTabByConnection
+      if (state.activeTabByConnection[connectionId] === action.id) {
+        const ownAfter = own.filter((t) => t.id !== action.id)
+        const nextActive =
+          ownAfter.length === 0 ? null : ownAfter[Math.min(idxInOwn, ownAfter.length - 1)].id
+        activeTabByConnection = withActiveTab(activeTabByConnection, connectionId, nextActive)
       }
-      return { tabs, activeTabId }
+      return { ...state, tabs, activeTabByConnection }
     }
     case 'CLOSE_OTHER_TABS': {
       const current = state.tabs.find((t) => t.id === action.id)
       if (!current) return state
-      const tabs = state.tabs.filter((t) => t.id === action.id || t.pinned)
-      return { tabs, activeTabId: action.id }
+      const connectionId = current.connectionId
+      const tabs = state.tabs.filter(
+        (t) => t.connectionId !== connectionId || t.id === action.id || t.pinned
+      )
+      return {
+        ...state,
+        tabs,
+        activeTabByConnection: withActiveTab(state.activeTabByConnection, connectionId, action.id),
+      }
     }
     case 'CLOSE_TABS_TO_LEFT': {
-      const idx = state.tabs.findIndex((t) => t.id === action.id)
+      const current = state.tabs.find((t) => t.id === action.id)
+      if (!current) return state
+      const connectionId = current.connectionId
+      const own = tabsForConnection(state.tabs, connectionId)
+      const idx = own.findIndex((t) => t.id === action.id)
       if (idx === -1) return state
-      const tabs = state.tabs.filter((t, index) => index >= idx || t.pinned)
-      return { tabs, activeTabId: resolveActiveTabId(tabs, state.activeTabId, action.id) }
+      const keepIds = new Set(own.filter((t, i) => i >= idx || t.pinned).map((t) => t.id))
+      const tabs = state.tabs.filter((t) => t.connectionId !== connectionId || keepIds.has(t.id))
+      const ownAfter = tabsForConnection(tabs, connectionId)
+      const nextActive = resolveActiveTabId(
+        ownAfter,
+        state.activeTabByConnection[connectionId] ?? null,
+        action.id
+      )
+      return {
+        ...state,
+        tabs,
+        activeTabByConnection: withActiveTab(state.activeTabByConnection, connectionId, nextActive),
+      }
     }
     case 'CLOSE_TABS_TO_RIGHT': {
-      const idx = state.tabs.findIndex((t) => t.id === action.id)
+      const current = state.tabs.find((t) => t.id === action.id)
+      if (!current) return state
+      const connectionId = current.connectionId
+      const own = tabsForConnection(state.tabs, connectionId)
+      const idx = own.findIndex((t) => t.id === action.id)
       if (idx === -1) return state
-      const tabs = state.tabs.filter((t, index) => index <= idx || t.pinned)
-      return { tabs, activeTabId: resolveActiveTabId(tabs, state.activeTabId, action.id) }
+      const keepIds = new Set(own.filter((t, i) => i <= idx || t.pinned).map((t) => t.id))
+      const tabs = state.tabs.filter((t) => t.connectionId !== connectionId || keepIds.has(t.id))
+      const ownAfter = tabsForConnection(tabs, connectionId)
+      const nextActive = resolveActiveTabId(
+        ownAfter,
+        state.activeTabByConnection[connectionId] ?? null,
+        action.id
+      )
+      return {
+        ...state,
+        tabs,
+        activeTabByConnection: withActiveTab(state.activeTabByConnection, connectionId, nextActive),
+      }
     }
     case 'SET_ACTIVE': {
-      return { ...state, activeTabId: action.id }
+      const target = state.tabs.find((t) => t.id === action.id)
+      if (!target) return state
+      const base = ensureOpenAndActive(state, target.connectionId)
+      return {
+        ...base,
+        activeTabByConnection: withActiveTab(
+          base.activeTabByConnection,
+          target.connectionId,
+          action.id
+        ),
+      }
     }
     case 'TOGGLE_PIN_TAB': {
-      const tabs = state.tabs.map((tab) =>
+      const target = state.tabs.find((t) => t.id === action.id)
+      if (!target) return state
+      const connectionId = target.connectionId
+      const own = tabsForConnection(state.tabs, connectionId).map((tab) =>
         tab.id === action.id ? { ...tab, pinned: !tab.pinned } : tab
       )
-      return { ...state, tabs: movePinnedTab(tabs, action.id) }
+      const reordered = movePinnedTab(own, action.id)
+      const others = state.tabs.filter((t) => t.connectionId !== connectionId)
+      return { ...state, tabs: [...others, ...reordered] }
     }
     case 'MOVE_TAB': {
       if (action.fromId === action.toId) return state
-      const fromIdx = state.tabs.findIndex((t) => t.id === action.fromId)
-      const toIdx = state.tabs.findIndex((t) => t.id === action.toId)
+      const from = state.tabs.find((t) => t.id === action.fromId)
+      const to = state.tabs.find((t) => t.id === action.toId)
+      // Reorder only within a single connection's tab group.
+      if (!from || !to || from.connectionId !== to.connectionId) return state
+      const connectionId = from.connectionId
+      const own = tabsForConnection(state.tabs, connectionId)
+      const fromIdx = own.findIndex((t) => t.id === action.fromId)
+      const toIdx = own.findIndex((t) => t.id === action.toId)
       if (fromIdx === -1 || toIdx === -1) return state
 
-      const next = [...state.tabs]
+      const next = [...own]
       const [moved] = next.splice(fromIdx, 1)
       // Insert at the target's original index so the dragged tab takes the
       // target's slot (dropping after it when moving right, before it when
@@ -150,52 +305,91 @@ function reducer(state: State, action: Action): State {
       // matching the invariant used elsewhere in the store.
       const pinned = next.filter((t) => t.pinned)
       const unpinned = next.filter((t) => !t.pinned)
-      return { ...state, tabs: [...pinned, ...unpinned] }
+      const others = state.tabs.filter((t) => t.connectionId !== connectionId)
+      return { ...state, tabs: [...others, ...pinned, ...unpinned] }
     }
     case 'CLOSE_FOR_CONNECTION': {
       const tabs = state.tabs.filter((t) => t.connectionId !== action.connectionId)
-      const stillExists = tabs.find((t) => t.id === state.activeTabId)
-      const activeTabId = stillExists ? state.activeTabId : (tabs[tabs.length - 1]?.id ?? null)
-      return { tabs, activeTabId }
+      return {
+        ...state,
+        tabs,
+        activeTabByConnection: withActiveTab(state.activeTabByConnection, action.connectionId, null),
+      }
+    }
+    case 'HYDRATE_SESSION': {
+      const { restoreUnpinned, knownConnectionIds } = action.args
+      const tabs = state.tabs.filter((tab) => {
+        if (!knownConnectionIds.has(tab.connectionId)) return false
+        return tab.pinned ? true : restoreUnpinned
+      })
+      // Prune open connections / active-tab map to those still backed by a tab
+      // or a known connection.
+      const survivingConnectionIds = new Set(tabs.map((t) => t.connectionId))
+      const openConnectionIds = state.openConnectionIds.filter(
+        (id) => knownConnectionIds.has(id) && survivingConnectionIds.has(id)
+      )
+      const activeTabByConnection: Record<string, string> = {}
+      for (const id of openConnectionIds) {
+        const own = tabsForConnection(tabs, id)
+        const next = resolveActiveTabId(own, state.activeTabByConnection[id] ?? null)
+        if (next) activeTabByConnection[id] = next
+      }
+      const activeConnectionId =
+        state.activeConnectionId && openConnectionIds.includes(state.activeConnectionId)
+          ? state.activeConnectionId
+          : (openConnectionIds[openConnectionIds.length - 1] ?? '')
+      if (
+        tabs.length === state.tabs.length &&
+        openConnectionIds.length === state.openConnectionIds.length
+      ) {
+        return { ...state, activeConnectionId, activeTabByConnection }
+      }
+      return { ...state, tabs, openConnectionIds, activeConnectionId, activeTabByConnection }
+    }
+    case 'SET_ACTIVE_CONNECTION': {
+      if (action.connectionId === state.activeConnectionId) return state
+      return ensureOpenAndActive(state, action.connectionId)
+    }
+    case 'OPEN_CONNECTION': {
+      return ensureOpenAndActive(state, action.connectionId)
+    }
+    case 'CLOSE_CONNECTION': {
+      const connectionId = action.connectionId
+      const tabs = state.tabs.filter((t) => t.connectionId !== connectionId)
+      const openConnectionIds = state.openConnectionIds.filter((id) => id !== connectionId)
+      const activeTabByConnection = withActiveTab(state.activeTabByConnection, connectionId, null)
+      let activeConnectionId = state.activeConnectionId
+      if (state.activeConnectionId === connectionId) {
+        // Switch to the connection nearest the one being closed.
+        const closedIdx = state.openConnectionIds.indexOf(connectionId)
+        activeConnectionId =
+          openConnectionIds[Math.min(closedIdx, openConnectionIds.length - 1)] ?? ''
+      }
+      return { tabs, openConnectionIds, activeConnectionId, activeTabByConnection }
     }
     default:
       return state
   }
 }
 
-const initialState: State = { tabs: [], activeTabId: null }
-
-// Persist open tabs so Dora reopens where you left off. localStorage works in
-// both the Tauri webview and the web build and needs no async plumbing.
-const STORAGE_KEY = 'dora.tabs.v1'
-
-function isValidTab(value: unknown): value is Tab {
-  if (!value || typeof value !== 'object') return false
-  const tab = value as Record<string, unknown>
-  return (
-    typeof tab.id === 'string' &&
-    typeof tab.connectionId === 'string' &&
-    typeof tab.tableId === 'string' &&
-    typeof tab.tableName === 'string' &&
-    typeof tab.label === 'string'
-  )
+const initialState: State = {
+  tabs: [],
+  activeConnectionId: '',
+  openConnectionIds: [],
+  activeTabByConnection: {},
 }
 
+// Hydrate synchronously from the persisted session so restored tabs render on
+// the very first paint — cold start is never blocked. Tabs whose connection no
+// longer exists, and unpinned tabs when "restore on launch" is off, are pruned
+// later via HYDRATE_SESSION once that data is available (see Index.tsx).
 function loadInitialState(): State {
-  if (typeof window === 'undefined') return initialState
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY)
-    if (!raw) return initialState
-    const parsed = JSON.parse(raw) as { tabs?: unknown; activeTabId?: unknown }
-    if (!Array.isArray(parsed.tabs)) return initialState
-    const tabs = parsed.tabs.filter(isValidTab)
-    const activeTabId =
-      typeof parsed.activeTabId === 'string' && tabs.some((t) => t.id === parsed.activeTabId)
-        ? parsed.activeTabId
-        : (tabs[tabs.length - 1]?.id ?? null)
-    return { tabs, activeTabId }
-  } catch {
-    return initialState
+  const session = readSession()
+  return {
+    tabs: session.tabs,
+    activeConnectionId: session.activeConnectionId,
+    openConnectionIds: session.openConnectionIds,
+    activeTabByConnection: session.activeTabByConnection,
   }
 }
 
@@ -204,17 +398,14 @@ export function TabsProvider({ children }: { children: ReactNode }) {
 
   useEffect(
     function persistTabs() {
-      if (typeof window === 'undefined') return
-      try {
-        window.localStorage.setItem(
-          STORAGE_KEY,
-          JSON.stringify({ tabs: state.tabs, activeTabId: state.activeTabId })
-        )
-      } catch {
-        // Ignore quota/serialization errors — persistence is best-effort.
-      }
+      writeSession({
+        tabs: state.tabs,
+        activeConnectionId: state.activeConnectionId,
+        openConnectionIds: state.openConnectionIds,
+        activeTabByConnection: state.activeTabByConnection,
+      })
     },
-    [state.tabs, state.activeTabId]
+    [state.tabs, state.activeConnectionId, state.openConnectionIds, state.activeTabByConnection]
   )
 
   const openTab = useCallback((args: OpenTabArgs) => dispatch({ type: 'OPEN_TAB', args }), [])
@@ -232,10 +423,35 @@ export function TabsProvider({ children }: { children: ReactNode }) {
     (connectionId: string) => dispatch({ type: 'CLOSE_FOR_CONNECTION', connectionId }),
     []
   )
+  const hydrateSession = useCallback(
+    (args: HydrateSessionArgs) => dispatch({ type: 'HYDRATE_SESSION', args }),
+    []
+  )
+  const setActiveConnection = useCallback(
+    (connectionId: string) => dispatch({ type: 'SET_ACTIVE_CONNECTION', connectionId }),
+    []
+  )
+  const openConnection = useCallback(
+    (connectionId: string) => dispatch({ type: 'OPEN_CONNECTION', connectionId }),
+    []
+  )
+  const closeConnection = useCallback(
+    (connectionId: string) => dispatch({ type: 'CLOSE_CONNECTION', connectionId }),
+    []
+  )
+
+  const visibleTabs = useMemo(
+    () => state.tabs.filter((t) => t.connectionId === state.activeConnectionId),
+    [state.tabs, state.activeConnectionId]
+  )
+  const activeTabId = activeTabIdOf(state)
 
   const value: TabsContextValue = {
     tabs: state.tabs,
-    activeTabId: state.activeTabId,
+    visibleTabs,
+    activeTabId,
+    activeConnectionId: state.activeConnectionId,
+    openConnectionIds: state.openConnectionIds,
     openTab,
     closeTab,
     closeOtherTabs,
@@ -245,6 +461,10 @@ export function TabsProvider({ children }: { children: ReactNode }) {
     togglePinTab,
     reorderTab,
     closeTabsForConnection,
+    hydrateSession,
+    setActiveConnection,
+    openConnection,
+    closeConnection,
   }
 
   return <TabsContext.Provider value={value}>{children}</TabsContext.Provider>

--- a/packages/studio/src/features/connection-tab-bar/connection-tab-bar.tsx
+++ b/packages/studio/src/features/connection-tab-bar/connection-tab-bar.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from 'react'
+import { Plus, X } from 'lucide-react'
+import { cn } from '@studio/shared/utils/cn'
+import type { Connection } from '@studio/features/connections/types'
+
+// Connection tab bar (issue #96). Renders one tab per open connection above the
+// table TabBar so the user can keep several databases open at once and switch
+// between their isolated tab groups. A status dot mirrors the connection's live
+// state; the trailing + opens the existing connection dialog.
+
+type Props = {
+  // Connections the user has open, in display order.
+  connections: Connection[]
+  activeConnectionId: string
+  onSelect: (connectionId: string) => void
+  onClose: (connectionId: string) => void
+  onAddConnection: () => void
+  rightSlot?: ReactNode
+}
+
+function statusColor(status: Connection['status']): string {
+  switch (status) {
+    case 'connected':
+      return 'bg-green-500'
+    case 'error':
+      return 'bg-red-500'
+    case 'idle':
+    default:
+      // No definitive state yet — treat as connecting/idle.
+      return 'bg-amber-500'
+  }
+}
+
+function statusLabel(status: Connection['status']): string {
+  switch (status) {
+    case 'connected':
+      return 'Connected'
+    case 'error':
+      return 'Connection error'
+    default:
+      return 'Connecting'
+  }
+}
+
+export function ConnectionTabBar({
+  connections,
+  activeConnectionId,
+  onSelect,
+  onClose,
+  onAddConnection,
+  rightSlot,
+}: Props) {
+  return (
+    <div
+      className="flex items-center h-8 border-b border-border bg-sidebar shrink-0 select-none"
+      data-tauri-drag-region="true"
+    >
+      <div className="flex h-full min-w-0 flex-1 items-center overflow-x-auto scrollbar-none">
+        {connections.map((connection) => {
+          const isActive = connection.id === activeConnectionId
+          return (
+            <div
+              key={connection.id}
+              className={cn(
+                'relative flex items-center h-full shrink-0 border-r border-border transition-colors',
+                isActive
+                  ? 'bg-background text-foreground'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-sidebar-accent/50'
+              )}
+              data-tauri-drag-region="false"
+            >
+              <button
+                onClick={() => onSelect(connection.id)}
+                className="flex items-center gap-1.5 h-full px-2 pl-3 text-xs font-medium"
+                data-tauri-drag-region="false"
+                title={`${connection.name} — ${statusLabel(connection.status)}`}
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn('h-2 w-2 shrink-0 rounded-full', statusColor(connection.status))}
+                />
+                <span className="max-w-[140px] truncate">{connection.name}</span>
+              </button>
+              <button
+                aria-label={`Close ${connection.name}`}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onClose(connection.id)
+                }}
+                onAuxClick={(e) => {
+                  if (e.button === 1) {
+                    e.preventDefault()
+                    onClose(connection.id)
+                  }
+                }}
+                className="h-full px-1 pr-2 rounded hover:bg-sidebar-accent text-muted-foreground hover:text-foreground"
+                data-tauri-drag-region="false"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          )
+        })}
+        <button
+          aria-label="Add connection"
+          onClick={onAddConnection}
+          className="flex items-center justify-center h-full px-2 text-muted-foreground hover:text-foreground hover:bg-sidebar-accent/50"
+          data-tauri-drag-region="false"
+          title="Add connection"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      {rightSlot ? (
+        <div
+          className="flex h-full shrink-0 items-center border-l border-border px-1"
+          data-tauri-drag-region="false"
+        >
+          {rightSlot}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/studio/src/features/connection-tab-bar/index.ts
+++ b/packages/studio/src/features/connection-tab-bar/index.ts
@@ -1,0 +1,1 @@
+export { ConnectionTabBar } from './connection-tab-bar'

--- a/packages/studio/src/features/database-studio/components/cell-context-menu.tsx
+++ b/packages/studio/src/features/database-studio/components/cell-context-menu.tsx
@@ -5,10 +5,14 @@ import {
 	ContextMenuSeparator,
 	ContextMenuTrigger
 } from '@studio/shared/ui/context-menu'
-import { Copy, FileJson, Filter, Pencil, Trash2 } from 'lucide-react'
+import { Binary, Copy, FileDown, FileJson, Filter, Pencil, Trash2 } from 'lucide-react'
 import { ColumnDefinition } from '../types'
+import { detectBlob } from './cells/blob-utils'
 
 type CellAction = 'copy' | 'copy-json' | 'filter-by-value' | 'edit' | 'set-null' | 'set-null-batch'
+
+/** Blob-specific actions that need the original bytes, resolved by the parent. */
+type BlobAction = 'copy-hex' | 'copy-base64' | 'save-file'
 
 type BatchAction = {
 	action: 'set-null-batch'
@@ -21,6 +25,7 @@ type Props = {
 	column: ColumnDefinition
 	rowIndex: number
 	colIndex?: number
+	row?: Record<string, unknown>
 	selectedRows?: Set<number>
 	hasFilter?: boolean
 	onAction?: (
@@ -28,6 +33,12 @@ type Props = {
 		value: unknown,
 		column: ColumnDefinition,
 		batchAction?: BatchAction
+	) => void
+	/** Handle a blob action; the parent re-fetches the original bytes. */
+	onBlobAction?: (
+		action: BlobAction,
+		column: ColumnDefinition,
+		row: Record<string, unknown>
 	) => void
 	onOpenChange?: (open: boolean, rowIndex: number, colIndex: number) => void
 	children: React.ReactNode
@@ -38,9 +49,11 @@ export function CellContextMenu({
 	column,
 	rowIndex,
 	colIndex = 0,
+	row,
 	selectedRows,
 	hasFilter = false,
 	onAction,
+	onBlobAction,
 	onOpenChange,
 	children
 }: Props) {
@@ -85,8 +98,14 @@ export function CellContextMenu({
 		onOpenChange?.(open, rowIndex, colIndex)
 	}
 
+	function handleBlobAction(action: BlobAction) {
+		if (row && onBlobAction) onBlobAction(action, column, row)
+	}
+
 	const hasSelectedRows = selectedRows && selectedRows.size > 1 && selectedRows.has(rowIndex)
 	const isComplexType = typeof value === 'object' && value !== null
+	const blobInfo = detectBlob(value, column)
+	const showBlobActions = !!blobInfo && !!row && !!onBlobAction
 
 	return (
 		<ContextMenu onOpenChange={handleOpenChange}>
@@ -107,6 +126,23 @@ export function CellContextMenu({
 						<span>Copy as JSON</span>
 					</ContextMenuItem>
 				)}
+				{showBlobActions && (
+					<>
+						<ContextMenuSeparator />
+						<ContextMenuItem onClick={function () { handleBlobAction('copy-hex') }}>
+							<Binary />
+							<span>Copy as hex</span>
+						</ContextMenuItem>
+						<ContextMenuItem onClick={function () { handleBlobAction('copy-base64') }}>
+							<Copy />
+							<span>Copy as base64</span>
+						</ContextMenuItem>
+						<ContextMenuItem onClick={function () { handleBlobAction('save-file') }}>
+							<FileDown />
+							<span>Save to file…</span>
+						</ContextMenuItem>
+					</>
+				)}
 				<ContextMenuSeparator />
 				<ContextMenuItem onClick={handleFilterByValue} disabled={!hasFilter}>
 					<Filter />
@@ -126,4 +162,4 @@ export function CellContextMenu({
 	)
 }
 
-export type { CellAction }
+export type { CellAction, BlobAction }

--- a/packages/studio/src/features/database-studio/components/cells/blob-cell.tsx
+++ b/packages/studio/src/features/database-studio/components/cells/blob-cell.tsx
@@ -1,0 +1,38 @@
+import { Binary } from 'lucide-react'
+import { cn } from '@studio/shared/utils/cn'
+import type { TBlobInfo } from './blob-utils'
+
+type Props = {
+	info: TBlobInfo
+}
+
+/**
+ * Renders a binary/blob cell. Small blobs show as inline uppercase hex
+ * (truncated with the cell's ellipsis), large blobs as a `<type — size>` chip.
+ * Magic-byte type hints (e.g. "PNG image") are produced by the backend and just
+ * displayed here. Cell actions (copy hex/base64, save) live in the cell context
+ * menu, not on the renderer.
+ */
+export function BlobCell({ info }: Props) {
+	if (info.kind === 'hex') {
+		return (
+			<span className='font-mono text-xs text-muted-foreground truncate' title={info.hex}>
+				{info.hex}
+			</span>
+		)
+	}
+
+	return (
+		<span
+			className={cn(
+				'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md',
+				'bg-violet-500/10 text-violet-500 dark:text-violet-400 border border-violet-500/20',
+				'font-mono text-[11px] font-medium tracking-wide max-w-full'
+			)}
+			title={info.label}
+		>
+			<Binary className='w-3 h-3 shrink-0' />
+			<span className='truncate'>{info.label.replace(/^<|>$/g, '')}</span>
+		</span>
+	)
+}

--- a/packages/studio/src/features/database-studio/components/cells/blob-utils.ts
+++ b/packages/studio/src/features/database-studio/components/cells/blob-utils.ts
@@ -1,0 +1,76 @@
+import type { ColumnDefinition } from '../../types'
+
+/**
+ * Backend (`blob_display.rs`) renders binary cells as one of two string forms:
+ *  - small blobs (<=64 bytes): an inline uppercase hex string, e.g. `0xDEADBEEF`
+ *  - large blobs: a `<type — size>` summary, e.g. `<PNG image — 12.3 KB>`
+ * We re-detect these on the frontend so the data grid can render them as a
+ * dedicated blob cell (and expose hex/base64/save actions) instead of plain text.
+ */
+
+/** Matches the large-blob summary form `<… — …>` produced by `describe_blob`. */
+const SUMMARY_RE = /^<.+ — .+>$/
+
+/** Matches the inline hex form `0x` followed by an even count of hex digits. */
+const HEX_RE = /^0x([0-9A-Fa-f]{2})*$/
+
+export type TBlobInfo =
+	| { kind: 'hex'; hex: string }
+	| { kind: 'summary'; label: string }
+
+/** Column types that store binary data, used as a hint alongside value shape. */
+function isBinaryColumnType(column?: ColumnDefinition): boolean {
+	const type = column?.type?.toLowerCase() ?? ''
+	return (
+		type === 'blob' ||
+		type === 'bytea' ||
+		type.includes('blob') ||
+		type.includes('bytea') ||
+		type.includes('binary') ||
+		type.includes('varbinary')
+	)
+}
+
+/**
+ * Detects whether a cell value is a rendered blob. Returns the parsed shape, or
+ * `null` for everything else so normal text/numeric cells are never affected.
+ */
+export function detectBlob(value: unknown, column?: ColumnDefinition): TBlobInfo | null {
+	if (typeof value !== 'string') return null
+
+	const binaryColumn = isBinaryColumnType(column)
+
+	if (HEX_RE.test(value)) {
+		// A bare `0x…` is only treated as a blob when the column is binary, so
+		// hex-looking text in normal columns is left untouched.
+		if (binaryColumn) return { kind: 'hex', hex: value }
+		return null
+	}
+
+	if (SUMMARY_RE.test(value)) {
+		// The summary form is unambiguous (no real text value looks like
+		// `<binary — 4.9 KB>`), so accept it with or without column type info.
+		return { kind: 'summary', label: value }
+	}
+
+	return null
+}
+
+/** Strips the `0x` prefix from a rendered hex string. */
+export function hexBody(hex: string): string {
+	return hex.startsWith('0x') ? hex.slice(2) : hex
+}
+
+/** Converts a byte array (the raw-bytes command result) to an uppercase hex string. */
+export function bytesToHex(bytes: number[]): string {
+	let out = ''
+	for (const b of bytes) out += (b & 0xff).toString(16).padStart(2, '0')
+	return out.toUpperCase()
+}
+
+/** Converts a byte array to a base64 string. */
+export function bytesToBase64(bytes: number[]): string {
+	let binary = ''
+	for (const b of bytes) binary += String.fromCharCode(b & 0xff)
+	return btoa(binary)
+}

--- a/packages/studio/src/features/database-studio/components/data-grid.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid.tsx
@@ -19,6 +19,7 @@ import {
 	MIN_COLUMN_WIDTH,
 	useColumnResize
 } from './data-grid/use-column-resize'
+import { BlobAction } from './cell-context-menu'
 import { RowAction } from './row-context-menu'
 import { ScrollHint } from './scroll-hint'
 import { useRowVirtualizer } from './data-grid/use-row-virtualizer'
@@ -35,6 +36,7 @@ type Props = {
 	sort?: SortDescriptor
 	onSortChange?: (sort: SortDescriptor | undefined) => void
 	onFilterAdd?: (filter: FilterDescriptor) => void
+	onBlobAction?: (action: BlobAction, column: ColumnDefinition, row: Record<string, unknown>) => void
 	onCellEdit?: (rowIndex: number, columnName: string, newValue: unknown) => void
 	onDeleteSelectedRows?: () => void
 	onBatchCellEdit?: (rowIndexes: number[], columnName: string, newValue: unknown) => void
@@ -69,6 +71,7 @@ export function DataGrid({
 	sort,
 	onSortChange,
 	onFilterAdd,
+	onBlobAction,
 	onCellEdit,
 	onDeleteSelectedRows,
 	onBatchCellEdit,
@@ -370,6 +373,7 @@ export function DataGrid({
 						onDraftChange={onDraftChange}
 						onDraftSave={onDraftSave}
 						onFilterAdd={onFilterAdd}
+						onBlobAction={onBlobAction}
 						onFKNavigate={onFKNavigate}
 						onRowAction={onRowAction}
 						onRowSelect={onRowSelect}

--- a/packages/studio/src/features/database-studio/components/data-grid/cell-value.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid/cell-value.tsx
@@ -1,6 +1,8 @@
 import { Check, X, ChevronRight, ChevronDown } from 'lucide-react'
 import React, { useState } from 'react'
 import { ColumnDefinition } from '../../types'
+import { BlobCell } from '../cells/blob-cell'
+import { detectBlob } from '../cells/blob-utils'
 import { DateCell } from '../cells/date-cell'
 import { IpCell } from '../cells/ip-cell'
 import { TokenCell } from '../cells/token-cell'
@@ -80,6 +82,13 @@ function tryParseJson(value: string): object | null {
 export function formatCellValue(value: unknown, column: ColumnDefinition): React.ReactNode {
 	if (value === null || value === undefined) {
 		return <span className='text-muted-foreground italic'>NULL</span>
+	}
+
+	// Binary/blob cells: the backend renders these as `0x…` hex (small) or a
+	// `<type — size>` summary (large). Detect both and render a dedicated cell.
+	const blobInfo = detectBlob(value, column)
+	if (blobInfo) {
+		return <BlobCell info={blobInfo} />
 	}
 
 	const colName = column.name.toLowerCase()

--- a/packages/studio/src/features/database-studio/components/data-grid/grid-body.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid/grid-body.tsx
@@ -3,7 +3,7 @@ import type { VirtualItem } from '@tanstack/react-virtual'
 import { Checkbox } from '@studio/shared/ui/checkbox'
 import { cn } from '@studio/shared/utils/cn'
 import { ColumnDefinition, FilterDescriptor } from '../../types'
-import { CellContextMenu } from '../cell-context-menu'
+import { BlobAction, CellContextMenu } from '../cell-context-menu'
 import { RowAction, RowContextMenu } from '../row-context-menu'
 import { formatCellValue } from './cell-value'
 import { DraftRow } from './draft-row'
@@ -35,6 +35,11 @@ type GridBodyProps = {
 	onDraftChange?: (columnName: string, value: unknown) => void
 	onDraftSave?: () => void
 	onFilterAdd?: (filter: FilterDescriptor) => void
+	onBlobAction?: (
+		action: BlobAction,
+		column: ColumnDefinition,
+		row: Record<string, unknown>
+	) => void
 	onRowAction?: (
 		action: RowAction,
 		row: Record<string, unknown>,
@@ -81,6 +86,7 @@ export function GridBody({
 	onDraftChange,
 	onDraftSave,
 	onFilterAdd,
+	onBlobAction,
 	onRowAction,
 	onRowSelect,
 	pendingEdits,
@@ -221,8 +227,10 @@ export function GridBody({
 											column={col}
 											rowIndex={rowIndex}
 											colIndex={colIndex}
+											row={row}
 											selectedRows={effectiveSelectedRows}
 											hasFilter={!!onFilterAdd}
+											onBlobAction={onBlobAction}
 											onAction={function (
 												action,
 												value,

--- a/packages/studio/src/features/database-studio/components/export-options-dialog.tsx
+++ b/packages/studio/src/features/database-studio/components/export-options-dialog.tsx
@@ -1,0 +1,73 @@
+import { Button } from '@studio/shared/ui/button'
+import { StudioDialog } from './studio-dialog'
+
+export type ExportFormatChoice = 'json' | 'csv' | 'sql'
+
+type Props = {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	/** Format being exported (drives the title/labels only). */
+	format: ExportFormatChoice
+	/**
+	 * Number of rows that match the active filters, when known (e.g. the current
+	 * total count from the loaded table). Shown in the "matching rows" label.
+	 */
+	matchingRowCount?: number
+	/** Runs the export honoring the active filters and sort. */
+	onExportMatching: () => void
+	/** Runs the export over the full table, ignoring filters (sort still applies). */
+	onExportAll: () => void
+}
+
+const FORMAT_LABEL: Record<ExportFormatChoice, string> = {
+	json: 'JSON',
+	csv: 'CSV',
+	sql: 'SQL INSERT'
+}
+
+export function ExportOptionsDialog({
+	open,
+	onOpenChange,
+	format,
+	matchingRowCount,
+	onExportMatching,
+	onExportAll
+}: Props) {
+	const label = FORMAT_LABEL[format]
+	const matchingLabel =
+		typeof matchingRowCount === 'number'
+			? `Export ${matchingRowCount.toLocaleString()} matching rows`
+			: 'Export matching rows'
+
+	function handleMatching() {
+		onOpenChange(false)
+		onExportMatching()
+	}
+
+	function handleAll() {
+		onOpenChange(false)
+		onExportAll()
+	}
+
+	return (
+		<StudioDialog
+			open={open}
+			onOpenChange={onOpenChange}
+			title={`Export ${label}`}
+			description='Filters are active on this table. Choose what to export.'
+			footer={
+				<div className='flex w-full flex-col gap-2 sm:flex-row sm:justify-end'>
+					<Button variant='outline' onClick={handleAll}>
+						Export all rows (ignore filters)
+					</Button>
+					<Button onClick={handleMatching}>{matchingLabel}</Button>
+				</div>
+			}
+		>
+			<p className='text-sm text-muted-foreground'>
+				Exporting matching rows includes only the rows that satisfy your current filters and
+				respects the active sort order. Choose “ignore filters” to export the entire table.
+			</p>
+		</StudioDialog>
+	)
+}

--- a/packages/studio/src/features/database-studio/components/filter-bar.tsx
+++ b/packages/studio/src/features/database-studio/components/filter-bar.tsx
@@ -1,249 +1,350 @@
-import { X, Plus, Filter, Trash2, ChevronDown } from 'lucide-react'
+import { X, Plus, Trash2, ChevronDown, FolderPlus } from 'lucide-react'
 import { useState, useRef, useEffect } from 'react'
 import { Button } from '@studio/shared/ui/button'
 import { Input } from '@studio/shared/ui/input'
 import { cn } from '@studio/shared/utils/cn'
-import { ColumnDefinition, FilterConjunction, FilterDescriptor, FilterOperator } from '../types'
+import { buildWhereClauseFromGroup } from '@studio/core/data-provider/filter-sql'
+import {
+	ColumnDefinition,
+	FilterCondition,
+	FilterConjunction,
+	FilterGroup,
+	FilterOperator,
+	isFilterGroup
+} from '../types'
 
 type Props = {
-	filters: FilterDescriptor[]
-	onFiltersChange: (filters: FilterDescriptor[]) => void
-	conjunction?: FilterConjunction
-	onConjunctionChange?: (conjunction: FilterConjunction) => void
+	group: FilterGroup
+	onGroupChange: (group: FilterGroup) => void
 	columns: ColumnDefinition[]
 	isVisible: boolean
 }
 
-export function FilterBar({
-	filters,
-	onFiltersChange,
-	conjunction = 'AND',
-	onConjunctionChange,
+const OPERATOR_OPTIONS: Array<{ value: FilterOperator; label: string }> = [
+	{ value: 'eq', label: 'equals' },
+	{ value: 'neq', label: 'not equal' },
+	{ value: 'gt', label: 'greater than' },
+	{ value: 'lt', label: 'less than' },
+	{ value: 'gte', label: 'greater or equal' },
+	{ value: 'lte', label: 'less or equal' },
+	{ value: 'contains', label: 'contains' },
+	{ value: 'ilike', label: 'ilike' }
+]
+
+/** Immutably replaces a child at `index` within a group's conditions. */
+function withChildReplaced(
+	group: FilterGroup,
+	index: number,
+	child: FilterCondition | FilterGroup
+): FilterGroup {
+	const conditions = group.conditions.slice()
+	conditions[index] = child
+	return { ...group, conditions }
+}
+
+/** Immutably removes a child at `index` from a group's conditions. */
+function withChildRemoved(group: FilterGroup, index: number): FilterGroup {
+	const conditions = group.conditions.slice()
+	conditions.splice(index, 1)
+	return { ...group, conditions }
+}
+
+function makeCondition(columns: ColumnDefinition[]): FilterCondition {
+	return {
+		column: columns.length > 0 ? columns[0].name : '',
+		operator: 'eq',
+		value: ''
+	}
+}
+
+function OperatorSelect({
+	value,
+	onChange
+}: {
+	value: FilterOperator
+	onChange: (op: FilterOperator) => void
+}) {
+	return (
+		<div className='relative'>
+			<select
+				className='h-6 text-xs bg-background border border-sidebar-border rounded px-2 w-[120px] appearance-none focus:ring-1 focus:ring-secondary focus:border-primary outline-none cursor-pointer'
+				value={value}
+				onChange={(e) => onChange(e.target.value as FilterOperator)}
+			>
+				{OPERATOR_OPTIONS.map((o) => (
+					<option key={o.value} value={o.value}>
+						{o.label}
+					</option>
+				))}
+			</select>
+			<div className='absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-muted-foreground'>
+				<ChevronDown className='h-3 w-3' />
+			</div>
+		</div>
+	)
+}
+
+function ColumnSelect({
+	value,
 	columns,
-	isVisible
-}: Props) {
-	function toggleConjunction() {
-		onConjunctionChange?.(conjunction === 'AND' ? 'OR' : 'AND')
+	onChange
+}: {
+	value: string
+	columns: ColumnDefinition[]
+	onChange: (column: string) => void
+}) {
+	return (
+		<div className='relative'>
+			<select
+				className='h-6 text-xs bg-background border border-sidebar-border rounded px-2 min-w-[120px] appearance-none focus:ring-1 focus:ring-secondary focus:border-primary outline-none cursor-pointer'
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+			>
+				{columns.map((col) => (
+					<option key={col.name} value={col.name}>
+						{col.name}
+					</option>
+				))}
+			</select>
+			<div className='absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-muted-foreground'>
+				<ChevronDown className='h-3 w-3' />
+			</div>
+		</div>
+	)
+}
+
+/** AND/OR toggle for a group. */
+function LogicToggle({
+	logic,
+	onToggle
+}: {
+	logic: FilterConjunction
+	onToggle: () => void
+}) {
+	return (
+		<button
+			type='button'
+			onClick={onToggle}
+			title={`Joining conditions with ${logic}. Click to switch to ${logic === 'AND' ? 'OR' : 'AND'}.`}
+			className='text-[10px] uppercase text-primary font-bold w-10 text-center tracking-wider rounded border border-primary/20 bg-primary/5 hover:bg-primary/15 transition-colors'
+		>
+			{logic}
+		</button>
+	)
+}
+
+function ConditionRow({
+	condition,
+	columns,
+	prefix,
+	onChange,
+	onRemove
+}: {
+	condition: FilterCondition
+	columns: ColumnDefinition[]
+	prefix: React.ReactNode
+	onChange: (next: FilterCondition) => void
+	onRemove: () => void
+}) {
+	return (
+		<div className='flex items-center gap-2 px-2 h-9 group bg-sidebar-accent/5 hover:bg-sidebar-accent/20 transition-colors rounded'>
+			<Button
+				variant='ghost'
+				size='icon'
+				className='h-5 w-5 text-muted-foreground hover:text-destructive opacity-50 group-hover:opacity-100 transition-opacity'
+				onClick={onRemove}
+			>
+				<X className='h-3 w-3' />
+			</Button>
+
+			<div className='w-10 flex justify-center'>{prefix}</div>
+
+			<div className='flex items-center gap-2 text-xs flex-1'>
+				<ColumnSelect
+					value={condition.column}
+					columns={columns}
+					onChange={(column) => onChange({ ...condition, column })}
+				/>
+				<OperatorSelect
+					value={condition.operator}
+					onChange={(operator) => onChange({ ...condition, operator })}
+				/>
+				<Input
+					className='h-6 text-xs w-[200px]'
+					placeholder='Value...'
+					value={String(condition.value ?? '')}
+					onChange={(e) => onChange({ ...condition, value: e.target.value })}
+				/>
+			</div>
+		</div>
+	)
+}
+
+/**
+ * Renders a filter group and its children. `depth` controls nesting; nested
+ * groups (depth >= 1) cannot add further groups (one-level nesting only).
+ */
+function GroupEditor({
+	group,
+	columns,
+	depth,
+	onChange,
+	onRemove
+}: {
+	group: FilterGroup
+	columns: ColumnDefinition[]
+	depth: number
+	onChange: (next: FilterGroup) => void
+	onRemove?: () => void
+}) {
+	function setLogic(logic: FilterConjunction) {
+		onChange({ ...group, logic })
 	}
-	const [isAddingFilter, setIsAddingFilter] = useState(false)
-	const [newFilterColumn, setNewFilterColumn] = useState('')
-	const [newFilterOperator, setNewFilterOperator] = useState<FilterOperator>('eq')
-	const [newFilterValue, setNewFilterValue] = useState('')
 
-	// Auto-focus input when adding filter
-	const valueInputRef = useRef<HTMLInputElement>(null)
-
-	useEffect(() => {
-		if (isAddingFilter && valueInputRef.current) {
-			valueInputRef.current.focus()
-		}
-	}, [isAddingFilter])
-
-	if (!isVisible) return null
-
-	function removeFilter(index: number) {
-		const newFilters = [...filters]
-		newFilters.splice(index, 1)
-		onFiltersChange(newFilters)
+	function addCondition() {
+		onChange({ ...group, conditions: [...group.conditions, makeCondition(columns)] })
 	}
 
-	function clearFilters() {
-		onFiltersChange([])
+	function addGroup() {
+		const child: FilterGroup = { logic: 'AND', conditions: [makeCondition(columns)] }
+		onChange({ ...group, conditions: [...group.conditions, child] })
 	}
 
-	function startAddingFilter() {
-		if (columns.length > 0) {
-			setNewFilterColumn(columns[0].name)
-		}
-		setIsAddingFilter(true)
-		setNewFilterValue('')
-	}
-
-	function saveNewFilter() {
-		if (!newFilterColumn) return
-
-		onFiltersChange([
-			...filters,
-			{
-				column: newFilterColumn,
-				operator: newFilterOperator,
-				value: newFilterValue
-			}
-		])
-		setIsAddingFilter(false)
-		setNewFilterValue('')
-	}
-
-	function cancelAddingFilter() {
-		setIsAddingFilter(false)
-		setNewFilterValue('')
-	}
+	const isRoot = depth === 0
 
 	return (
-		<div className='flex flex-col border-b border-sidebar-border bg-sidebar-accent/10'>
-			{filters.map((filter, index) => (
-				<div
-					key={index}
-					className='flex items-center gap-2 px-2 h-9 border-b border-sidebar-border/50 last:border-0 group bg-sidebar-accent/5 hover:bg-sidebar-accent/20 transition-colors'
-				>
-					<Button
-						variant='ghost'
-						size='icon'
-						className='h-5 w-5 text-muted-foreground hover:text-destructive opacity-50 group-hover:opacity-100 transition-opacity'
-						onClick={() => removeFilter(index)}
-					>
-						<X className='h-3 w-3' />
-					</Button>
-
-					{index === 0 ? (
-						<span className='text-[10px] uppercase text-muted-foreground font-bold w-10 text-center tracking-wider select-none'>
-							WHERE
-						</span>
-					) : (
-						<button
-							type='button'
-							onClick={toggleConjunction}
-							disabled={!onConjunctionChange}
-							title={`Joining conditions with ${conjunction}. Click to switch to ${conjunction === 'AND' ? 'OR' : 'AND'}.`}
-							className='text-[10px] uppercase text-primary font-bold w-10 text-center tracking-wider rounded border border-primary/20 bg-primary/5 hover:bg-primary/15 transition-colors disabled:cursor-default disabled:opacity-70'
-						>
-							{conjunction}
-						</button>
-					)}
-
-					<div className='flex items-center gap-2 text-xs flex-1'>
-						<span className='font-mono text-primary font-medium px-1.5 py-0.5 rounded border border-primary/20 bg-primary/5'>
-							{filter.column}
-						</span>
-						<div className='relative'>
-							<select
-								className='h-6 text-xs bg-background border border-sidebar-border rounded px-2 w-[110px] appearance-none focus:ring-1 focus:ring-secondary focus:border-primary outline-none cursor-pointer'
-								value={filter.operator}
-								onChange={(e) => {
-									const newFilters = [...filters]
-									newFilters[index].operator = e.target.value as FilterOperator
-									onFiltersChange(newFilters)
-								}}
-							>
-								<option value='eq'>equals</option>
-								<option value='neq'>not equal</option>
-								<option value='gt'>greater than</option>
-								<option value='lt'>less than</option>
-								<option value='gte'>greater or equal</option>
-								<option value='lte'>less or equal</option>
-								<option value='contains'>contains</option>
-								<option value='ilike'>ilike</option>
-							</select>
-							<div className='absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-muted-foreground'>
-								<ChevronDown className='h-3 w-3' />
-							</div>
-						</div>
-						<span className='font-mono text-foreground font-medium px-1.5 py-0.5 rounded border border-border bg-background'>
-							{String(filter.value)}
-						</span>
-					</div>
-				</div>
-			))}
-
-			{/* Add Filter Row */}
-			{isAddingFilter ? (
-				<div className='flex items-center gap-2 px-2 h-9 border-b border-sidebar-border bg-sidebar-accent/20'>
-					<Button
-						variant='ghost'
-						size='icon'
-						className='h-5 w-5 text-muted-foreground hover:text-sidebar-foreground'
-						onClick={cancelAddingFilter}
-					>
-						<X className='h-3 w-3' />
-					</Button>
-
-					<span className='text-xs text-muted-foreground font-mono w-12 text-center'>
-						{filters.length === 0 ? 'where' : conjunction.toLowerCase()}
+		<div
+			className={cn(
+				'flex flex-col gap-1',
+				!isRoot && 'rounded border border-primary/20 bg-sidebar-accent/10 p-1.5 ml-10'
+			)}
+		>
+			{!isRoot && (
+				<div className='flex items-center gap-2 px-1'>
+					<span className='text-[10px] uppercase text-muted-foreground font-bold tracking-wider'>
+						Group
 					</span>
-
-					<div className='relative'>
-						<select
-							className='h-6 text-xs bg-background border border-sidebar-border rounded px-2 min-w-[120px] appearance-none focus:ring-1 focus:ring-secondary focus:border-primary outline-none cursor-pointer'
-							value={newFilterColumn}
-							onChange={(e) => setNewFilterColumn(e.target.value)}
-						>
-							{columns.map((col) => (
-								<option key={col.name} value={col.name}>
-									{col.name}
-								</option>
-							))}
-						</select>
-						<div className='absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-muted-foreground'>
-							<ChevronDown className='h-3 w-3' />
-						</div>
-					</div>
-
-					<div className='relative'>
-						<select
-							className='h-6 text-xs bg-background border border-sidebar-border rounded px-2 w-[110px] appearance-none focus:ring-1 focus:ring-secondary focus:border-primary outline-none cursor-pointer'
-							value={newFilterOperator}
-							onChange={(e) => setNewFilterOperator(e.target.value as FilterOperator)}
-						>
-							<option value='eq'>equals</option>
-							<option value='neq'>not equal</option>
-							<option value='gt'>greater than</option>
-							<option value='lt'>less than</option>
-							<option value='gte'>greater or equal</option>
-							<option value='lte'>less or equal</option>
-							<option value='contains'>contains</option>
-							<option value='ilike'>ilike</option>
-						</select>
-						<div className='absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-muted-foreground'>
-							<ChevronDown className='h-3 w-3' />
-						</div>
-					</div>
-
-					<Input
-						ref={valueInputRef}
-						className='h-6 text-xs w-[200px]'
-						placeholder='Value...'
-						value={newFilterValue}
-						onChange={(e) => setNewFilterValue(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === 'Enter') saveNewFilter()
-							if (e.key === 'Escape') cancelAddingFilter()
-						}}
-					/>
-
-					<Button
-						size='sm'
-						variant='default'
-						className='h-6 px-2 text-[10px]'
-						onClick={saveNewFilter}
-					>
-						Apply
-					</Button>
-				</div>
-			) : (
-				<div className='flex items-center px-2 h-9 gap-2'>
-					<Button
-						variant='ghost'
-						size='sm'
-						className='h-6 px-2 text-xs text-muted-foreground hover:text-sidebar-foreground gap-1.5'
-						onClick={startAddingFilter}
-					>
-						<Plus className='h-3 w-3' />
-						Add filter
-					</Button>
-
-					{filters.length > 0 && (
+					<LogicToggle logic={group.logic} onToggle={() => setLogic(group.logic === 'AND' ? 'OR' : 'AND')} />
+					{onRemove && (
 						<Button
 							variant='ghost'
-							size='sm'
-							className='h-6 px-2 text-xs text-muted-foreground hover:text-destructive gap-1.5 ml-auto'
-							onClick={clearFilters}
+							size='icon'
+							className='h-5 w-5 text-muted-foreground hover:text-destructive ml-auto'
+							onClick={onRemove}
+							title='Remove group'
 						>
 							<Trash2 className='h-3 w-3' />
-							Clear filters
 						</Button>
 					)}
 				</div>
 			)}
+
+			{group.conditions.map((child, index) => {
+				const prefix =
+					index === 0 ? (
+						isRoot ? (
+							<span className='text-[10px] uppercase text-muted-foreground font-bold tracking-wider select-none'>
+								WHERE
+							</span>
+						) : null
+					) : (
+						<LogicToggle
+							logic={group.logic}
+							onToggle={() => setLogic(group.logic === 'AND' ? 'OR' : 'AND')}
+						/>
+					)
+
+				if (isFilterGroup(child)) {
+					return (
+						<GroupEditor
+							key={index}
+							group={child}
+							columns={columns}
+							depth={depth + 1}
+							onChange={(next) => onChange(withChildReplaced(group, index, next))}
+							onRemove={() => onChange(withChildRemoved(group, index))}
+						/>
+					)
+				}
+
+				return (
+					<ConditionRow
+						key={index}
+						condition={child}
+						columns={columns}
+						prefix={prefix}
+						onChange={(next) => onChange(withChildReplaced(group, index, next))}
+						onRemove={() => onChange(withChildRemoved(group, index))}
+					/>
+				)
+			})}
+
+			<div className='flex items-center px-2 h-8 gap-2'>
+				<Button
+					variant='ghost'
+					size='sm'
+					className='h-6 px-2 text-xs text-muted-foreground hover:text-sidebar-foreground gap-1.5'
+					onClick={addCondition}
+				>
+					<Plus className='h-3 w-3' />
+					Add condition
+				</Button>
+				{isRoot && (
+					<Button
+						variant='ghost'
+						size='sm'
+						className='h-6 px-2 text-xs text-muted-foreground hover:text-sidebar-foreground gap-1.5'
+						onClick={addGroup}
+					>
+						<FolderPlus className='h-3 w-3' />
+						Add group
+					</Button>
+				)}
+			</div>
+		</div>
+	)
+}
+
+export function FilterBar({ group, onGroupChange, columns, isVisible }: Props) {
+	const [newFilterColumn, setNewFilterColumn] = useState('')
+	const valueInputRef = useRef<HTMLInputElement>(null)
+
+	useEffect(() => {
+		if (columns.length > 0 && !newFilterColumn) {
+			setNewFilterColumn(columns[0].name)
+		}
+	}, [columns, newFilterColumn])
+
+	if (!isVisible) return null
+
+	const wherePreview = buildWhereClauseFromGroup(group)
+	const hasConditions = group.conditions.length > 0
+
+	return (
+		<div className='flex flex-col border-b border-sidebar-border bg-sidebar-accent/10 p-1.5 gap-1.5'>
+			<GroupEditor group={group} columns={columns} depth={0} onChange={onGroupChange} />
+
+			<div className='flex items-center gap-2 px-2'>
+				<div className='flex-1 min-w-0'>
+					{hasConditions && (
+						<div className='text-[10px] font-mono text-muted-foreground truncate'>
+							<span className='uppercase tracking-wider text-primary/70 mr-1'>WHERE</span>
+							<span className='text-foreground/80'>{wherePreview || '—'}</span>
+						</div>
+					)}
+				</div>
+				{hasConditions && (
+					<Button
+						variant='ghost'
+						size='sm'
+						className='h-6 px-2 text-xs text-muted-foreground hover:text-destructive gap-1.5'
+						onClick={() => onGroupChange({ logic: 'AND', conditions: [] })}
+					>
+						<Trash2 className='h-3 w-3' />
+						Clear filters
+					</Button>
+				)}
+			</div>
 		</div>
 	)
 }

--- a/packages/studio/src/features/database-studio/components/studio-toolbar.tsx
+++ b/packages/studio/src/features/database-studio/components/studio-toolbar.tsx
@@ -11,7 +11,8 @@ import {
 	RefreshCw,
 	Sparkles,
 	Copy,
-	Upload
+	Upload,
+	Gauge
 } from 'lucide-react'
 import { useState, useEffect } from 'react'
 import { Button } from '@studio/shared/ui/button'
@@ -25,12 +26,19 @@ import {
 } from '@studio/shared/ui/dropdown-menu'
 import { Input } from '@studio/shared/ui/input'
 import { cn } from '@studio/shared/utils/cn'
-import { ViewMode, PaginationState, FilterConjunction, FilterDescriptor, ColumnDefinition } from '../types'
+import { ViewMode, PaginationState, FilterGroup, ColumnDefinition, isFilterGroup } from '../types'
 import type { LiveMonitorConfig, ChangeEvent } from '@studio/core/live-monitor'
 import { LiveMonitorPopover } from './live-monitor-popover'
 import { ChangeFeed } from './change-feed'
 import { FilterBar } from './filter-bar'
 import type { ReactNode } from 'react'
+
+/** Counts leaf conditions in a filter group, recursing into nested groups. */
+function countConditions(group: FilterGroup): number {
+	return group.conditions.reduce(function (total, node) {
+		return total + (isFilterGroup(node) ? countConditions(node) : 1)
+	}, 0)
+}
 
 type Props = {
 	tableName: string
@@ -44,10 +52,8 @@ type Props = {
 	onRestore?: () => void
 	onAddRecord?: () => void
 	isLoading?: boolean
-	filters?: FilterDescriptor[]
-	onFiltersChange?: (filters: FilterDescriptor[]) => void
-	conjunction?: FilterConjunction
-	onConjunctionChange?: (conjunction: FilterConjunction) => void
+	filterGroup?: FilterGroup
+	onFilterGroupChange?: (group: FilterGroup) => void
 	columns?: ColumnDefinition[]
 	visibleColumns?: Set<string>
 	onToggleColumn?: (columnName: string, visible: boolean) => void
@@ -58,6 +64,7 @@ type Props = {
 	onSeed?: () => void
 	onCopySchema?: () => void
 	onCopyDrizzleSchema?: () => void
+	onSuggestIndexes?: () => void
 	liveMonitorConfig?: LiveMonitorConfig
 	onLiveMonitorConfigChange?: (config: LiveMonitorConfig) => void
 	isLiveMonitorPolling?: boolean
@@ -79,10 +86,8 @@ export function StudioToolbar({
 	onRestore,
 	onAddRecord,
 	isLoading,
-	filters = [],
-	onFiltersChange,
-	conjunction = 'AND',
-	onConjunctionChange,
+	filterGroup = { logic: 'AND', conditions: [] },
+	onFilterGroupChange,
 	columns = [],
 	visibleColumns,
 	onToggleColumn,
@@ -91,6 +96,7 @@ export function StudioToolbar({
 	onSeed,
 	onCopySchema,
 	onCopyDrizzleSchema,
+	onSuggestIndexes,
 	liveMonitorConfig,
 	onLiveMonitorConfigChange,
 	isLiveMonitorPolling,
@@ -101,13 +107,14 @@ export function StudioToolbar({
 	onClearChangeEvents,
 	onMarkChangesRead
 }: Props) {
-	const [showFilters, setShowFilters] = useState(filters.length > 0)
+	const filterCount = countConditions(filterGroup)
+	const [showFilters, setShowFilters] = useState(filterCount > 0)
 
 	useEffect(() => {
-		if (filters.length > 0) {
+		if (filterCount > 0) {
 			setShowFilters(true)
 		}
-	}, [filters.length])
+	}, [filterCount])
 
 	return (
 		<div className='flex flex-col shrink-0 bg-sidebar border-b border-sidebar-border'>
@@ -159,20 +166,20 @@ export function StudioToolbar({
 					</div>
 					<div className='h-4 w-px bg-sidebar-border mx-1' />
 					<Button
-						variant={showFilters || filters.length > 0 ? 'secondary' : 'ghost'}
+						variant={showFilters || filterCount > 0 ? 'secondary' : 'ghost'}
 						size='sm'
 						className={cn(
 							'h-7 px-2 text-xs gap-1.5 ml-1',
-							(showFilters || filters.length > 0) &&
+							(showFilters || filterCount > 0) &&
 								'text-sidebar-foreground bg-sidebar-accent'
 						)}
 						onClick={() => setShowFilters(!showFilters)}
 					>
 						<Filter className='h-3.5 w-3.5' />
 						<span className='hidden sm:inline'>Filters</span>
-						{filters.length > 0 && (
+						{filterCount > 0 && (
 							<span className='bg-primary text-primary-foreground text-[10px] px-1 rounded-full min-w-[14px] h-3.5 flex items-center justify-center'>
-								{filters.length}
+								{filterCount}
 							</span>
 						)}
 					</Button>
@@ -252,6 +259,19 @@ export function StudioToolbar({
 						>
 							<Sparkles className='h-3.5 w-3.5 text-blue-400' />
 							<span className='hidden sm:inline'>Seed Data</span>
+						</Button>
+					)}
+
+					{onSuggestIndexes && (
+						<Button
+							variant='ghost'
+							size='sm'
+							className='h-7 px-2 text-xs gap-1.5'
+							onClick={onSuggestIndexes}
+							title='Suggest indexes for this table using AI'
+						>
+							<Gauge className='h-3.5 w-3.5 text-blue-400' />
+							<span className='hidden sm:inline'>Suggest indexes</span>
 						</Button>
 					)}
 
@@ -383,10 +403,8 @@ export function StudioToolbar({
 			{/* Filter Bar */}
 			<FilterBar
 				isVisible={showFilters}
-				filters={filters}
-				onFiltersChange={onFiltersChange || (() => {})}
-				conjunction={conjunction}
-				onConjunctionChange={onConjunctionChange}
+				group={filterGroup}
+				onGroupChange={onFilterGroupChange || (() => {})}
 				columns={columns}
 			/>
 		</div>

--- a/packages/studio/src/features/database-studio/database-studio.tsx
+++ b/packages/studio/src/features/database-studio/database-studio.tsx
@@ -10,6 +10,7 @@ import { useUndo } from '@studio/core/undo'
 import { getTableRefParts } from '@studio/shared/utils/table-ref'
 import { getSourceCaps } from '@studio/features/connections/source-caps'
 import { isUiActionVisible } from '@studio/features/connections/ui-actions'
+import { askAi, buildSuggestIndexesPrompt } from '@studio/features/ai-assistant/ai-actions'
 import { DataFileSessionChrome } from './components/data-file-session-chrome'
 import { ImportFilesIntoDuckDbButton } from './components/import-files-into-duckdb-button'
 import {
@@ -42,6 +43,7 @@ import { RowDetailPanel } from './components/row-detail-panel'
 import { SelectionActionBar } from './components/selection-action-bar'
 import { SetNullDialog } from './components/set-null-dialog'
 import { StudioToolbar } from './components/studio-toolbar'
+import { ExportOptionsDialog, type ExportFormatChoice } from './components/export-options-dialog'
 import { ImportCsvDialog } from './components/import-csv-dialog'
 import { DataSeederDialog } from './data-seeder-dialog'
 import { useDatabaseStudioSync } from './hooks/use-database-studio-sync'
@@ -49,9 +51,14 @@ import { useDatabaseStudioActions } from './hooks/use-database-studio-actions'
 import { useDatabaseStudioEdits } from './hooks/use-database-studio-edits'
 import { useDatabaseStudioCommands } from './hooks/use-database-studio-commands'
 import { buildTableCacheKey } from './utils/table-cache'
-import { FilterConjunction, FilterDescriptor, PaginationState, SortDescriptor, TableData, ViewMode } from './types'
+import { FilterConjunction, FilterDescriptor, FilterGroup, PaginationState, SortDescriptor, TableData, ViewMode } from './types'
+import { flatFiltersToGroup, groupToFlatFilters } from '@studio/core/data-provider/filter-sql'
 import { ResultChartPanel } from '@studio/features/result-charts/result-chart-panel'
 import type { ResultChartConfig } from '@studio/features/result-charts/types'
+import { commands } from '@studio/lib/bindings'
+import type { ColumnDefinition } from './types'
+import type { BlobAction } from './components/cell-context-menu'
+import { bytesToBase64, bytesToHex } from './components/cells/blob-utils'
 
 type Props = {
 	tableId: string | null
@@ -194,6 +201,10 @@ export function DatabaseStudio({
 	const [sort, setSort] = useState<SortDescriptor | undefined>()
 	const [filters, setFilters] = useState<FilterDescriptor[]>([])
 	const [filterConjunction, setFilterConjunction] = useState<FilterConjunction>('AND')
+	// Structured AND/OR filter tree (#102). Source of truth for the filter UI and
+	// the data fetch. The flat `filters`/`filterConjunction` above are kept in sync
+	// as the root-level projection, for cache keys and tab persistence (#98).
+	const [filterGroup, setFilterGroup] = useState<FilterGroup>({ logic: 'AND', conditions: [] })
 	const [selectedRows, setSelectedRows] = useState<Set<number>>(new Set())
 	const [showAddColumnDialog, setShowAddColumnDialog] = useState(false)
 	const [showDropTableDialog, setShowDropTableDialog] = useState(false)
@@ -223,6 +234,31 @@ export function DatabaseStudio({
 	const [contextMenuState, setContextMenuState] = useState<ContextMenuState>(null)
 	const toolbarRef = useRef<HTMLDivElement>(null)
 	const gridContainerRef = useRef<HTMLDivElement>(null)
+	// Applies an edited filter tree from the FilterBar: stores the group and keeps
+	// the flat projection (#98 persistence + cache key) in sync.
+	const handleFilterGroupChange = useCallback(function (group: FilterGroup) {
+		setFilterGroup(group)
+		const flat = groupToFlatFilters(group)
+		setFilters(flat.filters)
+		setFilterConjunction(flat.conjunction)
+	}, [])
+
+	// Flat-filter dispatcher used by the sync hook (restoring persisted filters)
+	// and the bulk "filter by value" actions. Accepts both a value and the
+	// updater form, and lifts the result back into the structured group so the
+	// UI and the data fetch stay consistent. The group's existing logic is
+	// preserved (the flat conjunction state mirrors `group.logic`).
+	const handleSetFiltersFromSync = useCallback(function (
+		next: React.SetStateAction<FilterDescriptor[]>
+	) {
+		setFilterGroup(function (prevGroup) {
+			const prevFlat = groupToFlatFilters(prevGroup).filters
+			const resolved = typeof next === 'function' ? next(prevFlat) : next
+			setFilters(resolved)
+			return flatFiltersToGroup(resolved, prevGroup.logic)
+		})
+	}, [])
+
 	const currentCacheKey = useMemo(
 		function () {
 			return buildTableCacheKey(
@@ -232,10 +268,11 @@ export function DatabaseStudio({
 				pagination.offset,
 				sort,
 				filters,
-				filterConjunction
+				filterConjunction,
+				filterGroup
 			)
 		},
-		[activeConnectionId, tableId, pagination.limit, pagination.offset, sort, filters, filterConjunction]
+		[activeConnectionId, tableId, pagination.limit, pagination.offset, sort, filters, filterConjunction, filterGroup]
 	)
 	const {
 		liveMonitor,
@@ -252,6 +289,7 @@ export function DatabaseStudio({
 		sort,
 		filters,
 		filterConjunction,
+		filterGroup,
 		tableData,
 		draftRow,
 		draftInsertIndex,
@@ -268,7 +306,7 @@ export function DatabaseStudio({
 		setIsTableTransitioning,
 		setPagination,
 		setSort,
-		setFilters,
+		setFilters: handleSetFiltersFromSync,
 		setSelectedRows,
 		setSelectedCells,
 		setFocusedCell,
@@ -358,9 +396,73 @@ export function DatabaseStudio({
 		setAddDialogMode,
 		setSelectedRowForDetail,
 		setShowRowDetail,
-		setFilters,
+		setFilters: handleSetFiltersFromSync,
 		displayTableName
 	})
+
+	// Re-fetch the original bytes of a blob cell (the grid only has the rendered
+	// display string) and copy/save them. Addresses the cell by primary key,
+	// reusing the same safe parameter binding as cell edits.
+	const handleBlobAction = useCallback(
+		async function handleBlobAction(
+			action: BlobAction,
+			column: ColumnDefinition,
+			row: Record<string, unknown>
+		) {
+			if (!activeConnectionId || !tableRefName) return
+			const pkColumn = tableData?.columns.find(function (c) {
+				return c.primaryKey
+			})
+			if (!pkColumn) {
+				notifyMissingPrimaryKey('fetch binary cell')
+				return
+			}
+			const tableRef = getTableRefParts(tableRefName)
+			try {
+				const result = await commands.getBlobBytes(
+					activeConnectionId,
+					tableRef.tableName,
+					tableRef.schemaName,
+					pkColumn.name,
+					row[pkColumn.name] as never,
+					column.name
+				)
+				if (result.status !== 'ok') {
+					notifyActionFailure('Failed to read binary cell', result.error)
+					return
+				}
+				const bytes = result.data
+
+				if (action === 'copy-hex') {
+					await navigator.clipboard.writeText('0x' + bytesToHex(bytes))
+					toast({ title: `Copied ${bytes.length} bytes as hex` })
+				} else if (action === 'copy-base64') {
+					await navigator.clipboard.writeText(bytesToBase64(bytes))
+					toast({ title: `Copied ${bytes.length} bytes as base64` })
+				} else if (action === 'save-file') {
+					const { save } = await import('@tauri-apps/plugin-dialog')
+					const { writeFile } = await import('@tauri-apps/plugin-fs')
+					const path = await save({
+						defaultPath: `${displayTableName}_${column.name}.bin`
+					})
+					if (!path) return
+					await writeFile(path, new Uint8Array(bytes))
+					toast({ title: `Saved ${bytes.length} bytes to file` })
+				}
+			} catch (error) {
+				notifyActionFailure('Failed to read binary cell', error)
+			}
+		},
+		[
+			activeConnectionId,
+			tableRefName,
+			tableData,
+			displayTableName,
+			toast,
+			notifyMissingPrimaryKey,
+			notifyActionFailure
+		]
+	)
 
 	useEffect(
 		function announceSelection() {
@@ -405,7 +507,7 @@ export function DatabaseStudio({
 	)
 
 	$.bind(shortcuts.exportTable.combo).on(
-		function () { handleExport() },
+		function () { requestExport('json') },
 		{ description: shortcuts.exportTable.description }
 	)
 
@@ -578,6 +680,7 @@ export function DatabaseStudio({
 		handleExport,
 		handleExportCsvAll,
 		handleExportSqlAll,
+		hasActiveFilters,
 		handleBackupDatabase,
 		handleRestoreDatabase,
 		handleCopySchema,
@@ -594,12 +697,62 @@ export function DatabaseStudio({
 		sort,
 		filters,
 		filterConjunction,
+		filterGroup,
 		loadTableData,
 		setIsDdlLoading,
 		setShowAddColumnDialog,
 		setShowDropTableDialog,
 		notifyActionFailure
 	})
+
+	// Export dialog (#99): when filters are active, clicking an export action
+	// opens a chooser ("Export N matching rows" vs "Export all rows (ignore
+	// filters)"). With no active filters, export runs immediately as before.
+	const [exportDialogFormat, setExportDialogFormat] = useState<ExportFormatChoice | null>(null)
+
+	const runExport = useCallback(
+		function (format: ExportFormatChoice, ignoreFilters: boolean) {
+			if (format === 'json') void handleExport(ignoreFilters)
+			else if (format === 'csv') void handleExportCsvAll(ignoreFilters)
+			else void handleExportSqlAll(ignoreFilters)
+		},
+		[handleExport, handleExportCsvAll, handleExportSqlAll]
+	)
+
+	const requestExport = useCallback(
+		function (format: ExportFormatChoice) {
+			if (hasActiveFilters) {
+				setExportDialogFormat(format)
+				return
+			}
+			runExport(format, false)
+		},
+		[hasActiveFilters, runExport]
+	)
+
+	const handleSuggestIndexes = useCallback(
+		function () {
+			if (!tableData) return
+			const columnLines = tableData.columns
+				.map(function (col) {
+					const flags: string[] = [col.type]
+					if (col.primaryKey) flags.push('PRIMARY KEY')
+					if (!col.nullable) flags.push('NOT NULL')
+					if (col.foreignKey) {
+						flags.push(
+							`REFERENCES ${col.foreignKey.referencedTable}(${col.foreignKey.referencedColumn})`
+						)
+					}
+					return `  ${col.name} ${flags.join(' ')}`
+				})
+				.join('\n')
+			const schema = `CREATE TABLE ${displayTableName} (\n${columnLines}\n);`
+			const queries =
+				'No recent query samples available; base suggestions on the schema and common access patterns.'
+			askAi(buildSuggestIndexesPrompt(schema, queries))
+		},
+		[tableData, displayTableName]
+	)
 
 	// No connection selected
 	if (!activeConnectionId) {
@@ -655,9 +808,9 @@ export function DatabaseStudio({
 				viewMode={viewMode}
 				onViewModeChange={setViewMode}
 				onRefresh={loadTableData}
-				onExport={canExportFile ? handleExport : function () {}}
-				onExportCsv={canExportFile ? handleExportCsvAll : undefined}
-				onExportSql={canExportFile ? handleExportSqlAll : undefined}
+				onExport={canExportFile ? function () { requestExport('json') } : function () {}}
+				onExportCsv={canExportFile ? function () { requestExport('csv') } : undefined}
+				onExportSql={canExportFile ? function () { requestExport('sql') } : undefined}
 				onBackup={handleBackupDatabase}
 				onRestore={handleRestoreDatabase}
 				isLoading={isLoading}
@@ -694,19 +847,17 @@ export function DatabaseStudio({
 					viewMode={viewMode}
 					onViewModeChange={setViewMode}
 					onRefresh={loadTableData}
-					onExport={canExportFile ? handleExport : function () {}}
-					onExportCsv={canExportFile ? handleExportCsvAll : undefined}
-					onExportSql={canExportFile ? handleExportSqlAll : undefined}
+					onExport={canExportFile ? function () { requestExport('json') } : function () {}}
+					onExportCsv={canExportFile ? function () { requestExport('csv') } : undefined}
+					onExportSql={canExportFile ? function () { requestExport('sql') } : undefined}
 					onBackup={handleBackupDatabase}
 					onRestore={handleRestoreDatabase}
 					onAddRecord={canEditRows ? handleAddRecord : undefined}
 					onImportCsv={canImportFile ? function () { setShowImportDialog(true) } : undefined}
 					importFilesAction={importFilesAction}
 					isLoading={isLoading}
-					filters={filters}
-					onFiltersChange={setFilters}
-					conjunction={filterConjunction}
-					onConjunctionChange={setFilterConjunction}
+					filterGroup={filterGroup}
+					onFilterGroupChange={handleFilterGroupChange}
 					columns={tableData.columns}
 					visibleColumns={visibleColumns}
 					onToggleColumn={handleToggleColumn}
@@ -714,6 +865,7 @@ export function DatabaseStudio({
 					onDryEditModeChange={canEditRows ? setDryEditMode : undefined}
 					onCopySchema={handleCopySchema}
 					onCopyDrizzleSchema={handleCopyDrizzleSchema}
+					onSuggestIndexes={handleSuggestIndexes}
 					liveMonitorConfig={showLiveMonitor ? liveMonitor.config : undefined}
 					onLiveMonitorConfigChange={showLiveMonitor ? liveMonitor.setConfig : undefined}
 					isLiveMonitorPolling={showLiveMonitor ? liveMonitor.isPolling : false}
@@ -746,19 +898,17 @@ export function DatabaseStudio({
 				viewMode={viewMode}
 				onViewModeChange={setViewMode}
 				onRefresh={loadTableData}
-				onExport={canExportFile ? handleExport : function () {}}
-				onExportCsv={canExportFile ? handleExportCsvAll : undefined}
-				onExportSql={canExportFile ? handleExportSqlAll : undefined}
+				onExport={canExportFile ? function () { requestExport('json') } : function () {}}
+				onExportCsv={canExportFile ? function () { requestExport('csv') } : undefined}
+				onExportSql={canExportFile ? function () { requestExport('sql') } : undefined}
 				onBackup={handleBackupDatabase}
 				onRestore={handleRestoreDatabase}
 				onAddRecord={canEditRows ? handleAddRecord : undefined}
 				onImportCsv={canImportFile ? function () { setShowImportDialog(true) } : undefined}
 				importFilesAction={importFilesAction}
 				isLoading={isLoading}
-				filters={filters}
-				onFiltersChange={setFilters}
-				conjunction={filterConjunction}
-				onConjunctionChange={setFilterConjunction}
+				filterGroup={filterGroup}
+				onFilterGroupChange={handleFilterGroupChange}
 				columns={tableData?.columns || []}
 				visibleColumns={visibleColumns}
 				onToggleColumn={handleToggleColumn}
@@ -766,6 +916,7 @@ export function DatabaseStudio({
 				onDryEditModeChange={canEditRows ? setDryEditMode : undefined}
 				onCopySchema={handleCopySchema}
 				onCopyDrizzleSchema={handleCopyDrizzleSchema}
+				onSuggestIndexes={handleSuggestIndexes}
 				liveMonitorConfig={showLiveMonitor ? liveMonitor.config : undefined}
 				onLiveMonitorConfigChange={showLiveMonitor ? liveMonitor.setConfig : undefined}
 				isLiveMonitorPolling={showLiveMonitor ? liveMonitor.isPolling : false}
@@ -797,6 +948,7 @@ export function DatabaseStudio({
 							sort={sort}
 							onSortChange={setSort}
 							onFilterAdd={handleFilterAdd}
+							onBlobAction={handleBlobAction}
 							onCellEdit={canEditRows ? handleCellEdit : undefined}
 							onDeleteSelectedRows={canEditRows ? handleBulkDelete : undefined}
 							onBatchCellEdit={canEditRows ? handleBatchCellEdit : undefined}
@@ -1126,6 +1278,21 @@ export function DatabaseStudio({
 					onGenerate={handleSeederGenerate}
 				/>
 			)}
+
+			<ExportOptionsDialog
+				open={exportDialogFormat !== null}
+				onOpenChange={function (open) {
+					if (!open) setExportDialogFormat(null)
+				}}
+				format={exportDialogFormat ?? 'json'}
+				matchingRowCount={tableData?.totalCount}
+				onExportMatching={function () {
+					if (exportDialogFormat) runExport(exportDialogFormat, false)
+				}}
+				onExportAll={function () {
+					if (exportDialogFormat) runExport(exportDialogFormat, true)
+				}}
+			/>
 		</div>
 	)
 }

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-commands.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-commands.ts
@@ -9,7 +9,7 @@ import { useToast } from '@studio/shared/ui/use-toast'
 import { getTableRefParts } from '@studio/shared/utils/table-ref'
 import type { ColumnFormData } from '../components/add-column-dialog'
 import { rowsToCsv, rowsToSqlInsert, splitSqlStatements } from '../utils/studio-data'
-import type { FilterConjunction, FilterDescriptor, SortDescriptor, TableData } from '../types'
+import type { FilterConjunction, FilterDescriptor, FilterGroup, SortDescriptor, TableData } from '../types'
 
 type Args = {
 	adapter: DataAdapter
@@ -21,6 +21,7 @@ type Args = {
 	sort?: SortDescriptor
 	filters?: FilterDescriptor[]
 	filterConjunction?: FilterConjunction
+	filterGroup?: FilterGroup
 	loadTableData: () => void
 	setIsDdlLoading: (value: boolean) => void
 	setShowAddColumnDialog: (value: boolean) => void
@@ -54,6 +55,7 @@ export function useDatabaseStudioCommands(args: Args) {
 		sort,
 		filters,
 		filterConjunction,
+		filterGroup,
 		loadTableData,
 		setIsDdlLoading,
 		setShowAddColumnDialog,
@@ -61,10 +63,17 @@ export function useDatabaseStudioCommands(args: Args) {
 		notifyActionFailure
 	} = args
 
+	// True when any filter is active (flat list or structured group). Drives the
+	// "Export N matching rows" vs "Export all rows" choice in the export dialog.
+	const hasActiveFilters =
+		(filters?.length ?? 0) > 0 || (filterGroup?.conditions.length ?? 0) > 0
+
 	// Fetches every row matching the active filters/sort (up to a cap) so an
 	// export reflects what the user is looking at, not the whole table or just
-	// the loaded page. Returns null on failure (caller already notified).
-	async function fetchRowsForExport(): Promise<TableData | null> {
+	// the loaded page. When `ignoreFilters` is set the filters are dropped so the
+	// full table is exported (sort is still honored). Returns null on failure
+	// (caller already notified).
+	async function fetchRowsForExport(ignoreFilters = false): Promise<TableData | null> {
 		if (!activeConnectionId || !tableRefName) return null
 		const result = await adapter.fetchTableData(
 			activeConnectionId,
@@ -72,8 +81,9 @@ export function useDatabaseStudioCommands(args: Args) {
 			0,
 			EXPORT_ROW_CAP,
 			sort,
-			filters,
-			filterConjunction
+			ignoreFilters ? undefined : filters,
+			ignoreFilters ? undefined : filterConjunction,
+			ignoreFilters ? undefined : filterGroup
 		)
 		if (!result.ok) {
 			notifyActionFailure('Export failed', getAdapterError(result))
@@ -82,8 +92,8 @@ export function useDatabaseStudioCommands(args: Args) {
 		return result.data
 	}
 
-	async function handleExport() {
-		const data = await fetchRowsForExport()
+	async function handleExport(ignoreFilters = false) {
+		const data = await fetchRowsForExport(ignoreFilters)
 		if (!data || data.rows.length === 0) return
 		downloadTextFile(
 			JSON.stringify(data.rows, null, 2),
@@ -92,8 +102,8 @@ export function useDatabaseStudioCommands(args: Args) {
 		)
 	}
 
-	async function handleExportCsvAll() {
-		const data = await fetchRowsForExport()
+	async function handleExportCsvAll(ignoreFilters = false) {
+		const data = await fetchRowsForExport(ignoreFilters)
 		if (!data || data.rows.length === 0) return
 		const csvString = rowsToCsv(
 			data.rows,
@@ -104,8 +114,8 @@ export function useDatabaseStudioCommands(args: Args) {
 		downloadTextFile(csvString, `${tableName || 'data'}.csv`, 'text/csv')
 	}
 
-	async function handleExportSqlAll() {
-		const data = await fetchRowsForExport()
+	async function handleExportSqlAll(ignoreFilters = false) {
+		const data = await fetchRowsForExport(ignoreFilters)
 		if (!data || data.rows.length === 0) return
 		const sqlString = rowsToSqlInsert(
 			data.rows,
@@ -302,6 +312,7 @@ export function useDatabaseStudioCommands(args: Args) {
 		handleExport,
 		handleExportCsvAll,
 		handleExportSqlAll,
+		hasActiveFilters,
 		handleBackupDatabase,
 		handleRestoreDatabase,
 		handleCopySchema,

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
@@ -10,7 +10,7 @@ import { enrichColumnsWithFKs } from "../utils/fk-enrichment";
 import { buildTableCacheKey, schemaHasTable } from "../utils/table-cache";
 import { createDefaultValues } from "../utils/studio-data";
 import { getTableRefParts } from "@studio/shared/utils/table-ref";
-import type { FilterConjunction, FilterDescriptor, PaginationState, SortDescriptor, TableData } from "../types";
+import type { FilterConjunction, FilterDescriptor, FilterGroup, PaginationState, SortDescriptor, TableData } from "../types";
 
 type Args = {
   adapter: DataAdapter;
@@ -23,6 +23,7 @@ type Args = {
   sort: SortDescriptor | undefined;
   filters: FilterDescriptor[];
   filterConjunction: FilterConjunction;
+  filterGroup: FilterGroup;
   tableData: TableData | null;
   draftRow: Record<string, unknown> | null;
   draftInsertIndex: number | null;
@@ -60,6 +61,7 @@ export function useDatabaseStudioSync(args: Args) {
     sort,
     filters,
     filterConjunction,
+    filterGroup,
     tableData,
     draftRow,
     draftInsertIndex,
@@ -166,6 +168,7 @@ export function useDatabaseStudioSync(args: Args) {
         sort,
         filters,
         filterConjunction,
+        filterGroup,
       );
       if (!isCurrentRequest()) return;
 
@@ -230,6 +233,7 @@ export function useDatabaseStudioSync(args: Args) {
     currentCacheKey,
     filters,
     filterConjunction,
+    filterGroup,
     pagination.limit,
     pagination.offset,
     setIsLoading,

--- a/packages/studio/src/features/database-studio/types.ts
+++ b/packages/studio/src/features/database-studio/types.ts
@@ -35,6 +35,28 @@ export type FilterDescriptor = {
 /** How multiple filter conditions are joined together. */
 export type FilterConjunction = 'AND' | 'OR'
 
+/**
+ * A single leaf condition inside a filter group. Identical shape to
+ * {@link FilterDescriptor}; aliased for clarity within the group model.
+ */
+export type FilterCondition = FilterDescriptor
+
+/**
+ * A nestable group of filter conditions joined by a single logic operator.
+ * The root group defaults to `AND`. Nesting is supported one level deep
+ * (i.e. two levels total): a child group may contain only leaf conditions.
+ * Fully serializable for tab persistence (#98).
+ */
+export type FilterGroup = {
+	logic: FilterConjunction
+	conditions: Array<FilterCondition | FilterGroup>
+}
+
+/** Narrows a group member to a nested group (vs a leaf condition). */
+export function isFilterGroup(node: FilterCondition | FilterGroup): node is FilterGroup {
+	return typeof (node as FilterGroup).logic === 'string' && Array.isArray((node as FilterGroup).conditions)
+}
+
 export type TableQueryParams = {
 	tableId: string
 	limit: number
@@ -42,6 +64,12 @@ export type TableQueryParams = {
 	sort?: SortDescriptor
 	filters?: FilterDescriptor[]
 	conjunction?: FilterConjunction
+	/**
+	 * Structured AND/OR filter tree. When present it supersedes the flat
+	 * `filters`/`conjunction` pair. The flat fields are kept for backward
+	 * compatibility with persisted state.
+	 */
+	filterGroup?: FilterGroup
 }
 
 export type ViewMode = 'content' | 'structure' | 'chart'

--- a/packages/studio/src/features/database-studio/utils/table-cache.ts
+++ b/packages/studio/src/features/database-studio/utils/table-cache.ts
@@ -1,5 +1,5 @@
 import { getTableRefParts } from '@studio/shared/utils/table-ref'
-import type { SortDescriptor, FilterDescriptor, FilterConjunction } from '../types'
+import type { SortDescriptor, FilterDescriptor, FilterConjunction, FilterGroup } from '../types'
 
 export function buildTableCacheKey(
 	connectionId: string | undefined,
@@ -8,7 +8,8 @@ export function buildTableCacheKey(
 	offset: number,
 	sort: SortDescriptor | undefined,
 	filters: FilterDescriptor[],
-	conjunction: FilterConjunction = 'AND'
+	conjunction: FilterConjunction = 'AND',
+	filterGroup?: FilterGroup
 ) {
 	return JSON.stringify({
 		connectionId: connectionId || '',
@@ -17,7 +18,8 @@ export function buildTableCacheKey(
 		offset,
 		sort: sort || null,
 		filters,
-		conjunction
+		conjunction,
+		filterGroup: filterGroup || null
 	})
 }
 

--- a/packages/studio/src/features/docker-manager/api/container-service.ts
+++ b/packages/studio/src/features/docker-manager/api/container-service.ts
@@ -123,6 +123,13 @@ type DatabaseImageConfig = {
 	command?: string[]
 }
 
+// CockroachDB publishes its images under `v`-prefixed tags (e.g. `v25.1.1`).
+// The UI stores the bare version (`25.1.1`), so prepend `v` unless it's already
+// there or a non-numeric tag like `latest` was supplied.
+function normalizeCockroachTag(tag: string): string {
+	return /^\d/.test(tag) ? `v${tag}` : tag
+}
+
 function getDatabaseImageConfig(config: DatabaseContainerConfig): DatabaseImageConfig {
 	switch (config.provider) {
 		case 'mariadb':
@@ -157,7 +164,9 @@ function getDatabaseImageConfig(config: DatabaseContainerConfig): DatabaseImageC
 		case 'cockroach':
 			return {
 				image: COCKROACH_IMAGE,
-				imageTag: config.cockroachVersion || '25.1.1',
+				// CockroachDB image tags require a leading `v` (e.g. `v25.1.1`); the
+				// version stored from the UI omits it, so normalize here or the pull 404s.
+				imageTag: normalizeCockroachTag(config.cockroachVersion || '25.1.1'),
 				displayName: 'CockroachDB',
 				buildArgs: [
 					'-p',
@@ -178,8 +187,10 @@ function getDatabaseImageConfig(config: DatabaseContainerConfig): DatabaseImageC
 				command: [
 					'start-single-node',
 					'--insecure',
-					'--listen-addr=0.0.0.0:26257',
-					'--http-addr=0.0.0.0:8080',
+					// CockroachDB v24+ rejects an explicit `0.0.0.0` host in --listen-addr;
+					// an empty host (`:port`) binds all interfaces and is accepted.
+					'--listen-addr=:26257',
+					'--http-addr=:8080',
 					'--store=/cockroach-data'
 				]
 			}

--- a/packages/studio/src/features/sidebar/changelog-data.ts
+++ b/packages/studio/src/features/sidebar/changelog-data.ts
@@ -18,9 +18,14 @@ export const CHANGELOG: ChangelogEntry[] = [
 		version: "Unreleased",
 		date: "2026-06-14",
 		commit: "vUnreleased",
-		title: "Release vUnreleased",
-		description: "Updates in vUnreleased.",
-		type: "feature"
+		title: "AI provider errors now use clear, consistent copy across all providers (Groq, OpenAI, Anthropic, Gemini, Ollama): rate limits, invalid keys, missing models, and an offline Ollama daemon each surface an actionable message instead of a raw HTTP status and response body (#82)",
+		description: "AI provider errors now use clear, consistent copy across all providers (Groq, OpenAI, Anthropic, Gemini, Ollama): rate limits, invalid keys, missing models, and an offline Ollama daemon each surface an actionable message instead of a raw HTTP status and response body (#82). AI Keys settings now spell out that Groq/OpenAI/Anthropic/Gemini need an API key while Ollama runs locally with no key, pointing to `docs/ai-providers.md` for setup (#82).",
+		type: "fix",
+		details: [
+			"AI provider errors now use clear, consistent copy across all providers (Groq, OpenAI, Anthropic, Gemini, Ollama): rate limits, invalid keys, missing models, and an offline Ollama daemon each surface an actionable message instead of a raw HTTP status and response body (#82)",
+			"the AI rate-limit message includes a retry hint so the user knows to wait and try again (#82)",
+			"AI Keys settings now spell out that Groq/OpenAI/Anthropic/Gemini need an API key while Ollama runs locally with no key, pointing to `docs/ai-providers.md` for setup (#82)",
+		]
 	},
 	{
 		version: "0.28.0",

--- a/packages/studio/src/features/sidebar/components/ai-keys-section.tsx
+++ b/packages/studio/src/features/sidebar/components/ai-keys-section.tsx
@@ -353,6 +353,13 @@ export function AiKeysSection() {
 					<code className='font-mono'>{activeProvider.envVar}</code> are merged automatically.
 				</div>
 
+				<div className='text-[10px] leading-snug text-muted-foreground/80'>
+					Groq, OpenAI, Anthropic, and Gemini are cloud providers and need an API key.
+					Ollama runs locally — it needs no key and is configured under the AI provider
+					settings instead. See{' '}
+					<code className='font-mono'>docs/ai-providers.md</code> for per-provider setup.
+				</div>
+
 				<div className='space-y-2 rounded-sm border border-sidebar-border bg-background p-2'>
 					<div className='flex items-center justify-between gap-2'>
 						<span className='text-[10px] uppercase tracking-wide text-muted-foreground'>

--- a/packages/studio/src/features/sidebar/components/settings-panel.tsx
+++ b/packages/studio/src/features/sidebar/components/settings-panel.tsx
@@ -487,6 +487,24 @@ export function SettingsView({ windowControls }: SettingsViewProps = {}) {
 										</Select>
 									</div>
 								</div>
+								<div className='flex items-start justify-between gap-4'>
+									<div className='flex-1'>
+										<div className='text-sm text-sidebar-foreground'>
+											Restore tabs on launch
+										</div>
+										<div className='text-xs leading-tight text-muted-foreground'>
+											Reopen your tabs from the last session. Pinned tabs always restore.
+										</div>
+									</div>
+									<div className='flex-shrink-0 pt-0.5'>
+										<Switch
+											checked={settings.restoreTabsOnLaunch}
+											onCheckedChange={function (checked) {
+												updateSetting('restoreTabsOnLaunch', checked)
+											}}
+										/>
+									</div>
+								</div>
 							</SectionCard>
 
 							<SectionCard

--- a/packages/studio/src/features/sidebar/database-sidebar.tsx
+++ b/packages/studio/src/features/sidebar/database-sidebar.tsx
@@ -709,6 +709,8 @@ export function DatabaseSidebar({
         getTableRefParts(tableName).schemaName,
         format,
         null,
+        null,
+        null,
       );
       if (result.status !== "ok") throw new Error(formatBackendError(result.error));
 

--- a/packages/studio/src/features/sql-console/components/console-toolbar.tsx
+++ b/packages/studio/src/features/sql-console/components/console-toolbar.tsx
@@ -9,7 +9,9 @@ import {
 	Filter,
 	Clock,
 	Bookmark,
-	Database
+	Database,
+	BookOpen,
+	Gauge
 } from 'lucide-react'
 
 import { Button } from '@studio/shared/ui/button'
@@ -19,6 +21,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger
 } from '@studio/shared/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@studio/shared/ui/tooltip'
 import { cn } from '@studio/shared/utils/cn'
 import { WindowControls } from '@studio/components/window-controls'
 import { formatShortcut } from '@studio/core/shortcuts'
@@ -50,25 +53,29 @@ const ToolbarIconButton = forwardRef<HTMLButtonElement, ToolbarIconButtonProps>(
 		ref
 	) {
 		return (
-			<Button
-				ref={ref}
-				variant='ghost'
-				size='icon'
-				className={cn(
-					'h-8 w-8 rounded-md text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out active:scale-[0.97]',
-					'hover:bg-sidebar-accent hover:text-sidebar-foreground',
-					active && 'bg-sidebar-accent text-sidebar-foreground',
-					disabled && 'cursor-not-allowed opacity-45',
-					className
-				)}
-				onClick={onClick}
-				disabled={disabled}
-				title={label}
-				aria-label={label}
-				{...props}
-			>
-				{children}
-			</Button>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						ref={ref}
+						variant='ghost'
+						size='icon'
+						className={cn(
+							'h-8 w-8 rounded-md text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out active:scale-[0.97]',
+							'hover:bg-sidebar-accent hover:text-sidebar-foreground',
+							active && 'bg-sidebar-accent text-sidebar-foreground',
+							disabled && 'cursor-not-allowed opacity-45',
+							className
+						)}
+						onClick={onClick}
+						disabled={disabled}
+						aria-label={label}
+						{...props}
+					>
+						{children}
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent>{label}</TooltipContent>
+			</Tooltip>
 		)
 	}
 )
@@ -180,6 +187,8 @@ type ActionBarProps = {
 	showFilter?: boolean
 	onToggleFilter?: () => void
 	onSave?: () => void
+	onExplainQuery?: () => void
+	onExplainAnalyze?: () => void
 }
 
 export function EditorActionBar({
@@ -196,23 +205,30 @@ export function EditorActionBar({
 	onShowJsonToggle,
 	showFilter,
 	onToggleFilter,
-	onSave
+	onSave,
+	onExplainQuery,
+	onExplainAnalyze
 }: ActionBarProps) {
 	return (
 		<div className='flex h-9 shrink-0 items-center justify-between gap-2 border-t border-sidebar-border bg-sidebar px-2'>
 			<div className='flex min-w-0 items-center gap-1'>
 				{onSave && (
-					<Button
-						size='sm'
-						variant='ghost'
-						className='h-7 gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.97]'
-						onClick={onSave}
-						title='Save to Snippet Library'
-					>
-						<Bookmark className='h-3.5 w-3.5' />
-						<span className='hidden sm:inline'>Save</span>
-						<Kbd className='ml-0.5 inline-flex'>⌘S</Kbd>
-					</Button>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size='sm'
+								variant='ghost'
+								className='h-7 gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.97]'
+								onClick={onSave}
+								aria-label='Save to Snippet Library'
+							>
+								<Bookmark className='h-3.5 w-3.5' />
+								<span className='hidden sm:inline'>Save</span>
+								<Kbd className='ml-0.5 inline-flex'>⌘S</Kbd>
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Save to Snippet Library</TooltipContent>
+					</Tooltip>
 				)}
 
 				{onPrettify && (
@@ -241,6 +257,24 @@ export function EditorActionBar({
 						onClick={onToggleFilter}
 					>
 						<Filter className='h-3.5 w-3.5' />
+					</ToolbarIconButton>
+				)}
+
+				{onExplainQuery && (
+					<ToolbarIconButton
+						label='Explain this query with AI'
+						onClick={onExplainQuery}
+					>
+						<BookOpen className='h-3.5 w-3.5' />
+					</ToolbarIconButton>
+				)}
+
+				{onExplainAnalyze && (
+					<ToolbarIconButton
+						label='Run with EXPLAIN ANALYZE'
+						onClick={onExplainAnalyze}
+					>
+						<Gauge className='h-3.5 w-3.5' />
 					</ToolbarIconButton>
 				)}
 
@@ -288,25 +322,30 @@ export function EditorActionBar({
 					</Button>
 				) : null}
 
-				<Button
-					variant='ghost'
-					size='sm'
-					className={cn(
-						'h-7 gap-1.5 rounded-md px-2 text-xs text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.97]',
-						showRightSidebar && 'bg-sidebar-accent'
-					)}
-					onClick={onToggleRightSidebar}
-					title='Toggle snippets'
-				>
-					<PanelRight
-						className={cn(
-							'h-3.5 w-3.5 transition-transform duration-200',
-							showRightSidebar && 'rotate-180'
-						)}
-						style={{ transitionTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)' }}
-					/>
-					<span className='hidden lg:inline'>Snippets</span>
-				</Button>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant='ghost'
+							size='sm'
+							className={cn(
+								'h-7 gap-1.5 rounded-md px-2 text-xs text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.97]',
+								showRightSidebar && 'bg-sidebar-accent'
+							)}
+							onClick={onToggleRightSidebar}
+							aria-label='Toggle snippets'
+						>
+							<PanelRight
+								className={cn(
+									'h-3.5 w-3.5 transition-transform duration-200',
+									showRightSidebar && 'rotate-180'
+								)}
+								style={{ transitionTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)' }}
+							/>
+							<span className='hidden lg:inline'>Snippets</span>
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Toggle snippets</TooltipContent>
+				</Tooltip>
 			</div>
 		</div>
 	)

--- a/packages/studio/src/features/sql-console/components/query-plan-panel.tsx
+++ b/packages/studio/src/features/sql-console/components/query-plan-panel.tsx
@@ -1,0 +1,301 @@
+import { useMemo } from 'react'
+import { Copy, Network } from 'lucide-react'
+
+import { Button } from '@studio/shared/ui/button'
+import { ScrollArea } from '@studio/shared/ui/scroll-area'
+import { cn } from '@studio/shared/utils/cn'
+import type { SqlQueryResult } from '../types'
+
+type Props = {
+	result: SqlQueryResult
+}
+
+type PlanNode = {
+	label: string
+	detail?: string
+	cost?: number
+	rows?: number
+	width?: number
+	actualTime?: number
+	actualRows?: number
+	loops?: number
+	children: PlanNode[]
+}
+
+type ParsedPlan = {
+	root: PlanNode | null
+	/** Flat text rendering used as a fallback (MySQL, unknown formats). */
+	text: string | null
+	maxCost: number
+}
+
+/**
+ * Detects whether the executed statement was an EXPLAIN / EXPLAIN ANALYZE so the
+ * results area can route it to the dedicated plan view instead of the grid.
+ */
+export function isExplainQuery(query: string | undefined | null): boolean {
+	if (!query) return false
+	return /^\s*explain\b/i.test(query)
+}
+
+/**
+ * Best-effort parser that handles the three shapes Dora can produce:
+ * - Postgres `EXPLAIN (FORMAT JSON)` -> a single JSON column with a `Plan` tree.
+ * - SQLite `EXPLAIN QUERY PLAN` -> rows of { id, parent, detail }.
+ * - Anything else (MySQL, raw text) -> concatenated cell text.
+ */
+function parsePlan(result: SqlQueryResult): ParsedPlan {
+	// --- Postgres: FORMAT JSON ---
+	const pgPlan = tryParsePostgresJson(result)
+	if (pgPlan) {
+		return { root: pgPlan, text: null, maxCost: maxCostOf(pgPlan) }
+	}
+
+	// --- SQLite: EXPLAIN QUERY PLAN ---
+	const sqlitePlan = tryParseSqliteQueryPlan(result)
+	if (sqlitePlan) {
+		return { root: sqlitePlan, text: null, maxCost: 0 }
+	}
+
+	// --- Fallback: render every cell as indented text ---
+	const lines: string[] = []
+	for (const row of result.rows) {
+		for (const col of result.columns) {
+			const value = row[col]
+			if (value === null || value === undefined) continue
+			lines.push(String(value))
+		}
+	}
+	return { root: null, text: lines.join('\n') || 'No plan output.', maxCost: 0 }
+}
+
+function tryParsePostgresJson(result: SqlQueryResult): PlanNode | null {
+	if (result.rows.length === 0) return null
+	const firstRow = result.rows[0]
+
+	// The JSON plan can arrive as a real object/array or as a JSON string.
+	let candidate: unknown = null
+	for (const col of result.columns) {
+		const value = firstRow[col]
+		if (value == null) continue
+		if (typeof value === 'object') {
+			candidate = value
+			break
+		}
+		if (typeof value === 'string') {
+			const trimmed = value.trim()
+			if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+				try {
+					candidate = JSON.parse(trimmed)
+					break
+				} catch {
+					// not JSON, keep scanning
+				}
+			}
+		}
+	}
+
+	if (candidate == null) return null
+
+	// Postgres wraps the plan as: [{ "Plan": { ... } }]
+	const wrapper = Array.isArray(candidate) ? candidate[0] : candidate
+	if (!wrapper || typeof wrapper !== 'object') return null
+	const planObj = (wrapper as Record<string, unknown>).Plan ?? wrapper
+	if (!planObj || typeof planObj !== 'object') return null
+	if (!('Node Type' in (planObj as Record<string, unknown>))) return null
+
+	return convertPostgresNode(planObj as Record<string, unknown>)
+}
+
+function convertPostgresNode(node: Record<string, unknown>): PlanNode {
+	const nodeType = String(node['Node Type'] ?? 'Node')
+	const relation = node['Relation Name']
+	const indexName = node['Index Name']
+	const labelParts = [nodeType]
+	if (typeof indexName === 'string') labelParts.push(`using ${indexName}`)
+	else if (typeof relation === 'string') labelParts.push(`on ${relation}`)
+
+	const childrenRaw = node['Plans']
+	const children = Array.isArray(childrenRaw)
+		? childrenRaw.map(function (child) {
+				return convertPostgresNode(child as Record<string, unknown>)
+			})
+		: []
+
+	return {
+		label: labelParts.join(' '),
+		cost: numberOrUndefined(node['Total Cost']),
+		rows: numberOrUndefined(node['Plan Rows']),
+		width: numberOrUndefined(node['Plan Width']),
+		actualTime: numberOrUndefined(node['Actual Total Time']),
+		actualRows: numberOrUndefined(node['Actual Rows']),
+		loops: numberOrUndefined(node['Actual Loops']),
+		children
+	}
+}
+
+function tryParseSqliteQueryPlan(result: SqlQueryResult): PlanNode | null {
+	const cols = result.columns.map(function (c) {
+		return c.toLowerCase()
+	})
+	const hasDetail = cols.includes('detail')
+	const hasId = cols.includes('id')
+	const hasParent = cols.includes('parent')
+	if (!hasDetail || !hasId || !hasParent) return null
+
+	const idCol = result.columns[cols.indexOf('id')]
+	const parentCol = result.columns[cols.indexOf('parent')]
+	const detailCol = result.columns[cols.indexOf('detail')]
+
+	const nodesById = new Map<number, PlanNode>()
+	const childrenByParent = new Map<number, PlanNode[]>()
+
+	for (const row of result.rows) {
+		const id = Number(row[idCol])
+		const parent = Number(row[parentCol])
+		const node: PlanNode = {
+			label: String(row[detailCol] ?? ''),
+			children: []
+		}
+		nodesById.set(id, node)
+		const siblings = childrenByParent.get(parent) ?? []
+		siblings.push(node)
+		childrenByParent.set(parent, siblings)
+	}
+
+	for (const [id, node] of nodesById) {
+		node.children = childrenByParent.get(id) ?? []
+	}
+
+	const roots = childrenByParent.get(0) ?? []
+	if (roots.length === 0) return null
+	if (roots.length === 1) return roots[0]
+	return { label: 'QUERY PLAN', children: roots }
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+	const n = Number(value)
+	return Number.isFinite(n) ? n : undefined
+}
+
+function maxCostOf(node: PlanNode): number {
+	let max = node.cost ?? 0
+	for (const child of node.children) {
+		max = Math.max(max, maxCostOf(child))
+	}
+	return max
+}
+
+/** Maps a node cost onto a green -> amber -> red scale relative to the plan max. */
+function costColorClass(cost: number | undefined, maxCost: number): string {
+	if (cost === undefined || maxCost <= 0) return 'border-l-sidebar-border'
+	const ratio = cost / maxCost
+	if (ratio < 0.25) return 'border-l-emerald-500'
+	if (ratio < 0.5) return 'border-l-lime-500'
+	if (ratio < 0.75) return 'border-l-amber-500'
+	return 'border-l-red-500'
+}
+
+function PlanTreeNode({
+	node,
+	depth,
+	maxCost
+}: {
+	node: PlanNode
+	depth: number
+	maxCost: number
+}) {
+	const hasMetrics =
+		node.cost !== undefined || node.rows !== undefined || node.actualTime !== undefined
+
+	return (
+		<div>
+			<div
+				className={cn(
+					'border-l-2 py-1 pr-2',
+					costColorClass(node.cost, maxCost)
+				)}
+				style={{ paddingLeft: `${depth * 16 + 8}px` }}
+			>
+				<div className='font-mono text-xs text-sidebar-foreground'>{node.label}</div>
+				{hasMetrics && (
+					<div className='mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 font-mono text-[11px] text-muted-foreground'>
+						{node.cost !== undefined && (
+							<span>cost={node.cost.toLocaleString()}</span>
+						)}
+						{node.rows !== undefined && <span>rows={node.rows.toLocaleString()}</span>}
+						{node.width !== undefined && <span>width={node.width}</span>}
+						{node.actualTime !== undefined && (
+							<span className='text-amber-600 dark:text-amber-400'>
+								actual time={node.actualTime}ms
+							</span>
+						)}
+						{node.actualRows !== undefined && (
+							<span className='text-amber-600 dark:text-amber-400'>
+								actual rows={node.actualRows.toLocaleString()}
+							</span>
+						)}
+						{node.loops !== undefined && <span>loops={node.loops}</span>}
+					</div>
+				)}
+			</div>
+			{node.children.map(function (child, index) {
+				return (
+					<PlanTreeNode
+						key={index}
+						node={child}
+						depth={depth + 1}
+						maxCost={maxCost}
+					/>
+				)
+			})}
+		</div>
+	)
+}
+
+export function QueryPlanPanel({ result }: Props) {
+	const plan = useMemo(
+		function () {
+			return parsePlan(result)
+		},
+		[result]
+	)
+
+	function handleCopy() {
+		const text = plan.text ?? JSON.stringify(result.rows, null, 2)
+		navigator.clipboard.writeText(text)
+	}
+
+	return (
+		<div className='flex h-full flex-col bg-background'>
+			<div className='flex h-8 shrink-0 items-center justify-between border-b border-sidebar-border bg-sidebar-accent/30 px-2'>
+				<div className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+					<Network className='h-3.5 w-3.5' />
+					<span className='font-medium text-sidebar-foreground'>Query plan</span>
+					<span className='text-[11px]'>{result.executionTime}ms</span>
+				</div>
+				<Button
+					variant='ghost'
+					size='icon'
+					className='h-6 w-6 text-muted-foreground hover:text-sidebar-foreground'
+					onClick={handleCopy}
+					title='Copy plan'
+				>
+					<Copy className='h-3.5 w-3.5' />
+				</Button>
+			</div>
+
+			<ScrollArea className='flex-1'>
+				{plan.root ? (
+					<div className='py-2'>
+						<PlanTreeNode node={plan.root} depth={0} maxCost={plan.maxCost} />
+					</div>
+				) : (
+					<pre className='whitespace-pre-wrap p-3 font-mono text-xs text-sidebar-foreground'>
+						{plan.text}
+					</pre>
+				)}
+			</ScrollArea>
+		</div>
+	)
+}

--- a/packages/studio/src/features/sql-console/components/sql-results.tsx
+++ b/packages/studio/src/features/sql-console/components/sql-results.tsx
@@ -1,6 +1,7 @@
 import Editor from '@monaco-editor/react'
 import { Table2, Braces, Download, Copy, Trash2, CircleCheck, Database, BarChart3, Sparkles } from 'lucide-react'
 import { askAi, buildFixErrorPrompt } from '@studio/features/ai-assistant/ai-actions'
+import { QueryPlanPanel, isExplainQuery } from './query-plan-panel'
 import { useAsyncRowCount } from '../hooks/use-async-row-count'
 import {
 	AlertDialog,
@@ -16,6 +17,7 @@ import { useState, useRef, useEffect, useMemo } from 'react'
 import { useDataMutation } from '@studio/core/data-provider'
 import { useSettings } from '@studio/core/settings'
 import { Button } from '@studio/shared/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@studio/shared/ui/tooltip'
 import {
 	ContextMenu,
 	ContextMenuTrigger,
@@ -350,48 +352,63 @@ export function SqlResults({
 		<div className='flex flex-col h-full bg-background'>
 			<div className='flex items-center justify-between h-8 px-2 border-b border-sidebar-border bg-sidebar-accent/30 shrink-0'>
 				<div className='flex items-center gap-0.5'>
-					<Button
-						variant='ghost'
-						size='icon'
-						className={cn(
-							'h-6 w-6',
-							viewMode === 'table'
-								? 'bg-sidebar-accent text-sidebar-foreground'
-								: 'text-muted-foreground hover:text-sidebar-foreground'
-						)}
-						onClick={() => onViewModeChange('table')}
-						title='Table view'
-					>
-						<Table2 className='h-3.5 w-3.5' />
-					</Button>
-					<Button
-						variant='ghost'
-						size='icon'
-						className={cn(
-							'h-6 w-6',
-							viewMode === 'json'
-								? 'bg-sidebar-accent text-sidebar-foreground'
-								: 'text-muted-foreground hover:text-sidebar-foreground'
-						)}
-						onClick={() => onViewModeChange('json')}
-						title='JSON view'
-					>
-						<Braces className='h-3.5 w-3.5' />
-					</Button>
-					<Button
-						variant='ghost'
-						size='icon'
-						className={cn(
-							'h-6 w-6',
-							viewMode === 'chart'
-								? 'bg-sidebar-accent text-sidebar-foreground'
-								: 'text-muted-foreground hover:text-sidebar-foreground'
-						)}
-						onClick={() => onViewModeChange('chart')}
-						title='Chart view'
-					>
-						<BarChart3 className='h-3.5 w-3.5' />
-					</Button>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant='ghost'
+								size='icon'
+								className={cn(
+									'h-6 w-6',
+									viewMode === 'table'
+										? 'bg-sidebar-accent text-sidebar-foreground'
+										: 'text-muted-foreground hover:text-sidebar-foreground'
+								)}
+								onClick={() => onViewModeChange('table')}
+								aria-label='Table view'
+							>
+								<Table2 className='h-3.5 w-3.5' />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Table view</TooltipContent>
+					</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant='ghost'
+								size='icon'
+								className={cn(
+									'h-6 w-6',
+									viewMode === 'json'
+										? 'bg-sidebar-accent text-sidebar-foreground'
+										: 'text-muted-foreground hover:text-sidebar-foreground'
+								)}
+								onClick={() => onViewModeChange('json')}
+								aria-label='JSON view'
+							>
+								<Braces className='h-3.5 w-3.5' />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>JSON view</TooltipContent>
+					</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant='ghost'
+								size='icon'
+								className={cn(
+									'h-6 w-6',
+									viewMode === 'chart'
+										? 'bg-sidebar-accent text-sidebar-foreground'
+										: 'text-muted-foreground hover:text-sidebar-foreground'
+								)}
+								onClick={() => onViewModeChange('chart')}
+								aria-label='Chart view'
+							>
+								<BarChart3 className='h-3.5 w-3.5' />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>Chart view</TooltipContent>
+					</Tooltip>
 					{result && !result.error && (
 						<span className='ml-1.5 inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] text-emerald-600 dark:text-emerald-400'>
 							<CircleCheck className='h-3 w-3' />
@@ -400,16 +417,21 @@ export function SqlResults({
 					)}
 				</div>
 
-				<Button
-					variant='ghost'
-					size='icon'
-					className='h-6 w-6 text-muted-foreground hover:text-sidebar-foreground'
-					onClick={onExport}
-					disabled={!result || result.rows.length === 0}
-					title='Export results'
-				>
-					<Download className='h-3.5 w-3.5' />
-				</Button>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant='ghost'
+							size='icon'
+							className='h-6 w-6 text-muted-foreground hover:text-sidebar-foreground'
+							onClick={onExport}
+							disabled={!result || result.rows.length === 0}
+							aria-label='Export results'
+						>
+							<Download className='h-3.5 w-3.5' />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Export results</TooltipContent>
+				</Tooltip>
 			</div>
 
 			<div className='flex-1 overflow-hidden'>
@@ -438,6 +460,8 @@ export function SqlResults({
 							)}
 						</div>
 					</div>
+				) : isExplainQuery(result.executedQuery) ? (
+					<QueryPlanPanel result={result} />
 				) : viewMode === 'chart' ? (
 					<ResultChartPanel
 						columns={result.columns.map(function (column) {

--- a/packages/studio/src/features/sql-console/sql-console.tsx
+++ b/packages/studio/src/features/sql-console/sql-console.tsx
@@ -1,6 +1,8 @@
-import { lazy, Suspense, useState, useCallback, useEffect, useRef } from "react";
+import { lazy, Suspense, useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useAdapter, useIsTauri } from "@studio/core/data-provider/context";
+import { useConnections } from "@studio/core/data-provider";
+import { askAi, buildExplainQueryPrompt } from "@studio/features/ai-assistant/ai-actions";
 import { getAdapterError } from "@studio/core/data-provider/types";
 import { useShortcut, useActiveScope, useEffectiveShortcuts } from "@studio/core/shortcuts";
 import {
@@ -73,6 +75,7 @@ function SqlConsoleInner({
 }: Props) {
   const adapter = useAdapter();
   const isTauri = useIsTauri();
+  const { data: connections } = useConnections();
   const tabStore = useQueryTabs();
   const { activeTab } = tabStore;
   const shortcuts = useEffectiveShortcuts();
@@ -399,6 +402,7 @@ function SqlConsoleInner({
               queryType,
               columnDefinitions,
               sourceTable: extractMutationSourceTable(queryToRun),
+              executedQuery: queryToRun,
             });
             // Auto-title the tab from the query
             tabStore.autoTitleTab(activeTab.id, queryToRun);
@@ -452,6 +456,7 @@ function SqlConsoleInner({
               queryType: getQueryType(sqlToRun),
               columnDefinitions: res.data.columnDefinitions,
               sourceTable: extractMutationSourceTable(queryToRun),
+              executedQuery: sqlToRun,
             });
 
             // Drizzle queries may also mutate data (insert, update, delete).
@@ -523,6 +528,48 @@ function SqlConsoleInner({
       await adapter.cancelActiveQuery(activeConnectionId);
     }
   }, [adapter, activeConnectionId]);
+
+  const activeDialect = useMemo(() => {
+    const connection = connections?.find(function (c) {
+      return c.id === activeConnectionId;
+    });
+    if (!connection) return "unknown";
+    const type = connection.type;
+    if (type === "sqlite" || type === "libsql" || type === "duckdb") return "sqlite";
+    if (type === "postgres" || type === "cockroach") return "postgres";
+    if (type === "mysql" || type === "mariadb") return "mysql";
+    return "unknown";
+  }, [connections, activeConnectionId]);
+
+  const handleExplainQuery = useCallback(() => {
+    const query = (mode === "sql" ? currentSqlQuery : currentDrizzleQuery).trim();
+    if (!query) return;
+    askAi(buildExplainQueryPrompt(query));
+  }, [mode, currentSqlQuery, currentDrizzleQuery]);
+
+  const handleExplainAnalyze = useCallback(() => {
+    const baseQuery = currentSqlQuery.trim().replace(/;\s*$/, "");
+    if (!baseQuery) return;
+
+    let explained: string;
+    if (activeDialect === "sqlite") {
+      // SQLite does not support EXPLAIN ANALYZE; use EXPLAIN QUERY PLAN.
+      explained = `EXPLAIN QUERY PLAN ${baseQuery}`;
+    } else if (activeDialect === "postgres") {
+      explained = `EXPLAIN (ANALYZE, FORMAT JSON) ${baseQuery}`;
+    } else {
+      // MySQL / MariaDB / unknown: best-effort text plan.
+      explained = `EXPLAIN ANALYZE ${baseQuery}`;
+    }
+
+    if (mode !== "sql") {
+      setMode("sql");
+    }
+    handleExecute(explained, "sql").catch(function (error) {
+      console.error("Failed to run EXPLAIN ANALYZE:", error);
+      notifyFailure("Failed to run EXPLAIN ANALYZE", error);
+    });
+  }, [activeDialect, currentSqlQuery, mode, handleExecute]);
 
   useEffect(
     function registerCaptureHelpers() {
@@ -1165,6 +1212,8 @@ function SqlConsoleInner({
                         setShowFilter(!showFilter);
                       }}
                       onSave={handleSaveSnippet}
+                      onExplainQuery={handleExplainQuery}
+                      onExplainAnalyze={mode === "sql" ? handleExplainAnalyze : undefined}
                     />
                   </div>
                 }

--- a/packages/studio/src/features/sql-console/types.ts
+++ b/packages/studio/src/features/sql-console/types.ts
@@ -22,6 +22,8 @@ export type SqlQueryResult = {
 	queryType: 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE' | 'OTHER'
 	columnDefinitions?: ColumnDefinition[]
 	sourceTable?: string
+	/** The exact SQL that produced this result, used to detect EXPLAIN plans. */
+	executedQuery?: string
 }
 
 export type TableInfo = {

--- a/packages/studio/src/features/tab-bar/tab-bar.tsx
+++ b/packages/studio/src/features/tab-bar/tab-bar.tsx
@@ -115,6 +115,7 @@ export function TabBar({
                   ) : null}
                   <button
                     onClick={() => onTabClick(tab.id)}
+                    onAuxClick={(e) => { if (e.button === 1) { e.preventDefault(); onTabClose(tab.id) } }}
                     className="flex items-center gap-1.5 h-full px-2 pl-3 text-xs font-medium"
                     data-tauri-drag-region="false"
                   >

--- a/packages/studio/src/lib/bindings.ts
+++ b/packages/studio/src/lib/bindings.ts
@@ -463,6 +463,14 @@ async updateCell(connectionId: string, tableName: string, schemaName: string | n
     else return { status: "error", error: e  as any };
 }
 },
+async getBlobBytes(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValue: JsonValue, columnName: string) : Promise<Result<number[], { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_blob_bytes", { connectionId, tableName, schemaName, primaryKeyColumn, primaryKeyValue, columnName }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async deleteRows(connectionId: string, tableName: string, schemaName: string | null, primaryKeyColumn: string, primaryKeyValues: JsonValue[]) : Promise<Result<MutationResult, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("delete_rows", { connectionId, tableName, schemaName, primaryKeyColumn, primaryKeyValues }) };
@@ -479,9 +487,9 @@ async duplicateRow(connectionId: string, tableName: string, schemaName: string |
     else return { status: "error", error: e  as any };
 }
 },
-async exportTable(connectionId: string, tableName: string, schemaName: string | null, format: ExportFormat, limit: number | null) : Promise<Result<string, { kind: string; detail: string }>> {
+async exportTable(connectionId: string, tableName: string, schemaName: string | null, format: ExportFormat, limit: number | null, whereClause: string | null, orderBy: string | null) : Promise<Result<string, { kind: string; detail: string }>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("export_table", { connectionId, tableName, schemaName, format, limit }) };
+    return { status: "ok", data: await TAURI_INVOKE("export_table", { connectionId, tableName, schemaName, format, limit, whereClause, orderBy }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/packages/studio/src/pages/Index.tsx
+++ b/packages/studio/src/pages/Index.tsx
@@ -32,6 +32,7 @@ import { Sparkles } from "lucide-react";
 import { Button } from "@studio/shared/ui/button";
 import { TabsProvider, useTabs } from "@studio/core/tabs";
 import { TabBar } from "@studio/features/tab-bar";
+import { ConnectionTabBar } from "@studio/features/connection-tab-bar";
 const DatabaseStudio = lazy(function () {
   return import("@studio/features/database-studio/database-studio").then(function (m) {
     return { default: m.DatabaseStudio };
@@ -80,7 +81,8 @@ function IndexInner() {
 
   const { data: connections = [], isLoading: isConnectionsLoading } = useConnections();
   const isLoading = isSettingsLoading || isConnectionsLoading;
-  const { addConnection, updateConnection, removeConnection } = useConnectionMutations();
+  const { addConnection, updateConnection, removeConnection, disconnectFromDatabase } =
+    useConnectionMutations();
   const isTauri = useIsTauri();
 
   const urlView = searchParams.get("view");
@@ -93,7 +95,10 @@ function IndexInner() {
 
   const {
     tabs,
+    visibleTabs,
     activeTabId,
+    activeConnectionId,
+    openConnectionIds,
     openTab,
     closeTab,
     closeOtherTabs,
@@ -103,15 +108,52 @@ function IndexInner() {
     togglePinTab,
     reorderTab,
     closeTabsForConnection,
+    hydrateSession,
+    setActiveConnection,
+    openConnection,
+    closeConnection,
   } = useTabs();
+  const sessionHydratedRef = useRef(false);
+
+  // Restore tabs persisted from the last session (issue #98). Tabs render
+  // synchronously from storage on first paint; this one-shot effect prunes them
+  // once we know the user's preference and which connections still exist:
+  // unpinned tabs are dropped when "restore on launch" is off, and any tab whose
+  // connection no longer exists is dropped. Pinned tabs always restore.
+  useEffect(
+    function hydrateTabSessionOnce() {
+      if (sessionHydratedRef.current) return;
+      if (isSettingsLoading || isConnectionsLoading) return;
+      sessionHydratedRef.current = true;
+      hydrateSession({
+        restoreUnpinned: settings.restoreTabsOnLaunch,
+        knownConnectionIds: new Set(connections.map((c) => c.id)),
+      });
+    },
+    [
+      isSettingsLoading,
+      isConnectionsLoading,
+      settings.restoreTabsOnLaunch,
+      connections,
+      hydrateSession,
+    ],
+  );
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
   const activeTabConnectionId = activeTab?.connectionId ?? "";
 
   const autoSelectFirstTableRef = useRef(false);
   const connectionInitializedRef = useRef(false);
-  const previousConnectionIdRef = useRef<string>("");
 
-  const [activeConnectionId, setActiveConnectionId] = useState<string>("");
+  // `activeConnectionId` now lives in the tabs store so each connection keeps its
+  // own tab group (issue #96). This bridge keeps the existing call sites that
+  // expect a setter working: selecting a connection opens + activates it, and
+  // passing "" is a no-op (use closeConnection to actually close one).
+  const setActiveConnectionId = useCallback(
+    function (connectionId: string) {
+      if (connectionId) setActiveConnection(connectionId);
+    },
+    [setActiveConnection],
+  );
   const [sqlConsoleEditorContext, setSqlConsoleEditorContext] =
     useState<AiAssistantEditorContext | null>(null);
   const selectedTableId =
@@ -264,6 +306,24 @@ function IndexInner() {
         setActiveNavId("docker");
       },
       { description: shortcuts.gotoDocker.description },
+    );
+
+  // Cycle through open connection tab groups (issue #96).
+  $.bind(shortcuts.prevConnection.combo)
+    .except("typing")
+    .on(
+      function () {
+        cycleConnection(-1);
+      },
+      { description: shortcuts.prevConnection.description },
+    );
+  $.bind(shortcuts.nextConnection.combo)
+    .except("typing")
+    .on(
+      function () {
+        cycleConnection(1);
+      },
+      { description: shortcuts.nextConnection.description },
     );
 
   // Connection switching by index (1-9)
@@ -596,9 +656,8 @@ function IndexInner() {
     if (!connection) return;
     try {
       await removeConnection.mutateAsync(connection.id);
-      if (activeConnectionId === connection.id) {
-        setActiveConnectionId("");
-      }
+      // Removing a connection also closes its tab group and clears it as active.
+      closeConnection(connection.id);
       closeTabsForConnection(connection.id);
       toast({
         title: "Connection Deleted",
@@ -617,9 +676,32 @@ function IndexInner() {
   }
 
   async function handleConnectionSelect(connectionId: string) {
-    setActiveConnectionId(connectionId);
+    setActiveConnection(connectionId);
     autoSelectFirstTableRef.current = false;
   }
+
+  // Close a connection tab (issue #96): disconnect its backend session and drop
+  // its tab group. The store picks the nearest remaining connection as active,
+  // or the empty state when none remain. The connection itself is NOT deleted —
+  // it stays in the saved connection list and can be reopened.
+  function handleCloseConnection(connectionId: string) {
+    closeConnection(connectionId);
+    closeTabsForConnection(connectionId);
+    disconnectFromDatabase.mutate(connectionId);
+  }
+
+  // Cycle through open connection tabs (Ctrl+Shift+[ / Ctrl+Shift+]).
+  const cycleConnection = useCallback(
+    function (direction: 1 | -1) {
+      if (openConnectionIds.length < 2) return;
+      const currentIndex = openConnectionIds.indexOf(activeConnectionId);
+      const baseIndex = currentIndex === -1 ? 0 : currentIndex;
+      const nextIndex =
+        (baseIndex + direction + openConnectionIds.length) % openConnectionIds.length;
+      setActiveConnection(openConnectionIds[nextIndex]);
+    },
+    [openConnectionIds, activeConnectionId, setActiveConnection],
+  );
 
   const handleTabClick = useCallback(
     function (tabId: string) {
@@ -709,17 +791,11 @@ function IndexInner() {
     [activeNavId],
   );
 
-  useEffect(
-    function clearTabsFromPreviousConnection() {
-      const previousConnectionId = previousConnectionIdRef.current;
-      if (previousConnectionId && previousConnectionId !== activeConnectionId) {
-        closeTabsForConnection(previousConnectionId);
-      }
-
-      previousConnectionIdRef.current = activeConnectionId;
-    },
-    [activeConnectionId, closeTabsForConnection],
-  );
+  // Issue #96: switching connections no longer tears down the previous
+  // connection's tabs — each connection keeps its own isolated tab group. The
+  // table TabBar renders only the active connection's tabs (`visibleTabs`), so
+  // switching simply changes which group is shown and naturally preserves each
+  // connection's open tabs, active tab, filter and scroll state.
 
   // Show database panel for sql-console and database-studio views
   const showDatabasePanel =
@@ -730,6 +806,32 @@ function IndexInner() {
     activeNavId === "docker" || activeNavId === "sql-console" || activeNavId === "settings"
       ? activeNavId
       : "database-studio";
+
+  // The connections the user has open, resolved to full Connection objects in
+  // the order their connection tabs appear (issue #96). Stale ids (a connection
+  // deleted elsewhere) are filtered out.
+  const openConnections = openConnectionIds
+    .map(function (id) {
+      return connections.find(function (c) {
+        return c.id === id;
+      });
+    })
+    .filter(function (c): c is Connection {
+      return Boolean(c);
+    });
+  const showConnectionTabBar =
+    openConnections.length > 0 &&
+    (activeNavId === "database-studio" || activeNavId === "sql-console");
+
+  const connectionTabBar = showConnectionTabBar ? (
+    <ConnectionTabBar
+      connections={openConnections}
+      activeConnectionId={activeConnectionId}
+      onSelect={handleConnectionSelect}
+      onClose={handleCloseConnection}
+      onAddConnection={handleOpenNewConnection}
+    />
+  ) : null;
 
   return (
     <LiveMonitorProvider activeConnectionId={activeConnectionId || undefined}>
@@ -814,8 +916,9 @@ function IndexInner() {
                     </div>
                   ) : activeNavId === "database-studio" ? (
                     <div className="flex flex-col flex-1 min-h-0">
+                      {connectionTabBar}
                       <TabBar
-                        tabs={tabs}
+                        tabs={visibleTabs}
                         activeTabId={activeTabId}
                         onTabClick={handleTabClick}
                         onTabClose={closeTab}
@@ -851,19 +954,22 @@ function IndexInner() {
                       </ErrorBoundary>
                     </div>
                   ) : activeNavId === "sql-console" ? (
-                    <ErrorBoundary feature="SQL Console">
-                      <SqlConsole
-                        activeConnectionId={activeConnectionId}
-                        onEditorContextChange={setSqlConsoleEditorContext}
-                        getConnectionName={function (id) {
-                          return (
-                            connections.find(function (c) {
-                              return c.id === id;
-                            })?.name ?? id.slice(0, 8)
-                          );
-                        }}
-                      />
-                    </ErrorBoundary>
+                    <div className="flex flex-col flex-1 min-h-0">
+                      {connectionTabBar}
+                      <ErrorBoundary feature="SQL Console">
+                        <SqlConsole
+                          activeConnectionId={activeConnectionId}
+                          onEditorContextChange={setSqlConsoleEditorContext}
+                          getConnectionName={function (id) {
+                            return (
+                              connections.find(function (c) {
+                                return c.id === id;
+                              })?.name ?? id.slice(0, 8)
+                            );
+                          }}
+                        />
+                      </ErrorBoundary>
+                    </div>
                   ) : activeNavId === "schema-visualizer" ? (
                     <ErrorBoundary feature="Schema Visualizer">
                       <SchemaVisualizer


### PR DESCRIPTION
Net-new work on top of `master` closing several open issues, plus two genuine bug fixes found while validating the dialect work.

## Features
- **#96 Multiple simultaneous connections** with per-connection tab groups — `ConnectionTabBar`, `Ctrl+Shift+[` / `]` cycling, session persistence v2. Lower-risk approach: keep the flat tab list, scope by `activeConnectionId` (no `Map<conn, Tab[]>` rewrite).
- **#97 EXPLAIN / query-plan panel** — Postgres `FORMAT JSON`, SQLite `QUERY PLAN`, MySQL text; cost heat-coloring; "Run with EXPLAIN ANALYZE" toolbar button.
- **#104 Contextual AI actions (finished)** — "Explain this query" + "Suggest indexes" ("Fix with AI" already existed).
- **#90 Binary/blob cell display (frontend)** — cell renderer, Copy as hex/base64, Save to file, new `get_blob_bytes` command (SQLite/Postgres/LibSQL), Postgres `BYTEA` routed through `blob_display`.
- **#88/#89 Dialect detection foundation** — runtime `SELECT version()` detection of CockroachDB / MariaDB, dialect stored on the connection, `SourceCaps` gating (CockroachDB LISTEN/NOTIFY disabled), unit tests. **Schema-introspection parity is deliberately deferred** with `TODO(dialect-parity)` markers — it needs live clusters and is the subject of the follow-up plan.

## Beta hardening (#82)
- Unified per-provider AI error messages (rate limit, invalid key, model not found, Ollama offline), settings copy, changelog entries.

## Fixes
- **docker-manager: CockroachDB containers failed to start** — image tag was missing the required `v` prefix, and `--listen-addr=0.0.0.0` is rejected by CockroachDB v24+. Normalize the tag and bind via `:port`. Same fix applied to `docker-compose.databases.yml`.

## UI polish
- Styled hover tooltips on the SQL console + results toolbars (replacing slow native `title=`); aria-labels retained.
- Middle-click anywhere on a tab to close it (previously only the × button).

## Verification
- `bun run --cwd packages/studio typecheck` — clean
- `cargo check --lib` — clean
- 332 frontend tests pass; Rust dialect (11) + sqlite parser (15) tests pass

## Not in this PR (intentional)
Full CockroachDB/MariaDB dialect parity (schema introspection + type mapping) is staged behind `TODO` markers and tracked separately — see the engine/dialect architecture plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)