### PR TITLE
refactor(database): dialect as engine field, not peer variant (keystone)

### DIFF
--- a/apps/desktop/src-tauri/src/database/adapter/read.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/read.rs
@@ -13,6 +13,7 @@ use tokio_postgres::Client as PgClient;
 
 use crate::{
     database::{
+        dialect::{MySqlDialect, PgDialect},
         parser::ParsedStatement,
         types::{DatabaseSchema, ExecSender},
     },
@@ -29,7 +30,7 @@ use crate::{
 /// # Example
 ///
 /// ```ignore
-/// let adapter = PostgresAdapter::new(client);
+/// let adapter = PostgresAdapter::new(client, use_simple_query, dialect);
 /// let statements = adapter.parse_statements("SELECT * FROM users")?;
 /// adapter.execute_query(statements[0], &sender).await?;
 /// ```
@@ -82,18 +83,26 @@ impl std::fmt::Display for DatabaseType {
 pub struct PostgresAdapter {
     client: Arc<PgClient>,
     use_simple_query: bool,
+    /// Runtime dialect (vanilla unless CockroachDB detected). Threaded into
+    /// schema introspection and the row writer; vanilla-only behaviour for now.
+    dialect: PgDialect,
 }
 
 impl PostgresAdapter {
-    pub fn new(client: Arc<PgClient>, use_simple_query: bool) -> Self {
+    pub fn new(client: Arc<PgClient>, use_simple_query: bool, dialect: PgDialect) -> Self {
         Self {
             client,
             use_simple_query,
+            dialect,
         }
     }
 
     pub fn client(&self) -> &PgClient {
         &self.client
+    }
+
+    pub fn dialect(&self) -> PgDialect {
+        self.dialect
     }
 }
 
@@ -109,12 +118,13 @@ impl DatabaseAdapter for PostgresAdapter {
             stmt,
             sender,
             self.use_simple_query,
+            self.dialect,
         )
         .await
     }
 
     async fn get_schema(&self) -> Result<DatabaseSchema, Error> {
-        crate::database::postgres::schema::get_database_schema(&self.client).await
+        crate::database::postgres::schema::get_database_schema(&self.client, self.dialect).await
     }
 
     fn is_connected(&self) -> bool {
@@ -277,15 +287,21 @@ impl DatabaseAdapter for LibSqlAdapter {
 
 pub struct MySqlAdapter {
     pool: Arc<mysql_async::Pool>,
+    /// Runtime dialect (vanilla unless MariaDB detected). Vanilla-only today.
+    dialect: MySqlDialect,
 }
 
 impl MySqlAdapter {
-    pub fn new(pool: Arc<mysql_async::Pool>) -> Self {
-        Self { pool }
+    pub fn new(pool: Arc<mysql_async::Pool>, dialect: MySqlDialect) -> Self {
+        Self { pool, dialect }
     }
 
     pub fn pool(&self) -> &mysql_async::Pool {
         &self.pool
+    }
+
+    pub fn dialect(&self) -> MySqlDialect {
+        self.dialect
     }
 }
 
@@ -300,7 +316,7 @@ impl DatabaseAdapter for MySqlAdapter {
     }
 
     async fn get_schema(&self) -> Result<DatabaseSchema, Error> {
-        crate::database::mysql::schema::get_database_schema(self.pool.clone()).await
+        crate::database::mysql::schema::get_database_schema(self.pool.clone(), self.dialect).await
     }
 
     fn is_connected(&self) -> bool {
@@ -319,9 +335,10 @@ pub fn adapter_from_client(client: &crate::database::types::DatabaseClient) -> B
         crate::database::types::DatabaseClient::Postgres {
             client,
             use_simple_query,
-        } => Box::new(PostgresAdapter::new(client.clone(), *use_simple_query)),
-        crate::database::types::DatabaseClient::MySQL { pool } => {
-            Box::new(MySqlAdapter::new(pool.clone()))
+            dialect,
+        } => Box::new(PostgresAdapter::new(client.clone(), *use_simple_query, *dialect)),
+        crate::database::types::DatabaseClient::MySQL { pool, dialect } => {
+            Box::new(MySqlAdapter::new(pool.clone(), *dialect))
         }
         crate::database::types::DatabaseClient::SQLite { connection } => {
             Box::new(SqliteAdapter::new(connection.clone()))

--- a/apps/desktop/src-tauri/src/database/adapter/watch.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/watch.rs
@@ -30,7 +30,7 @@ impl WatchAdapter for PostgresAdapter {
 
         let mut row_values = Vec::with_capacity(rows.len());
         for row in &rows {
-            let mut writer = PostgresRowWriter::new();
+            let mut writer = PostgresRowWriter::new(self.dialect());
             writer.add_row(row)?;
             let value: serde_json::Value = serde_json::from_str(writer.finish().get())?;
             let values = value
@@ -181,9 +181,10 @@ pub fn watch_adapter_from_client(
         crate::database::types::DatabaseClient::Postgres {
             client,
             use_simple_query,
-        } => Box::new(PostgresAdapter::new(client.clone(), *use_simple_query)),
-        crate::database::types::DatabaseClient::MySQL { pool } => {
-            Box::new(MySqlAdapter::new(pool.clone()))
+            dialect,
+        } => Box::new(PostgresAdapter::new(client.clone(), *use_simple_query, *dialect)),
+        crate::database::types::DatabaseClient::MySQL { pool, dialect } => {
+            Box::new(MySqlAdapter::new(pool.clone(), *dialect))
         }
         crate::database::types::DatabaseClient::SQLite { connection } => {
             Box::new(SqliteAdapter::new(connection.clone()))

--- a/apps/desktop/src-tauri/src/database/adapter/write.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write.rs
@@ -123,9 +123,10 @@ pub fn write_adapter_from_client(
         crate::database::types::DatabaseClient::Postgres {
             client,
             use_simple_query,
-        } => Box::new(PostgresAdapter::new(client.clone(), *use_simple_query)),
-        crate::database::types::DatabaseClient::MySQL { pool } => {
-            Box::new(MySqlAdapter::new(pool.clone()))
+            dialect,
+        } => Box::new(PostgresAdapter::new(client.clone(), *use_simple_query, *dialect)),
+        crate::database::types::DatabaseClient::MySQL { pool, dialect } => {
+            Box::new(MySqlAdapter::new(pool.clone(), *dialect))
         }
         crate::database::types::DatabaseClient::SQLite { connection } => {
             Box::new(SqliteAdapter::new(connection.clone()))

--- a/apps/desktop/src-tauri/src/database/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/database/commands/ai.rs
@@ -93,10 +93,16 @@ fn engine_for_connection(state: &AppState, conn_id: Uuid) -> String {
         .connections
         .get(&conn_id)
         .map(|entry| match entry.value().database {
+            Database::Postgres {
+                dialect: crate::database::dialect::PgDialect::CockroachDb,
+                ..
+            } => "cockroach",
             Database::Postgres { .. } => "postgres",
-            Database::CockroachDB { .. } => "cockroach",
+            Database::MySQL {
+                dialect: crate::database::dialect::MySqlDialect::MariaDb,
+                ..
+            } => "mariadb",
             Database::MySQL { .. } => "mysql",
-            Database::MariaDB { .. } => "mariadb",
             Database::SQLite { .. } => "sqlite",
             Database::DuckDB { .. } => "duckdb",
             Database::LibSQL { .. } => "libsql",

--- a/apps/desktop/src-tauri/src/database/connection_monitor.rs
+++ b/apps/desktop/src-tauri/src/database/connection_monitor.rs
@@ -47,7 +47,6 @@ impl ConnectionMonitor {
         connection.connected = false;
         match &mut connection.database {
             crate::database::types::Database::Postgres { client, .. } => *client = None,
-            crate::database::types::Database::CockroachDB { client, .. } => *client = None,
             crate::database::types::Database::SQLite {
                 connection: sqlite_conn,
                 ..
@@ -61,9 +60,6 @@ impl ConnectionMonitor {
                 ..
             } => *libsql_conn = None,
             crate::database::types::Database::MySQL {
-                pool: mysql_pool, ..
-            } => *mysql_pool = None,
-            crate::database::types::Database::MariaDB {
                 pool: mysql_pool, ..
             } => *mysql_pool = None,
         }

--- a/apps/desktop/src-tauri/src/database/connection_repository.rs
+++ b/apps/desktop/src-tauri/src/database/connection_repository.rs
@@ -52,10 +52,10 @@ impl ConnectionRepository for AppState {
             .ok_or(Error::ConnectionNotFound(connection_id))?;
 
         match &connection_entry.value().database {
-            Database::Postgres { .. } | Database::CockroachDB { .. } => {
+            Database::Postgres { .. } => {
                 crate::database::postgres::parser::parse_statements(query).map_err(Into::into)
             }
-            Database::MySQL { .. } | Database::MariaDB { .. } => {
+            Database::MySQL { .. } => {
                 crate::database::mysql::parser::parse_statements(query).map_err(Into::into)
             }
             Database::SQLite { .. } => {

--- a/apps/desktop/src-tauri/src/database/dialect.rs
+++ b/apps/desktop/src-tauri/src/database/dialect.rs
@@ -15,23 +15,94 @@ use serde::Serialize;
 use specta::Type;
 
 /// Concrete engine behind a Postgres-wire connection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum PgDialect {
     /// Vanilla PostgreSQL (the default / safe path).
+    #[default]
     Postgres,
     /// CockroachDB speaking the Postgres wire protocol.
     CockroachDb,
 }
 
+impl PgDialect {
+    /// Source capabilities for this dialect.
+    ///
+    /// Resolution layers (per the data-source spec): model defaults → engine
+    /// overrides → dialect overrides. For now the engine default is vanilla
+    /// Postgres and only CockroachDB diverges (no LISTEN/NOTIFY).
+    pub const fn caps(self) -> SourceCaps {
+        SourceCaps::for_dialect(self.detected())
+    }
+
+    /// The unified `DetectedDialect` tag for this Postgres-wire dialect.
+    pub const fn detected(self) -> DetectedDialect {
+        match self {
+            PgDialect::Postgres => DetectedDialect::Postgres,
+            PgDialect::CockroachDb => DetectedDialect::CockroachDb,
+        }
+    }
+
+    /// Introspection-query overrides for this dialect.
+    ///
+    /// Vanilla for every dialect today; Phase 2 will return per-dialect catalog
+    /// query overrides here.
+    // TODO(dialect-parity): override per dialect
+    pub const fn introspection(self) -> PgIntrospection {
+        PgIntrospection::VANILLA
+    }
+}
+
+/// Placeholder for per-dialect Postgres introspection query overrides.
+///
+/// Phase 2 will give this real fields (catalog query strings, type-mapping
+/// tables). For now it is a zero-sized vanilla marker so the seam exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PgIntrospection;
+
+impl PgIntrospection {
+    pub const VANILLA: Self = Self;
+}
+
 /// Concrete engine behind a MySQL-wire connection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum MySqlDialect {
     /// Vanilla MySQL (the default / safe path).
+    #[default]
     MySql,
     /// MariaDB speaking the MySQL wire protocol.
     MariaDb,
+}
+
+impl MySqlDialect {
+    /// Source capabilities for this dialect (MySQL/MariaDB never use
+    /// Postgres-style LISTEN/NOTIFY).
+    pub const fn caps(self) -> SourceCaps {
+        SourceCaps::for_dialect(self.detected())
+    }
+
+    /// The unified `DetectedDialect` tag for this MySQL-wire dialect.
+    pub const fn detected(self) -> DetectedDialect {
+        match self {
+            MySqlDialect::MySql => DetectedDialect::MySql,
+            MySqlDialect::MariaDb => DetectedDialect::MariaDb,
+        }
+    }
+
+    /// Introspection-query overrides for this dialect.
+    // TODO(dialect-parity): override per dialect
+    pub const fn introspection(self) -> MySqlIntrospection {
+        MySqlIntrospection::VANILLA
+    }
+}
+
+/// Placeholder for per-dialect MySQL introspection query overrides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MySqlIntrospection;
+
+impl MySqlIntrospection {
+    pub const VANILLA: Self = Self;
 }
 
 /// A unified, runtime-detected dialect tag stored on a connection.

--- a/apps/desktop/src-tauri/src/database/live_monitor.rs
+++ b/apps/desktop/src-tauri/src/database/live_monitor.rs
@@ -307,12 +307,7 @@ async fn create_postgres_notification_receiver(
     }
 
     let (mut connection_string, tunnel_local_port) = match &connection_entry.value().database {
-        Database::CockroachDB {
-            connection_string,
-            tunnel,
-            ..
-        }
-        | Database::Postgres {
+        Database::Postgres {
             connection_string,
             tunnel,
             ..
@@ -654,7 +649,7 @@ async fn fetch_table_snapshot(
         DatabaseClient::LibSQL { connection } => {
             fetch_libsql_snapshot(connection, table_name).await
         }
-        DatabaseClient::MySQL { pool } => fetch_mysql_snapshot(pool, table_name).await,
+        DatabaseClient::MySQL { pool, .. } => fetch_mysql_snapshot(pool, table_name).await,
     }
 }
 
@@ -683,7 +678,9 @@ async fn fetch_postgres_snapshot(
 }
 
 fn postgres_row_to_values(row: &tokio_postgres::Row) -> Result<Vec<serde_json::Value>, Error> {
-    let mut writer = PostgresRowWriter::new();
+    // Vanilla serialization is dialect-agnostic; the writer ignores the dialect
+    // on the vanilla path. CockroachDB rows serialize identically here.
+    let mut writer = PostgresRowWriter::new(crate::database::dialect::PgDialect::Postgres);
     writer.add_row(row)?;
     let json = writer.finish();
     let value: serde_json::Value = serde_json::from_str(json.get())?;

--- a/apps/desktop/src-tauri/src/database/mysql/schema.rs
+++ b/apps/desktop/src-tauri/src/database/mysql/schema.rs
@@ -5,11 +5,22 @@ use mysql_async::prelude::Queryable;
 use mysql_async::{Pool, Row, Value as MysqlValue};
 
 use crate::{
-    database::types::{ColumnInfo, DatabaseSchema, ForeignKeyInfo, IndexInfo, TableInfo},
+    database::{
+        dialect::MySqlDialect,
+        types::{ColumnInfo, DatabaseSchema, ForeignKeyInfo, IndexInfo, TableInfo},
+    },
     Error,
 };
 
-pub async fn get_database_schema(pool: Arc<Pool>) -> Result<DatabaseSchema, Error> {
+/// Introspect the schema for a MySQL-wire connection.
+///
+/// `dialect` is threaded through so Phase 2 can branch per dialect (e.g.
+/// MariaDB type mapping). For now every dialect uses the vanilla MySQL path.
+// TODO(dialect-parity): override per dialect
+pub async fn get_database_schema(
+    pool: Arc<Pool>,
+    _dialect: MySqlDialect,
+) -> Result<DatabaseSchema, Error> {
     let mut conn = pool
         .get_conn()
         .await

--- a/apps/desktop/src-tauri/src/database/postgres/execute.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/execute.rs
@@ -3,7 +3,8 @@ use tokio_postgres::{types::ToSql, Client, SimpleQueryMessage};
 
 use crate::{
     database::{
-        parser::ParsedStatement, postgres::row_writer::RowWriter, types::ExecSender, QueryExecEvent,
+        dialect::PgDialect, parser::ParsedStatement, postgres::row_writer::RowWriter,
+        types::ExecSender, QueryExecEvent,
     },
     utils::serialize_as_json_array,
     Error,
@@ -14,15 +15,17 @@ pub async fn execute_query(
     stmt: ParsedStatement,
     sender: &ExecSender,
     use_simple_query: bool,
+    dialect: PgDialect,
 ) -> Result<(), Error> {
     if use_simple_query {
-        return execute_simple_query(client, &stmt.statement, stmt.returns_values, sender).await;
+        return execute_simple_query(client, &stmt.statement, stmt.returns_values, sender, dialect)
+            .await;
     }
 
     if stmt.returns_values {
-        execute_query_with_results(client, &stmt.statement, sender).await?;
+        execute_query_with_results(client, &stmt.statement, sender, dialect).await?;
     } else {
-        execute_modification_query(client, &stmt.statement, sender).await?;
+        execute_modification_query(client, &stmt.statement, sender, dialect).await?;
     }
 
     Ok(())
@@ -33,6 +36,7 @@ async fn execute_simple_query(
     query: &str,
     returns_values: bool,
     sender: &ExecSender,
+    dialect: PgDialect,
 ) -> Result<(), Error> {
     let started_at = std::time::Instant::now();
     log::info!("Starting simple Postgres query: {}", query);
@@ -52,7 +56,7 @@ async fn execute_simple_query(
     pin_mut!(stream);
 
     let batch_size = 50;
-    let mut writer = RowWriter::new();
+    let mut writer = RowWriter::new(dialect);
     let mut affected_rows = 0;
     let mut sent_columns = !returns_values;
 
@@ -114,6 +118,7 @@ async fn execute_query_with_results(
     client: &Client,
     query: &str,
     sender: &ExecSender,
+    dialect: PgDialect,
 ) -> Result<(), Error> {
     let started_at = std::time::Instant::now();
     log::info!("Starting streaming query: {}", query);
@@ -132,7 +137,7 @@ async fn execute_query_with_results(
                 log::warn!(
                     "Falling back to simple Postgres query after duplicate prepared statement"
                 );
-                return execute_simple_query(client, query, true, sender).await;
+                return execute_simple_query(client, query, true, sender, dialect).await;
             }
 
             let error_msg = postgres_error_message("Query preparation failed", &e);
@@ -159,7 +164,7 @@ async fn execute_query_with_results(
             let batch_size = 50;
             let mut total_rows = 0;
 
-            let mut writer = RowWriter::new();
+            let mut writer = RowWriter::new(dialect);
 
             loop {
                 match stream.try_next().await {
@@ -236,6 +241,7 @@ async fn execute_modification_query(
     client: &Client,
     query: &str,
     sender: &ExecSender,
+    dialect: PgDialect,
 ) -> Result<(), Error> {
     log::info!("Executing modification query: {}", query);
     let started_at = std::time::Instant::now();
@@ -256,7 +262,7 @@ async fn execute_modification_query(
                 log::warn!(
                     "Falling back to simple Postgres query after duplicate prepared statement"
                 );
-                return execute_simple_query(client, query, false, sender).await;
+                return execute_simple_query(client, query, false, sender, dialect).await;
             }
 
             let error_msg = postgres_error_message("Modification query failed", &e);
@@ -309,7 +315,7 @@ mod tests {
         let (sender, mut recv) = channel();
 
         tokio::task::spawn(async move {
-            execute_query(&conn, stmt, &sender, false).await.unwrap();
+            execute_query(&conn, stmt, &sender, false, crate::database::dialect::PgDialect::Postgres).await.unwrap();
         });
 
         let mut events = Vec::new();
@@ -334,7 +340,7 @@ mod tests {
         let (sender, mut recv) = channel();
 
         tokio::task::spawn(async move {
-            execute_query(&conn, stmt, &sender, false).await.unwrap();
+            execute_query(&conn, stmt, &sender, false, crate::database::dialect::PgDialect::Postgres).await.unwrap();
         });
 
         let event = recv

--- a/apps/desktop/src-tauri/src/database/postgres/row_writer.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/row_writer.rs
@@ -25,13 +25,20 @@ use crate::database::postgres::row_writer::{
 pub struct RowWriter {
     buf: String,
     row_count: usize,
+    /// Runtime dialect of the connection that produced these rows. Stored so
+    /// Phase 2 can apply CockroachDB-specific value/type overrides; the vanilla
+    /// path ignores it (no behaviour change today).
+    // TODO(dialect-parity): override per dialect
+    #[allow(dead_code)]
+    dialect: crate::database::dialect::PgDialect,
 }
 
 impl RowWriter {
-    pub fn new() -> Self {
+    pub fn new(dialect: crate::database::dialect::PgDialect) -> Self {
         Self {
             buf: String::new(),
             row_count: 0,
+            dialect,
         }
     }
 
@@ -365,7 +372,7 @@ mod tests {
         assert_eq!(rows.len(), 1);
         let row = &rows[0];
 
-        let mut writer = RowWriter::new();
+        let mut writer = RowWriter::new(crate::database::dialect::PgDialect::Postgres);
         writer.add_row(row).unwrap();
         let result = writer.finish();
         let result: Value = serde_json::from_str(result.get()).unwrap();
@@ -395,7 +402,7 @@ mod tests {
         let empty_rows = client.query(empty_sql, &[]).await.unwrap();
         assert_eq!(empty_rows.len(), 0);
 
-        let mut empty_writer = RowWriter::new();
+        let mut empty_writer = RowWriter::new(crate::database::dialect::PgDialect::Postgres);
         let empty_result = empty_writer.finish();
         let empty_result: Value = serde_json::from_str(empty_result.get()).unwrap();
         assert_eq!(empty_result, serde_json::json!([]));
@@ -413,7 +420,7 @@ mod tests {
         let null_rows = client.query(null_sql, &[]).await.unwrap();
         let null_row = &null_rows[0];
 
-        let mut null_writer = RowWriter::new();
+        let mut null_writer = RowWriter::new(crate::database::dialect::PgDialect::Postgres);
         null_writer.add_row(null_row).unwrap();
         let null_result = null_writer.finish();
         let null_result: Value = serde_json::from_str(null_result.get()).unwrap();
@@ -433,7 +440,7 @@ mod tests {
         let multi_rows = client.query(multi_sql, &[]).await.unwrap();
         assert_eq!(multi_rows.len(), 3);
 
-        let mut multi_writer = RowWriter::new();
+        let mut multi_writer = RowWriter::new(crate::database::dialect::PgDialect::Postgres);
         for row in &multi_rows {
             multi_writer.add_row(row).unwrap();
         }
@@ -457,7 +464,7 @@ mod tests {
         let float_rows = client.query(float_sql, &[]).await.unwrap();
         let float_row = &float_rows[0];
 
-        let mut float_writer = RowWriter::new();
+        let mut float_writer = RowWriter::new(crate::database::dialect::PgDialect::Postgres);
         float_writer.add_row(float_row).unwrap();
         let float_result = float_writer.finish();
         let float_result: Value = serde_json::from_str(float_result.get()).unwrap();
@@ -479,7 +486,7 @@ mod tests {
         let escape_rows = client.query(escape_sql, &[]).await.unwrap();
         let escape_row = &escape_rows[0];
 
-        let mut escape_writer = RowWriter::new();
+        let mut escape_writer = RowWriter::new(crate::database::dialect::PgDialect::Postgres);
         escape_writer.add_row(escape_row).unwrap();
         let escape_result = escape_writer.finish();
         let escape_result: Value = serde_json::from_str(escape_result.get()).unwrap();
@@ -503,7 +510,7 @@ mod tests {
         let array_rows = client.query(array_sql, &[]).await.unwrap();
         let array_row = &array_rows[0];
 
-        let mut array_writer = RowWriter::new();
+        let mut array_writer = RowWriter::new(crate::database::dialect::PgDialect::Postgres);
         array_writer.add_row(array_row).unwrap();
         let array_result = array_writer.finish();
         let array_result: Value = serde_json::from_str(array_result.get()).unwrap();
@@ -528,7 +535,7 @@ mod tests {
         let numeric_rows = client.query(numeric_sql, &[]).await.unwrap();
         let numeric_row = &numeric_rows[0];
 
-        let mut numeric_writer = RowWriter::new();
+        let mut numeric_writer = RowWriter::new(crate::database::dialect::PgDialect::Postgres);
         numeric_writer.add_row(numeric_row).unwrap();
         let numeric_result = numeric_writer.finish();
         let numeric_result: Value = serde_json::from_str(numeric_result.get()).unwrap();
@@ -554,7 +561,7 @@ mod tests {
         let interval_rows = client.query(interval_sql, &[]).await.unwrap();
         let interval_row = &interval_rows[0];
 
-        let mut interval_writer = RowWriter::new();
+        let mut interval_writer = RowWriter::new(crate::database::dialect::PgDialect::Postgres);
         interval_writer.add_row(interval_row).unwrap();
         let interval_result = interval_writer.finish();
         let interval_result: Value = serde_json::from_str(interval_result.get()).unwrap();

--- a/apps/desktop/src-tauri/src/database/postgres/schema.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/schema.rs
@@ -4,11 +4,23 @@ use anyhow::Context;
 use tokio_postgres::Client;
 
 use crate::{
-    database::types::{ColumnInfo, DatabaseSchema, ForeignKeyInfo, IndexInfo, TableInfo},
+    database::{
+        dialect::PgDialect,
+        types::{ColumnInfo, DatabaseSchema, ForeignKeyInfo, IndexInfo, TableInfo},
+    },
     Error,
 };
 
-pub async fn get_database_schema(client: &Client) -> Result<DatabaseSchema, Error> {
+/// Introspect the schema for a Postgres-wire connection.
+///
+/// `dialect` is threaded through so Phase 2 can branch catalog queries per
+/// dialect (e.g. CockroachDB). For now every dialect uses the vanilla Postgres
+/// introspection path.
+// TODO(dialect-parity): override per dialect
+pub async fn get_database_schema(
+    client: &Client,
+    _dialect: PgDialect,
+) -> Result<DatabaseSchema, Error> {
     // Main columns query with primary key detection
     let schema_query = r#"
         SELECT 

--- a/apps/desktop/src-tauri/src/database/services/connection.rs
+++ b/apps/desktop/src-tauri/src/database/services/connection.rs
@@ -105,6 +105,10 @@ impl<'a> ConnectionService<'a> {
 
             let config_changed = password_changed
                 || match (&connection.database, &database_info) {
+                    // Postgres-wire (vanilla + CockroachDB) and MySQL-wire
+                    // (vanilla + MariaDB) collapse onto a single runtime variant;
+                    // the incoming `DatabaseInfo` may still be either contract
+                    // variant, so match both against the same `Database` arm.
                     (
                         Database::Postgres {
                             connection_string: old,
@@ -114,15 +118,8 @@ impl<'a> ConnectionService<'a> {
                         DatabaseInfo::Postgres {
                             connection_string: new,
                             ssh_config: new_ssh,
-                        },
-                    ) => old != new || old_ssh != new_ssh,
-                    (
-                        Database::CockroachDB {
-                            connection_string: old,
-                            ssh_config: old_ssh,
-                            ..
-                        },
-                        DatabaseInfo::CockroachDB {
+                        }
+                        | DatabaseInfo::CockroachDB {
                             connection_string: new,
                             ssh_config: new_ssh,
                         },
@@ -136,15 +133,8 @@ impl<'a> ConnectionService<'a> {
                         DatabaseInfo::MySQL {
                             connection_string: new,
                             ssh_config: new_ssh,
-                        },
-                    ) => old != new || old_ssh != new_ssh,
-                    (
-                        Database::MariaDB {
-                            connection_string: old,
-                            ssh_config: old_ssh,
-                            ..
-                        },
-                        DatabaseInfo::MariaDB {
+                        }
+                        | DatabaseInfo::MariaDB {
                             connection_string: new,
                             ssh_config: new_ssh,
                         },
@@ -184,15 +174,7 @@ impl<'a> ConnectionService<'a> {
                         *client = None;
                         *tunnel = None;
                     }
-                    Database::CockroachDB { client, tunnel, .. } => {
-                        *client = None;
-                        *tunnel = None;
-                    }
                     Database::MySQL { pool, tunnel, .. } => {
-                        *pool = None;
-                        *tunnel = None;
-                    }
-                    Database::MariaDB { pool, tunnel, .. } => {
                         *pool = None;
                         *tunnel = None;
                     }
@@ -219,16 +201,18 @@ impl<'a> ConnectionService<'a> {
                         ssh_config,
                         client: None,
                         tunnel: None,
+                        dialect: crate::database::dialect::PgDialect::Postgres,
                     },
                     DatabaseInfo::CockroachDB {
                         connection_string,
                         ssh_config,
-                    } => Database::CockroachDB {
+                    } => Database::Postgres {
                         use_simple_query: false,
                         connection_string,
                         ssh_config,
                         client: None,
                         tunnel: None,
+                        dialect: crate::database::dialect::PgDialect::CockroachDb,
                     },
                     DatabaseInfo::MySQL {
                         connection_string,
@@ -238,15 +222,17 @@ impl<'a> ConnectionService<'a> {
                         ssh_config,
                         pool: None,
                         tunnel: None,
+                        dialect: crate::database::dialect::MySqlDialect::MySql,
                     },
                     DatabaseInfo::MariaDB {
                         connection_string,
                         ssh_config,
-                    } => Database::MariaDB {
+                    } => Database::MySQL {
                         connection_string,
                         ssh_config,
                         pool: None,
                         tunnel: None,
+                        dialect: crate::database::dialect::MySqlDialect::MariaDb,
                     },
                     DatabaseInfo::SQLite { db_path } => Database::SQLite {
                         db_path,
@@ -278,18 +264,8 @@ impl<'a> ConnectionService<'a> {
                         DatabaseInfo::Postgres {
                             connection_string: new_connection_string,
                             ssh_config: new_ssh_config,
-                        },
-                    ) => {
-                        *connection_string = new_connection_string;
-                        *ssh_config = new_ssh_config;
-                    }
-                    (
-                        Database::CockroachDB {
-                            connection_string,
-                            ssh_config,
-                            ..
-                        },
-                        DatabaseInfo::CockroachDB {
+                        }
+                        | DatabaseInfo::CockroachDB {
                             connection_string: new_connection_string,
                             ssh_config: new_ssh_config,
                         },
@@ -306,18 +282,8 @@ impl<'a> ConnectionService<'a> {
                         DatabaseInfo::MySQL {
                             connection_string: new_connection_string,
                             ssh_config: new_ssh_config,
-                        },
-                    ) => {
-                        *connection_string = new_connection_string;
-                        *ssh_config = new_ssh_config;
-                    }
-                    (
-                        Database::MariaDB {
-                            connection_string,
-                            ssh_config,
-                            ..
-                        },
-                        DatabaseInfo::MariaDB {
+                        }
+                        | DatabaseInfo::MariaDB {
                             connection_string: new_connection_string,
                             ssh_config: new_ssh_config,
                         },
@@ -449,18 +415,12 @@ impl<'a> ConnectionService<'a> {
         let connection = connection_entry.value_mut();
 
         match &mut connection.database {
-            Database::CockroachDB {
+            Database::Postgres {
                 connection_string,
                 ssh_config,
                 client,
                 tunnel,
-                ..
-            }
-            | Database::Postgres {
-                connection_string,
-                ssh_config,
-                client,
-                tunnel,
+                dialect,
                 ..
             } => {
                 // If we have an SSH config, start the tunnel
@@ -533,18 +493,24 @@ impl<'a> ConnectionService<'a> {
                     Ok((pg_client, conn_check)) => {
                         // Detect the real engine (Postgres vs CockroachDB) so
                         // capability gating (e.g. LISTEN/NOTIFY) is based on the
-                        // server, not the user's variant choice. Detection
-                        // failures are non-fatal: we keep the safe Postgres
-                        // default.
-                        let detected = match pg_client.query_one("SELECT version()", &[]).await {
-                            Ok(row) => row.try_get::<usize, String>(0).ok().map(|version| {
-                                crate::database::dialect::detect_pg_dialect(&version).into()
-                            }),
+                        // server, not the user's variant choice. The per-engine
+                        // `dialect` field is the source of truth; detection
+                        // failures are non-fatal and leave the existing (vanilla)
+                        // dialect in place.
+                        let detected_pg = match pg_client.query_one("SELECT version()", &[]).await {
+                            Ok(row) => row
+                                .try_get::<usize, String>(0)
+                                .ok()
+                                .map(|version| crate::database::dialect::detect_pg_dialect(&version)),
                             Err(e) => {
                                 log::warn!("Failed to detect Postgres dialect via version(): {}", e);
                                 None
                             }
                         };
+                        if let Some(detected_pg) = detected_pg {
+                            *dialect = detected_pg;
+                        }
+                        let detected = detected_pg.map(Into::into);
 
                         *client = Some(Arc::new(pg_client));
                         connection.connected = true;
@@ -566,17 +532,12 @@ impl<'a> ConnectionService<'a> {
                     }
                 }
             }
-            Database::MariaDB {
+            Database::MySQL {
                 connection_string,
                 ssh_config,
                 pool,
                 tunnel,
-            }
-            | Database::MySQL {
-                connection_string,
-                ssh_config,
-                pool,
-                tunnel,
+                dialect,
             } => {
                 // If we have an SSH config, start the tunnel and rewrite the MySQL target to localhost.
                 let mut mysql_url = url::Url::parse(connection_string).with_context(|| {
@@ -626,21 +587,27 @@ impl<'a> ConnectionService<'a> {
                     Ok(mut conn) => {
                         conn.ping().await?;
 
-                        // Detect the real engine (MySQL vs MariaDB). Non-fatal:
-                        // on failure we keep the safe MySQL default.
-                        let detected = match conn
+                        // Detect the real engine (MySQL vs MariaDB). The
+                        // per-engine `dialect` field is the source of truth.
+                        // Non-fatal: on failure we keep the existing (vanilla)
+                        // dialect.
+                        let detected_mysql = match conn
                             .query_first::<String, _>("SELECT VERSION()")
                             .await
                         {
-                            Ok(Some(version)) => Some(
-                                crate::database::dialect::detect_mysql_dialect(&version).into(),
-                            ),
+                            Ok(Some(version)) => {
+                                Some(crate::database::dialect::detect_mysql_dialect(&version))
+                            }
                             Ok(None) => None,
                             Err(e) => {
                                 log::warn!("Failed to detect MySQL dialect via VERSION(): {}", e);
                                 None
                             }
                         };
+                        if let Some(detected_mysql) = detected_mysql {
+                            *dialect = detected_mysql;
+                        }
+                        let detected = detected_mysql.map(Into::into);
                         drop(conn);
 
                         *pool = Some(Arc::new(mysql_pool));
@@ -1011,15 +978,7 @@ impl<'a> ConnectionService<'a> {
                 *client = None;
                 *tunnel = None;
             }
-            Database::CockroachDB { client, tunnel, .. } => {
-                *client = None;
-                *tunnel = None;
-            }
             Database::MySQL { pool, tunnel, .. } => {
-                *pool = None;
-                *tunnel = None;
-            }
-            Database::MariaDB { pool, tunnel, .. } => {
                 *pool = None;
                 *tunnel = None;
             }

--- a/apps/desktop/src-tauri/src/database/services/metadata.rs
+++ b/apps/desktop/src-tauri/src/database/services/metadata.rs
@@ -36,20 +36,14 @@ impl<'a> MetadataService<'a> {
         let schema = match &connection.database {
             // TODO(dialect-parity, #89): CockroachDB shares the Postgres
             // introspection path. Some Postgres catalog queries differ on
-            // CockroachDB; branch here on `connection.detected_dialect` once a
-            // live CockroachDB cluster is available to verify a Cockroach-specific
-            // query. Until then the vanilla Postgres query is the safe default.
-            Database::CockroachDB {
+            // CockroachDB; the `dialect` field is now threaded into
+            // `get_database_schema` so Phase 2 can branch there. Until then the
+            // vanilla Postgres query is the safe default.
+            Database::Postgres {
                 client: Some(client),
+                dialect,
                 ..
-            }
-            | Database::Postgres {
-                client: Some(client),
-                ..
-            } => postgres::schema::get_database_schema(client).await?,
-            Database::CockroachDB { client: None, .. } => {
-                return Err(Error::Any(anyhow!("CockroachDB connection not active")))
-            }
+            } => postgres::schema::get_database_schema(client, *dialect).await?,
             Database::Postgres { client: None, .. } => {
                 return Err(Error::Any(anyhow!("Postgres connection not active")))
             }
@@ -76,19 +70,15 @@ impl<'a> MetadataService<'a> {
             } => return Err(Error::Any(anyhow!("LibSQL connection not active"))),
             // TODO(dialect-parity, #88): MariaDB shares the MySQL introspection
             // path. MariaDB-specific types (UUID, INET4/INET6) and some
-            // information_schema differences need a dialect branch on
-            // `connection.detected_dialect`, plus row-writer type mapping in the
-            // write path. Deferred until a live MariaDB cluster is available; the
-            // vanilla MySQL query remains the safe default.
-            Database::MariaDB {
-                pool: Some(pool), ..
-            }
-            | Database::MySQL {
-                pool: Some(pool), ..
-            } => crate::database::mysql::schema::get_database_schema(pool.clone()).await?,
-            Database::MariaDB { pool: None, .. } => {
-                return Err(Error::Any(anyhow!("MariaDB connection not active")))
-            }
+            // information_schema differences need a dialect branch; the
+            // `dialect` field is now threaded into `get_database_schema` plus the
+            // row-writer for the write path. Deferred; the vanilla MySQL query
+            // remains the safe default.
+            Database::MySQL {
+                pool: Some(pool),
+                dialect,
+                ..
+            } => crate::database::mysql::schema::get_database_schema(pool.clone(), *dialect).await?,
             Database::MySQL { pool: None, .. } => {
                 return Err(Error::Any(anyhow!("MySQL connection not active")))
             }
@@ -112,19 +102,11 @@ impl<'a> MetadataService<'a> {
         let connection = connection_entry.value();
 
         match &connection.database {
-            Database::CockroachDB {
-                connection_string,
-                client: Some(client),
-                ..
-            }
-            | Database::Postgres {
+            Database::Postgres {
                 connection_string,
                 client: Some(client),
                 ..
             } => metadata::get_postgres_metadata(client, connection_string).await,
-            Database::CockroachDB { client: None, .. } => {
-                Err(Error::Any(anyhow!("CockroachDB connection not active")))
-            }
             Database::Postgres { client: None, .. } => {
                 Err(Error::Any(anyhow!("Postgres connection not active")))
             }
@@ -170,19 +152,11 @@ impl<'a> MetadataService<'a> {
             Database::LibSQL {
                 connection: None, ..
             } => Err(Error::Any(anyhow!("LibSQL connection not active"))),
-            Database::MariaDB {
-                connection_string,
-                pool: Some(pool),
-                ..
-            }
-            | Database::MySQL {
+            Database::MySQL {
                 connection_string,
                 pool: Some(pool),
                 ..
             } => metadata::get_mysql_metadata(pool, connection_string).await,
-            Database::MariaDB { pool: None, .. } => {
-                Err(Error::Any(anyhow!("MariaDB connection not active")))
-            }
             Database::MySQL { pool: None, .. } => {
                 Err(Error::Any(anyhow!("MySQL connection not active")))
             }

--- a/apps/desktop/src-tauri/src/database/services/mutation.rs
+++ b/apps/desktop/src-tauri/src/database/services/mutation.rs
@@ -702,7 +702,7 @@ async fn fetch_mysql_data(
     client: &DatabaseClient,
     query: &str,
 ) -> Result<(Vec<String>, Vec<Vec<serde_json::Value>>), Error> {
-    if let DatabaseClient::MySQL { pool } = client {
+    if let DatabaseClient::MySQL { pool, .. } = client {
         let mut conn = pool
             .get_conn()
             .await

--- a/apps/desktop/src-tauri/src/database/services/seeding.rs
+++ b/apps/desktop/src-tauri/src/database/services/seeding.rs
@@ -123,7 +123,7 @@ impl<'a> SeedingService<'a> {
                         .await
                         .map_err(|e| Error::Any(anyhow::anyhow!("LibSQL insert failed: {}", e)))?;
                 }
-                crate::database::types::DatabaseClient::MySQL { pool } => {
+                crate::database::types::DatabaseClient::MySQL { pool, .. } => {
                     let mut mysql_conn = pool
                         .get_conn()
                         .await
@@ -287,6 +287,7 @@ mod tests {
             pool: Arc::new(mysql_async::Pool::new(
                 mysql_async::Opts::from_url("mysql://user:pass@localhost:3306/db").unwrap(),
             )),
+            dialect: crate::database::dialect::MySqlDialect::MySql,
         };
 
         let (_, qualified) = seed_target_for_client(&client, "users", "tenant_a", None);

--- a/apps/desktop/src-tauri/src/database/stmt_manager.rs
+++ b/apps/desktop/src-tauri/src/database/stmt_manager.rs
@@ -251,11 +251,17 @@ impl StatementManager {
             DatabaseClient::Postgres {
                 client,
                 use_simple_query,
+                dialect,
             } => {
                 let handle = spawn(async move {
-                    let result =
-                        postgres::execute::execute_query(&client, stmt, &sender, use_simple_query)
-                            .await;
+                    let result = postgres::execute::execute_query(
+                        &client,
+                        stmt,
+                        &sender,
+                        use_simple_query,
+                        dialect,
+                    )
+                    .await;
                     log_query_exec_outcome("Postgres", result);
                 });
                 self.execution_handles.insert(id, handle);
@@ -298,7 +304,7 @@ impl StatementManager {
                 });
                 self.execution_handles.insert(id, handle);
             }
-            DatabaseClient::MySQL { pool } => {
+            DatabaseClient::MySQL { pool, .. } => {
                 let handle = spawn(async move {
                     let result = mysql::execute::execute_query(&pool, stmt, &sender).await;
                     log_query_exec_outcome("MySQL", result);

--- a/apps/desktop/src-tauri/src/database/types.rs
+++ b/apps/desktop/src-tauri/src/database/types.rs
@@ -7,6 +7,7 @@ use specta::Type;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
 
+use crate::database::dialect::{MySqlDialect, PgDialect};
 use crate::database::duckdb::file_source::DataFileSourceEntry;
 use crate::database::ssh_tunnel::SshTunnel;
 use crate::Error;
@@ -189,9 +190,16 @@ pub enum DatabaseClient {
     Postgres {
         client: Arc<tokio_postgres::Client>,
         use_simple_query: bool,
+        /// Runtime dialect of this Postgres-wire connection (vanilla unless a
+        /// CockroachDB server was detected). Threaded into adapters so schema
+        /// introspection and row writers can branch per dialect.
+        dialect: PgDialect,
     },
     MySQL {
         pool: Arc<mysql_async::Pool>,
+        /// Runtime dialect of this MySQL-wire connection (vanilla unless a
+        /// MariaDB server was detected).
+        dialect: MySqlDialect,
     },
     SQLite {
         connection: Arc<Mutex<rusqlite::Connection>>,
@@ -219,25 +227,20 @@ pub enum Database {
         /// `?pgbouncer=true` in the connection string (Prisma-compatible flag).
         /// Required for PgBouncer in transaction-pool mode.
         use_simple_query: bool,
-    },
-    CockroachDB {
-        connection_string: String,
-        ssh_config: Option<SshConfig>,
-        client: Option<Arc<tokio_postgres::Client>>,
-        tunnel: Option<Arc<SshTunnel>>,
-        use_simple_query: bool,
+        /// Runtime dialect behind this Postgres-wire connection. Defaults to
+        /// `Vanilla`; overwritten by `version()` detection at connect time and
+        /// is the source of truth for dialect-specific capability gating
+        /// (e.g. CockroachDB has no LISTEN/NOTIFY).
+        dialect: PgDialect,
     },
     MySQL {
         connection_string: String,
         ssh_config: Option<SshConfig>,
         pool: Option<Arc<mysql_async::Pool>>,
         tunnel: Option<Arc<SshTunnel>>,
-    },
-    MariaDB {
-        connection_string: String,
-        ssh_config: Option<SshConfig>,
-        pool: Option<Arc<mysql_async::Pool>>,
-        tunnel: Option<Arc<SshTunnel>>,
+        /// Runtime dialect behind this MySQL-wire connection. Defaults to
+        /// `Vanilla`; overwritten by `VERSION()` detection at connect time.
+        dialect: MySqlDialect,
     },
     SQLite {
         db_path: String,
@@ -263,6 +266,19 @@ impl DatabaseConnection {
             name: self.name.clone(),
             connected: self.connected,
             database_type: match &self.database {
+                // The runtime `dialect` field maps back onto the stable
+                // `DatabaseInfo` frontend contract: a CockroachDb/MariaDb
+                // dialect surfaces as the corresponding `DatabaseInfo` variant,
+                // everything else as the vanilla engine variant.
+                Database::Postgres {
+                    connection_string,
+                    ssh_config,
+                    dialect: PgDialect::CockroachDb,
+                    ..
+                } => DatabaseInfo::CockroachDB {
+                    connection_string: connection_string.clone(),
+                    ssh_config: ssh_config.clone(),
+                },
                 Database::Postgres {
                     connection_string,
                     ssh_config,
@@ -271,11 +287,12 @@ impl DatabaseConnection {
                     connection_string: connection_string.clone(),
                     ssh_config: ssh_config.clone(),
                 },
-                Database::CockroachDB {
+                Database::MySQL {
                     connection_string,
                     ssh_config,
+                    dialect: MySqlDialect::MariaDb,
                     ..
-                } => DatabaseInfo::CockroachDB {
+                } => DatabaseInfo::MariaDB {
                     connection_string: connection_string.clone(),
                     ssh_config: ssh_config.clone(),
                 },
@@ -284,14 +301,6 @@ impl DatabaseConnection {
                     ssh_config,
                     ..
                 } => DatabaseInfo::MySQL {
-                    connection_string: connection_string.clone(),
-                    ssh_config: ssh_config.clone(),
-                },
-                Database::MariaDB {
-                    connection_string,
-                    ssh_config,
-                    ..
-                } => DatabaseInfo::MariaDB {
                     connection_string: connection_string.clone(),
                     ssh_config: ssh_config.clone(),
                 },
@@ -334,16 +343,18 @@ impl DatabaseConnection {
                 ssh_config,
                 client: None,
                 tunnel: None,
+                dialect: PgDialect::Postgres,
             },
             DatabaseInfo::CockroachDB {
                 connection_string,
                 ssh_config,
-            } => Database::CockroachDB {
+            } => Database::Postgres {
                 use_simple_query: false,
                 connection_string,
                 ssh_config,
                 client: None,
                 tunnel: None,
+                dialect: PgDialect::CockroachDb,
             },
             DatabaseInfo::MySQL {
                 connection_string,
@@ -353,15 +364,17 @@ impl DatabaseConnection {
                 ssh_config,
                 pool: None,
                 tunnel: None,
+                dialect: MySqlDialect::MySql,
             },
             DatabaseInfo::MariaDB {
                 connection_string,
                 ssh_config,
-            } => Database::MariaDB {
+            } => Database::MySQL {
                 connection_string,
                 ssh_config,
                 pool: None,
                 tunnel: None,
+                dialect: MySqlDialect::MariaDb,
             },
             DatabaseInfo::SQLite { db_path } => Database::SQLite {
                 db_path,
@@ -406,16 +419,18 @@ impl DatabaseConnection {
                 ssh_config,
                 client: None,
                 tunnel: None,
+                dialect: PgDialect::Postgres,
             },
             DatabaseInfo::CockroachDB {
                 connection_string,
                 ssh_config,
-            } => Database::CockroachDB {
+            } => Database::Postgres {
                 use_simple_query: false,
                 connection_string,
                 ssh_config,
                 client: None,
                 tunnel: None,
+                dialect: PgDialect::CockroachDb,
             },
             DatabaseInfo::MySQL {
                 connection_string,
@@ -425,15 +440,17 @@ impl DatabaseConnection {
                 ssh_config,
                 pool: None,
                 tunnel: None,
+                dialect: MySqlDialect::MySql,
             },
             DatabaseInfo::MariaDB {
                 connection_string,
                 ssh_config,
-            } => Database::MariaDB {
+            } => Database::MySQL {
                 connection_string,
                 ssh_config,
                 pool: None,
                 tunnel: None,
+                dialect: MySqlDialect::MariaDb,
             },
             DatabaseInfo::SQLite { db_path } => Database::SQLite {
                 db_path,
@@ -471,19 +488,16 @@ impl DatabaseConnection {
         }
     }
 
-    /// Source capabilities for this connection, derived from the
-    /// runtime-detected dialect when available, otherwise from a safe default
-    /// based on the wire protocol (the existing vanilla behaviour).
+    /// Source capabilities for this connection.
+    ///
+    /// The per-engine `dialect` field is the source of truth: it defaults to
+    /// `Vanilla` and is overwritten by `version()` detection at connect time,
+    /// so caps follow the *runtime* engine rather than the user's variant pick.
     pub fn source_caps(&self) -> crate::database::dialect::SourceCaps {
         use crate::database::dialect::SourceCaps;
-        if let Some(dialect) = self.detected_dialect {
-            return SourceCaps::for_dialect(dialect);
-        }
         match &self.database {
-            Database::Postgres { .. } | Database::CockroachDB { .. } => {
-                SourceCaps::postgres_default()
-            }
-            Database::MySQL { .. } | Database::MariaDB { .. } => SourceCaps::mysql_default(),
+            Database::Postgres { dialect, .. } => dialect.caps(),
+            Database::MySQL { dialect, .. } => dialect.caps(),
             // Non Postgres/MySQL engines do not use LISTEN/NOTIFY live monitoring.
             _ => SourceCaps {
                 supports_listen_notify: false,
@@ -494,9 +508,7 @@ impl DatabaseConnection {
     pub fn is_client_connected(&self) -> bool {
         match &self.database {
             Database::Postgres { client, .. } => client.is_some(),
-            Database::CockroachDB { client, .. } => client.is_some(),
             Database::MySQL { pool, .. } => pool.is_some(),
-            Database::MariaDB { pool, .. } => pool.is_some(),
             Database::SQLite { connection, .. } => connection.is_some(),
             Database::DuckDB { connection, .. } => connection.is_some(),
             Database::LibSQL { connection, .. } => connection.is_some(),
@@ -509,40 +521,28 @@ impl DatabaseConnection {
             Database::Postgres {
                 client: Some(client),
                 use_simple_query,
+                dialect,
                 ..
             } => DatabaseClient::Postgres {
                 client: client.clone(),
                 use_simple_query: *use_simple_query,
+                dialect: *dialect,
             },
             Database::Postgres { client: None, .. } => {
                 return Err(Error::Any(anyhow::anyhow!(
                     "Postgres connection not active"
                 )));
             }
-            Database::CockroachDB {
-                client: Some(client),
-                use_simple_query,
-                ..
-            } => DatabaseClient::Postgres {
-                client: client.clone(),
-                use_simple_query: *use_simple_query,
-            },
-            Database::CockroachDB { client: None, .. } => {
-                return Err(Error::Any(anyhow::anyhow!(
-                    "CockroachDB connection not active"
-                )));
-            }
             Database::MySQL {
-                pool: Some(pool), ..
-            } => DatabaseClient::MySQL { pool: pool.clone() },
+                pool: Some(pool),
+                dialect,
+                ..
+            } => DatabaseClient::MySQL {
+                pool: pool.clone(),
+                dialect: *dialect,
+            },
             Database::MySQL { pool: None, .. } => {
                 return Err(Error::Any(anyhow::anyhow!("MySQL connection not active")));
-            }
-            Database::MariaDB {
-                pool: Some(pool), ..
-            } => DatabaseClient::MySQL { pool: pool.clone() },
-            Database::MariaDB { pool: None, .. } => {
-                return Err(Error::Any(anyhow::anyhow!("MariaDB connection not active")));
             }
             Database::SQLite {
                 connection: Some(sqlite_conn),

--- a/docs/architecture/data-sources.md
+++ b/docs/architecture/data-sources.md
@@ -1,0 +1,117 @@
+# Data Source Architecture — Models, Engines, Dialects
+
+Status: design locked (2026-06-14). Drives the dialect-parity work and all future
+data-source support (new SQL dialects, serverless vendors, and entirely new database
+models — document / key-value / columnar / graph).
+
+## The problem
+
+"Which database is this?" currently has three conflated answers:
+
+1. `Database::CockroachDB` / `Database::MariaDB` — backend connection-state *variants*,
+   peers of `Postgres`/`MySQL` (wrong: they are not different wire engines).
+2. `detected_dialect` — a runtime field added for version detection.
+3. Frontend `DbPreset` (neon, supabase, cockroach, planetscale, turso…) — already correct.
+
+This does not scale: the modern market is dominated by wire-compatible vendors. Modeling
+each as a top-level engine variant leads to `Database::Neon`, `Database::Supabase`,
+`Database::Aurora` — absurd. They are the **same Postgres engine with a label**.
+
+## The model: three tiers + one capability descriptor
+
+```
+Tier 1  MODEL / PARADIGM   relational | document | key-value | columnar | graph | search | timeseries
+Tier 2  ENGINE / WIRE      postgres | mysql | sqlite | duckdb | libsql | (future: mongo | redis | clickhouse)
+Tier 3  DIALECT / VENDOR   vanilla | cockroach | neon | supabase | aurora-pg ; mariadb | planetscale | tidb ; turso
+```
+
+- **Model** drives capability *defaults* and which UI affordances exist at all
+  (a document store has no rows-grid edit; a KV store has no schema tree).
+- **Engine** is the wire protocol → one `DatabaseAdapter` / `WriteAdapter` impl.
+  Adding MongoDB/ClickHouse is *additive* here.
+- **Dialect** is a vendor flavor *within* an engine → a `DialectProfile`. Most profiles
+  are pure metadata (Neon/Supabase/Aurora/PlanetScale = free); a few (Cockroach, Redshift,
+  TiDB) carry introspection-query and type-mapping overrides.
+
+### Capabilities are the routing mechanism (the enterprise bit)
+
+Feature code MUST NOT branch on engine/dialect identity. It asks the **resolved
+capability descriptor**:
+
+```
+Capabilities {
+  // paradigm
+  queryLanguage: 'sql' | 'mql' | 'redis' | ...
+  resultShape:   'rows' | 'documents' | 'keyvalue' | 'graph'
+  // surface (already on the frontend SourceCaps)
+  canRunSql, canInspectSchema, canEditRows, canImportFile, canExportFile,
+  canQueryFiles, canAttachFiles, supportsLocalFile, supportsRemoteUrl,
+  supportsSshTunnel, supportsLiveMonitor, isReadonly
+  // dialect deltas
+  supportsListenNotify, supportsTransactions, supportsExplainJson, ...
+}
+```
+
+Resolution layers: **model defaults → engine overrides → dialect overrides**. Adding a
+new model = define its defaults + the UI branches on `resultShape`. Nothing else rewrites.
+
+### Single source of truth for capabilities
+
+Caps are currently defined twice — frontend `source-caps.ts` (`ENGINE_CAPS`) and backend
+`dialect.rs` (`SourceCaps`). They will drift. **Backend is canonical**; it resolves caps
+for a (model, engine, dialect) and surfaces them to the frontend via a binding. The
+frontend keeps only presentation (labels/icons/presets).
+
+## Backend target shape
+
+`DatabaseType` (adapter engine id) — **already correct**, keep as-is:
+`Postgres | MySQL | SQLite | DuckDB | LibSQL`.
+
+`Database` (connection state) — remove the dialect peer-variants, dialect becomes a field:
+
+```rust
+Database::Postgres { client, use_simple_query, dialect: PgDialect, .. }   // was: + CockroachDB variant
+Database::MySQL    { client, dialect: MySqlDialect, .. }                  // was: + MariaDB variant
+// SQLite / DuckDB / LibSQL unchanged
+```
+
+`PgDialect` / `MySqlDialect` (in `dialect.rs`) — enum-as-strategy (closed, vendor-controlled
+set → enum, not a trait; exhaustive matches give compiler-enforced completeness):
+
+```rust
+impl PgDialect {
+    fn profile(&self) -> &'static DialectProfile;   // metadata + caps deltas
+    fn introspection(&self) -> PgIntrospection;     // query overrides; defaults to vanilla
+    fn map_type(&self, t: &Type) -> Option<Display>;// type overrides; None ⇒ base path
+}
+```
+
+Default dialect = `Vanilla`; `detect_pg_dialect`/`detect_mysql_dialect` set it at connect.
+Adapters (`PostgresAdapter`/`MySqlAdapter`) carry the dialect field — mirrors the existing
+`use_simple_query` precedent — and pass it into `get_schema` + the row writer.
+
+### Why enum-as-strategy, not a trait or parallel modules
+- Closed set we ship (no third-party plugins) → enum beats trait (no dispatch/ceremony).
+- Exhaustive match: add `PgDialect::Yugabyte` → every arm fails to compile until handled.
+- Parallel `cockroachdb/` modules would duplicate ~90% of working Postgres code.
+
+## Frontend
+Already engine/preset-aware (`DbEngine`, `DbPreset`, `SourceMeta`, `SourceCaps`). Keep
+`Connection.type` as the user-facing id; the binding/conversion layer bridges
+frontend `type='cockroach'` → backend `engine=postgres, dialect=Cockroach`. Cleaning the
+frontend `DatabaseType` to drop cockroach/mariadb is a *later, optional* tidy — not blocking.
+
+## What this unlocks (in cost order)
+- **Free** (metadata-only profiles): Neon, Supabase, Aurora-PG, AlloyDB, Timescale,
+  PlanetScale, Aurora-MySQL — label + preset + caps, zero introspection code.
+- **Cheap** (a few overrides): CockroachDB, MariaDB, YugabyteDB, TiDB.
+- **Most** (heavy overrides, still same engine): Redshift, Greenplum, SingleStore.
+- **New adapter** (separate effort, unaffected by this): MongoDB, ClickHouse, SQL Server,
+  Snowflake — implement `DatabaseAdapter`, define a model + caps, UI routes on `resultShape`.
+
+## Non-goals (now)
+- No new database engines in this work (Mongo/ClickHouse are future, additive).
+- No premature generalization of the adapter trait — the capability layer is the seam that
+  makes a future non-relational adapter additive.
+</content>
+</invoke>


### PR DESCRIPTION
Stacked on #118. Keystone of the engine↔dialect split — see `docs/architecture/data-sources.md`. Pure seam, **zero behavior change**: runtime `Database` enum drops `CockroachDB`/`MariaDB` peer-variants, dialect becomes a field on `Postgres`/`MySQL` (mirrors `use_simple_query`). `DatabaseInfo` frontend contract unchanged (conversions bridge); no bindings/frontend changes. Detection writes into the dialect field as source of truth; caps + CockroachDB LISTEN/NOTIFY gating derive from it. Dialect threaded into adapters → `get_schema` + row writers as vanilla-default seam with `// TODO(dialect-parity)` hooks. cargo check/test green (except 2 pre-existing pgtemp/initdb integration tests); typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)