### PR TITLE
feat(orm-cockpit): Wave A — Schema IR + live-DB mapper (frozen contract)

### DIFF
--- a/__tests__/packages/studio/orm-cockpit/from-live-schema.test.ts
+++ b/__tests__/packages/studio/orm-cockpit/from-live-schema.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest'
+import type { DatabaseSchema, TableInfo } from '@studio/lib/bindings'
+import { fromLiveSchema } from '@studio/features/orm-cockpit/ir/from-live-schema'
+import { normalizeDbType } from '@studio/features/orm-cockpit/ir/normalize-type'
+
+function schema(tables: TableInfo[]): DatabaseSchema {
+	return { tables, schemas: [], unique_columns: [] }
+}
+
+describe('fromLiveSchema (postgres)', function () {
+	const pg = schema([
+		{
+			name: 'post',
+			schema: 'public',
+			primary_key_columns: ['id'],
+			columns: [
+				// Deliberately out of alphabetical order to prove sorting.
+				{
+					name: 'author_id',
+					data_type: 'integer',
+					is_nullable: false,
+					default_value: null,
+					is_primary_key: false,
+					is_auto_increment: false,
+					foreign_key: {
+						referenced_table: 'user',
+						referenced_column: 'id',
+						referenced_schema: 'public',
+					},
+				},
+				{
+					name: 'id',
+					data_type: 'bigint',
+					is_nullable: false,
+					default_value: null,
+					is_primary_key: true,
+					is_auto_increment: true,
+					foreign_key: null,
+				},
+				{
+					name: 'created_at',
+					data_type: 'timestamp with time zone',
+					is_nullable: false,
+					default_value: 'now()',
+					is_primary_key: false,
+					is_auto_increment: false,
+					foreign_key: null,
+				},
+			],
+			indexes: [
+				{ name: 'post_pkey', column_names: ['id'], is_unique: true, is_primary: true },
+				{
+					name: 'post_author_idx',
+					column_names: ['author_id'],
+					is_unique: false,
+					is_primary: false,
+				},
+			],
+		},
+		{
+			name: 'user',
+			schema: 'public',
+			primary_key_columns: ['id'],
+			columns: [
+				{
+					name: 'id',
+					data_type: 'bigint',
+					is_nullable: false,
+					default_value: null,
+					is_primary_key: true,
+					is_auto_increment: true,
+					foreign_key: null,
+				},
+			],
+			indexes: [],
+		},
+	])
+
+	const ir = fromLiveSchema(pg, 'postgres')
+
+	it('sorts tables by name', function () {
+		expect(ir.tables.map((t) => t.name)).toEqual(['post', 'user'])
+	})
+
+	it('sorts columns by name and normalizes types', function () {
+		const post = ir.tables[0]
+		expect(post.columns.map((c) => c.name)).toEqual(['author_id', 'created_at', 'id'])
+		expect(post.columns.map((c) => c.type)).toEqual(['int', 'timestamptz', 'bigint'])
+	})
+
+	it('keeps the raw type alongside the normalized one', function () {
+		const createdAt = ir.tables[0].columns.find((c) => c.name === 'created_at')
+		expect(createdAt?.rawType).toBe('timestamp with time zone')
+	})
+
+	it('preserves primary-key order and the schema', function () {
+		expect(ir.tables[0].primaryKey).toEqual(['id'])
+		expect(ir.tables[0].schema).toBe('public')
+	})
+
+	it('drops the implicit primary-key index but keeps real ones', function () {
+		expect(ir.tables[0].indexes.map((i) => i.name)).toEqual(['post_author_idx'])
+	})
+
+	it('folds per-column foreign keys into the IR', function () {
+		expect(ir.tables[0].foreignKeys).toEqual([
+			{ columns: ['author_id'], refTable: 'user', refColumns: ['id'] },
+		])
+	})
+
+	it('carries through autoIncrement and nullability', function () {
+		const id = ir.tables[0].columns.find((c) => c.name === 'id')
+		expect(id?.autoIncrement).toBe(true)
+		expect(id?.nullable).toBe(false)
+	})
+})
+
+describe('fromLiveSchema (sqlite)', function () {
+	const sqlite = schema([
+		{
+			name: 'todo',
+			schema: '',
+			primary_key_columns: [],
+			columns: [
+				{
+					name: 'id',
+					data_type: 'INTEGER',
+					is_nullable: false,
+					default_value: null,
+					is_primary_key: true,
+					is_auto_increment: true,
+					foreign_key: null,
+				},
+				{
+					name: 'title',
+					data_type: 'TEXT',
+					is_nullable: true,
+					default_value: '   ',
+					is_primary_key: false,
+					is_auto_increment: false,
+					foreign_key: null,
+				},
+			],
+			indexes: [],
+		},
+	])
+
+	const ir = fromLiveSchema(sqlite, 'sqlite')
+
+	it('omits the schema field when the engine reports none', function () {
+		expect(ir.tables[0].schema).toBeUndefined()
+	})
+
+	it('derives the primary key from per-column flags when the list is empty', function () {
+		expect(ir.tables[0].primaryKey).toEqual(['id'])
+	})
+
+	it('collapses whitespace-only defaults to null', function () {
+		const title = ir.tables[0].columns.find((c) => c.name === 'title')
+		expect(title?.default).toBeNull()
+	})
+})
+
+describe('fromLiveSchema (composite foreign key)', function () {
+	const withComposite = schema([
+		{
+			name: 'membership',
+			schema: 'public',
+			primary_key_columns: ['org_id', 'user_id'],
+			columns: [
+				{
+					name: 'user_id',
+					data_type: 'bigint',
+					is_nullable: false,
+					default_value: null,
+					is_primary_key: true,
+					is_auto_increment: false,
+					foreign_key: {
+						referenced_table: 'account',
+						referenced_column: 'user_id',
+						referenced_schema: 'public',
+					},
+				},
+				{
+					name: 'org_id',
+					data_type: 'bigint',
+					is_nullable: false,
+					default_value: null,
+					is_primary_key: true,
+					is_auto_increment: false,
+					foreign_key: {
+						referenced_table: 'account',
+						referenced_column: 'org_id',
+						referenced_schema: 'public',
+					},
+				},
+			],
+			indexes: [],
+		},
+	])
+
+	it('groups multiple columns referencing the same table into one FK', function () {
+		const ir = fromLiveSchema(withComposite, 'postgres')
+		expect(ir.tables[0].foreignKeys).toEqual([
+			{
+				columns: ['user_id', 'org_id'],
+				refTable: 'account',
+				refColumns: ['user_id', 'org_id'],
+			},
+		])
+	})
+
+	it('preserves composite primary-key order', function () {
+		const ir = fromLiveSchema(withComposite, 'postgres')
+		expect(ir.tables[0].primaryKey).toEqual(['org_id', 'user_id'])
+	})
+})
+
+describe('normalizeDbType', function () {
+	it('maps the postgres vocabulary the live DB emits', function () {
+		expect(normalizeDbType('bigserial', 'postgres')).toBe('bigint')
+		expect(normalizeDbType('integer', 'postgres')).toBe('int')
+		expect(normalizeDbType('smallint', 'postgres')).toBe('smallint')
+		expect(normalizeDbType('character varying(255)', 'postgres')).toBe('varchar')
+		expect(normalizeDbType('jsonb', 'postgres')).toBe('jsonb')
+		expect(normalizeDbType('json', 'postgres')).toBe('json')
+		expect(normalizeDbType('timestamptz', 'postgres')).toBe('timestamptz')
+		expect(normalizeDbType('timestamp without time zone', 'postgres')).toBe('timestamp')
+		expect(normalizeDbType('uuid', 'postgres')).toBe('uuid')
+		expect(normalizeDbType('numeric(10,2)', 'postgres')).toBe('decimal')
+		expect(normalizeDbType('double precision', 'postgres')).toBe('double')
+		expect(normalizeDbType('bytea', 'postgres')).toBe('bytes')
+	})
+
+	it('maps the mysql vocabulary, including tinyint(1) as bool', function () {
+		expect(normalizeDbType('tinyint(1)', 'mysql')).toBe('bool')
+		expect(normalizeDbType('tinyint', 'mysql')).toBe('smallint')
+		expect(normalizeDbType('bigint unsigned', 'mysql')).toBe('bigint')
+		expect(normalizeDbType('varchar(191)', 'mysql')).toBe('varchar')
+		expect(normalizeDbType('datetime', 'mysql')).toBe('timestamp')
+		expect(normalizeDbType('json', 'mysql')).toBe('json')
+		expect(normalizeDbType('longblob', 'mysql')).toBe('bytes')
+	})
+
+	it('maps loose sqlite affinities', function () {
+		expect(normalizeDbType('INTEGER', 'sqlite')).toBe('int')
+		expect(normalizeDbType('REAL', 'sqlite')).toBe('float')
+		expect(normalizeDbType('TEXT', 'sqlite')).toBe('text')
+		expect(normalizeDbType('BLOB', 'sqlite')).toBe('bytes')
+	})
+
+	it('falls back to unknown rather than guessing', function () {
+		expect(normalizeDbType('geometry', 'postgres')).toBe('unknown')
+		expect(normalizeDbType('', 'postgres')).toBe('unknown')
+		expect(normalizeDbType('inet', 'postgres')).toBe('unknown')
+	})
+})

--- a/packages/studio/src/features/orm-cockpit/ir/from-live-schema.ts
+++ b/packages/studio/src/features/orm-cockpit/ir/from-live-schema.ts
@@ -1,0 +1,157 @@
+import type {
+	ColumnInfo,
+	DatabaseSchema,
+	IndexInfo,
+	TableInfo,
+} from '@studio/lib/bindings'
+import { normalizeDbType } from '@studio/features/orm-cockpit/ir/normalize-type'
+import type {
+	ColumnIR,
+	Dialect,
+	ForeignKeyIR,
+	IndexIR,
+	SchemaIR,
+	TableIR,
+} from '@studio/features/orm-cockpit/ir/types'
+
+/**
+ * Map the live database's {@link DatabaseSchema} (as it crosses the Rust→TS
+ * boundary via bindings) into the normalized {@link SchemaIR}.
+ *
+ * Note the bindings use snake_case (`data_type`, `is_nullable`,
+ * `primary_key_columns`, …) and several fields are optional — we read them
+ * defensively. Collections are sorted by name so the result diffs
+ * deterministically against an IR produced from a schema file.
+ */
+export function fromLiveSchema(schema: DatabaseSchema, dialect: Dialect): SchemaIR {
+	const tables = schema.tables
+		.map(function (table) {
+			return mapTable(table, dialect)
+		})
+		.sort(byName)
+
+	return { dialect, tables }
+}
+
+function mapTable(table: TableInfo, dialect: Dialect): TableIR {
+	const columns = table.columns.map(function (column) {
+		return mapColumn(column, dialect)
+	})
+
+	const primaryKey = derivePrimaryKey(table)
+	const hasExplicitPk = primaryKey.length > 0
+
+	const indexes = (table.indexes ?? [])
+		// The PK is already represented by `primaryKey`; drop its implicit index
+		// so it isn't double-counted as drift.
+		.filter(function (index) {
+			return !(index.is_primary && hasExplicitPk)
+		})
+		.map(mapIndex)
+		.sort(byName)
+
+	const ir: TableIR = {
+		name: table.name,
+		columns: columns.sort(byName),
+		primaryKey,
+		indexes,
+		foreignKeys: collectForeignKeys(table.columns),
+	}
+
+	// Preserve a meaningful schema; SQLite reports none.
+	if (table.schema && table.schema.length > 0) {
+		ir.schema = table.schema
+	}
+
+	return ir
+}
+
+function mapColumn(column: ColumnInfo, dialect: Dialect): ColumnIR {
+	return {
+		name: column.name,
+		type: normalizeDbType(column.data_type, dialect),
+		rawType: column.data_type,
+		nullable: column.is_nullable,
+		default: normalizeDefault(column.default_value),
+		autoIncrement: column.is_auto_increment ?? false,
+	}
+}
+
+function mapIndex(index: IndexInfo): IndexIR {
+	return {
+		name: index.name,
+		columns: index.column_names,
+		unique: index.is_unique,
+	}
+}
+
+/**
+ * Prefer the authoritative ordered `primary_key_columns`; fall back to the
+ * per-column `is_primary_key` flags (in column order) for adapters that don't
+ * populate it.
+ */
+function derivePrimaryKey(table: TableInfo): string[] {
+	if (table.primary_key_columns && table.primary_key_columns.length > 0) {
+		return table.primary_key_columns
+	}
+	return table.columns
+		.filter(function (column) {
+			return column.is_primary_key === true
+		})
+		.map(function (column) {
+			return column.name
+		})
+}
+
+/**
+ * The live schema carries foreign keys per column, so fold them into
+ * {@link ForeignKeyIR} grouped by referenced table/schema (composite FKs
+ * surface as multiple per-column entries pointing at the same table). Result
+ * is sorted for deterministic diffs.
+ */
+function collectForeignKeys(columns: ColumnInfo[]): ForeignKeyIR[] {
+	const byRef = new Map<string, ForeignKeyIR>()
+
+	for (const column of columns) {
+		const fk = column.foreign_key
+		if (!fk) {
+			continue
+		}
+
+		const key = `${fk.referenced_schema}.${fk.referenced_table}`
+		const existing = byRef.get(key)
+		if (existing) {
+			existing.columns.push(column.name)
+			existing.refColumns.push(fk.referenced_column)
+		} else {
+			byRef.set(key, {
+				columns: [column.name],
+				refTable: fk.referenced_table,
+				refColumns: [fk.referenced_column],
+			})
+		}
+	}
+
+	return Array.from(byRef.values()).sort(function (a, b) {
+		const table = a.refTable.localeCompare(b.refTable)
+		if (table !== 0) {
+			return table
+		}
+		return a.columns.join(',').localeCompare(b.columns.join(','))
+	})
+}
+
+/** Empty/whitespace-only defaults become null; otherwise keep the raw text.
+ * Deeper default normalization (e.g. `now()` vs `CURRENT_TIMESTAMP`) is left to
+ * the diff engine, which compares conservatively. */
+function normalizeDefault(value: string | null): string | null {
+	if (value === null) {
+		return null
+	}
+	const trimmed = value.trim()
+	return trimmed.length === 0 ? null : trimmed
+}
+
+function byName(a: { name: string }, b: { name: string }): number {
+	return a.name.localeCompare(b.name)
+}

--- a/packages/studio/src/features/orm-cockpit/ir/normalize-type.ts
+++ b/packages/studio/src/features/orm-cockpit/ir/normalize-type.ts
@@ -1,0 +1,122 @@
+import type { Dialect, NormalizedType } from '@studio/features/orm-cockpit/ir/types'
+
+/**
+ * Map a raw DB/ORM type string to the small canonical {@link NormalizedType}
+ * set so semantically-equal columns don't surface as drift.
+ *
+ * Design rule (the single most important call in Pillar 2): bias to
+ * `'unknown'` over guessing. Anything not confidently recognized returns
+ * `'unknown'`, which the diff engine (plan 05) treats as "review" rather than
+ * emitting a confident — and possibly destructive — ALTER. So it is always
+ * safe to leave a type out of this map; it is never safe to map it wrong.
+ *
+ * Matching is substring-based (raw types carry length/precision noise like
+ * `varchar(255)`, `numeric(10,2)`, `timestamp(6) with time zone`) and the
+ * checks are ordered most-specific-first (`bigint` before `int`, `jsonb`
+ * before `json`, `timestamptz` before `timestamp`, `timestamp` before `time`).
+ *
+ * Vocabulary cross-checked against the reverse mapping in
+ * `apps/desktop/src-tauri/src/database/services/schema_export.rs`
+ * (`get_drizzle_type`), which is what the live DB emits for pg/sqlite.
+ */
+export function normalizeDbType(rawType: string, dialect: Dialect): NormalizedType {
+	const t = rawType.trim().toLowerCase()
+	if (t.length === 0) {
+		return 'unknown'
+	}
+
+	switch (dialect) {
+		case 'postgres':
+			return normalizePostgres(t)
+		case 'mysql':
+			return normalizeMysql(t)
+		case 'sqlite':
+			return normalizeSqlite(t)
+		default:
+			return 'unknown'
+	}
+}
+
+function has(t: string, needle: string): boolean {
+	return t.includes(needle)
+}
+
+function normalizePostgres(t: string): NormalizedType {
+	if (has(t, 'bool')) return 'bool'
+	if (has(t, 'uuid')) return 'uuid'
+	if (has(t, 'jsonb')) return 'jsonb'
+	if (has(t, 'json')) return 'json'
+
+	// Integers: serial is a default-bearing alias for the int family.
+	if (has(t, 'bigserial') || has(t, 'int8') || has(t, 'bigint')) return 'bigint'
+	if (has(t, 'smallserial') || has(t, 'smallint') || has(t, 'int2')) return 'smallint'
+	if (has(t, 'serial') || has(t, 'int4') || has(t, 'integer') || has(t, 'int')) return 'int'
+
+	if (has(t, 'numeric') || has(t, 'decimal') || has(t, 'money')) return 'decimal'
+	if (has(t, 'double') || has(t, 'float8')) return 'double'
+	if (has(t, 'real') || has(t, 'float4') || has(t, 'float')) return 'float'
+
+	// timestamp/time variants: time-zone and "timestamp" must win over "time".
+	if (has(t, 'timestamptz') || has(t, 'timestamp with time zone')) return 'timestamptz'
+	if (has(t, 'timestamp')) return 'timestamp'
+	if (has(t, 'date')) return 'date'
+	if (has(t, 'time')) return 'time'
+
+	if (has(t, 'bytea')) return 'bytes'
+	if (has(t, 'varchar') || has(t, 'character varying')) return 'varchar'
+	if (has(t, 'char') || has(t, 'bpchar')) return 'varchar'
+	if (has(t, 'text')) return 'text'
+
+	return 'unknown'
+}
+
+function normalizeMysql(t: string): NormalizedType {
+	// MySQL has no boolean type; tinyint(1) is the idiomatic boolean.
+	if (has(t, 'tinyint(1)')) return 'bool'
+	if (has(t, 'bool')) return 'bool'
+
+	if (has(t, 'bigint')) return 'bigint'
+	if (has(t, 'smallint') || has(t, 'tinyint') || has(t, 'mediumint')) return 'smallint'
+	if (has(t, 'int')) return 'int'
+
+	if (has(t, 'decimal') || has(t, 'numeric')) return 'decimal'
+	if (has(t, 'double')) return 'double'
+	if (has(t, 'float') || has(t, 'real')) return 'float'
+
+	// MySQL has only `json` (no jsonb).
+	if (has(t, 'json')) return 'json'
+
+	if (has(t, 'datetime') || has(t, 'timestamp')) return 'timestamp'
+	if (has(t, 'date')) return 'date'
+	if (has(t, 'time')) return 'time'
+	if (has(t, 'year')) return 'int'
+
+	if (has(t, 'blob') || has(t, 'binary')) return 'bytes'
+	if (has(t, 'varchar')) return 'varchar'
+	if (has(t, 'char')) return 'varchar'
+	if (has(t, 'text') || has(t, 'enum')) return 'text'
+
+	return 'unknown'
+}
+
+function normalizeSqlite(t: string): NormalizedType {
+	// SQLite uses type affinity; raw type strings are still informative but
+	// loosely defined, so stay conservative.
+	if (has(t, 'bool')) return 'bool'
+
+	if (has(t, 'bigint')) return 'bigint'
+	if (has(t, 'int')) return 'int'
+
+	if (has(t, 'numeric') || has(t, 'decimal')) return 'decimal'
+	if (has(t, 'double')) return 'double'
+	if (has(t, 'real') || has(t, 'float')) return 'float'
+
+	if (has(t, 'timestamp') || has(t, 'datetime')) return 'timestamp'
+	if (has(t, 'date')) return 'date'
+	if (has(t, 'time')) return 'time'
+
+	if (has(t, 'blob')) return 'bytes'
+	if (has(t, 'char') || has(t, 'clob') || has(t, 'text')) return 'text'
+
+	return 'unknown'
+}

--- a/packages/studio/src/features/orm-cockpit/ir/types.ts
+++ b/packages/studio/src/features/orm-cockpit/ir/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Schema IR — the single normalized representation every Pillar-2 producer maps
+ * INTO and every consumer operates ON.
+ *
+ *   live DB (Rust getDatabaseSchema) ─┐
+ *   drizzle schema .ts ───────────────┼─► SchemaIR ─► diff ─► migration gen ─► UI
+ *   schema.prisma ────────────────────┘
+ *
+ * THIS IS A FROZEN CONTRACT. Once shipped (#144), downstream plans (drizzle
+ * parser, prisma parser, diff engine, migration gen, cockpit UI) import these
+ * types and must not redefine them. Add fields only additively and only after
+ * coordinating, because every producer/consumer keys off this shape.
+ *
+ * Collections (tables/columns/indexes/foreignKeys) are sorted by name by the
+ * producers so two IRs diff deterministically.
+ */
+
+export type Dialect = 'postgres' | 'mysql' | 'sqlite'
+
+/**
+ * Canonical type set. Intentionally small: the diff engine compares normalized
+ * types, so anything we cannot confidently map collapses to `'unknown'`, which
+ * the diff treats as "review" rather than emitting a confident (and possibly
+ * destructive) ALTER. Growing this set is a deliberate, conservative act.
+ */
+export type NormalizedType =
+	| 'int'
+	| 'bigint'
+	| 'smallint'
+	| 'float'
+	| 'double'
+	| 'decimal'
+	| 'bool'
+	| 'text'
+	| 'varchar'
+	| 'uuid'
+	| 'json'
+	| 'jsonb'
+	| 'timestamp'
+	| 'timestamptz'
+	| 'date'
+	| 'time'
+	| 'bytes'
+	| 'unknown'
+
+export type ColumnIR = {
+	name: string
+	/** Canonical type used for confident comparison. */
+	type: NormalizedType
+	/** Original DB/ORM type, kept for display and fallback comparison. */
+	rawType: string
+	nullable: boolean
+	/** Normalized textual default, or null when there is none. */
+	default: string | null
+	autoIncrement: boolean
+}
+
+export type IndexIR = {
+	name: string
+	columns: string[]
+	unique: boolean
+}
+
+export type ForeignKeyIR = {
+	columns: string[]
+	refTable: string
+	refColumns: string[]
+	onDelete?: string
+	onUpdate?: string
+}
+
+export type TableIR = {
+	name: string
+	/** Postgres schema; defaults to 'public'. Empty/absent for SQLite. */
+	schema?: string
+	/** Sorted by name. */
+	columns: ColumnIR[]
+	/** Ordered primary-key column names (composite keys preserve order). */
+	primaryKey: string[]
+	/** Sorted by name; excludes the implicit primary-key index. */
+	indexes: IndexIR[]
+	/** Sorted by (refTable, columns). */
+	foreignKeys: ForeignKeyIR[]
+}
+
+export type SchemaIR = {
+	dialect: Dialect
+	/** Sorted by name for stable diffs. */
+	tables: TableIR[]
+}


### PR DESCRIPTION
## Pillar 2 — Wave A (#144). Single-owner foundation; **blocks all of Pillar 2**.

Defines the normalized **Schema IR** that every Pillar-2 producer maps *into* and every consumer operates *on*, plus the mapper from the live DB's `DatabaseSchema` into it. This is the **frozen contract** — once merged, Wave B (drizzle parser, prisma parser, folder linking, diff engine) imports these types and must not redefine them.

```
 live DB ──(getDatabaseSchema)──► fromLiveSchema ─┐
 drizzle .ts ──(parser, Wave B)───────────────────┼─► SchemaIR ─► diff ─► migration gen ─► UI
 schema.prisma ──(parser, Wave B)─────────────────┘
```

### Files
- `packages/studio/src/features/orm-cockpit/ir/types.ts` — `SchemaIR` / `TableIR` / `ColumnIR` / `IndexIR` / `ForeignKeyIR` + the small canonical `NormalizedType` set.
- `ir/normalize-type.ts` — `normalizeDbType(rawType, dialect)` for postgres/mysql/sqlite. **Conservative by design:** anything not confidently recognized → `'unknown'`, which the diff engine (plan 05) treats as *"review"* rather than emitting a confident, possibly destructive `ALTER`. Vocabulary cross-checked against `schema_export.rs` `get_drizzle_type`.
- `ir/from-live-schema.ts` — `fromLiveSchema(schema, dialect)`: reads the snake_case bindings defensively, folds per-column FKs into grouped FK IR, preserves PK order, drops the implicit PK index, sorts all collections for deterministic diffs.
- `__tests__/packages/studio/orm-cockpit/from-live-schema.test.ts` — 16 tests: pg + sqlite + composite-FK fixtures, type-normalization vocab, conservative `unknown` fallback.

### Deviation from plan
The plan referenced `DatabaseSchema` fields in camelCase (`primaryKeyColumns`, `dataType`…); the real bindings on `master` are **snake_case** (`primary_key_columns`, `data_type`, `default_value`, …) with several optional fields. Followed the real API per RUNBOOK's "follow real API behavior over the plan if they differ."

### Verification
- `packages/studio` typecheck — clean (exit 0)
- `apps/desktop` typecheck — clean (exit 0)
- Full suite — **486 passed** (470 baseline + 16 new)
- Pure TypeScript; no Rust / bindings touched, so cargo is N/A.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/remco-stoeten/codesmith/dora/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784483681&installation_id=140085766&pr_number=151&repository=remco-stoeten%2Fdora&return_to=https%3A%2F%2Fgithub.com%2Fremco-stoeten%2Fdora%2Fpull%2F151&signature=c192dfa7759fa1e474920d5acd82a635eef23a553b7c55ebbac7be951bdae824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->