### PR TITLE
feat(orm-cockpit): Wave B — Drizzle/Prisma parsers, diff engine, folder linking

### DIFF
--- a/__tests__/packages/studio/orm-cockpit/diff/diff-schema.test.ts
+++ b/__tests__/packages/studio/orm-cockpit/diff/diff-schema.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from 'vitest'
+import type {
+	ColumnIR,
+	ForeignKeyIR,
+	IndexIR,
+	NormalizedType,
+	SchemaIR,
+	TableIR,
+} from '@studio/features/orm-cockpit/ir/types'
+import { diffSchema } from '@studio/features/orm-cockpit/diff/diff-schema'
+
+// ---- fixture builders ------------------------------------------------------
+
+function col(name: string, type: NormalizedType, over: Partial<ColumnIR> = {}): ColumnIR {
+	return {
+		name,
+		type,
+		rawType: over.rawType ?? type,
+		nullable: over.nullable ?? false,
+		default: over.default ?? null,
+		autoIncrement: over.autoIncrement ?? false,
+	}
+}
+
+function table(name: string, columns: ColumnIR[], over: Partial<TableIR> = {}): TableIR {
+	return {
+		name,
+		columns,
+		primaryKey: over.primaryKey ?? [],
+		indexes: over.indexes ?? [],
+		foreignKeys: over.foreignKeys ?? [],
+		...(over.schema !== undefined ? { schema: over.schema } : {}),
+	}
+}
+
+function schema(tables: TableIR[]): SchemaIR {
+	return { dialect: 'postgres', tables }
+}
+
+const idCol = col('id', 'int', { autoIncrement: true })
+
+// ---- identical -------------------------------------------------------------
+
+describe('diffSchema — identical', function () {
+	it('returns no changes for structurally identical schemas', function () {
+		const a = schema([table('user', [idCol, col('name', 'text')])])
+		const b = schema([table('user', [idCol, col('name', 'text')])])
+		const diff = diffSchema(a, b)
+		expect(diff.hasChanges).toBe(false)
+		expect(diff.tables).toEqual([])
+	})
+
+	it('does not flag a column when only rawType differs but normalized type is equal', function () {
+		const a = schema([table('t', [col('c', 'varchar', { rawType: 'varchar(255)' })])])
+		const b = schema([table('t', [col('c', 'varchar', { rawType: 'character varying(255)' })])])
+		const diff = diffSchema(a, b)
+		expect(diff.hasChanges).toBe(false)
+	})
+})
+
+// ---- table add / remove ----------------------------------------------------
+
+describe('diffSchema — tables added / removed', function () {
+	it('marks a table only in `to` as added + safe', function () {
+		const from = schema([])
+		const to = schema([table('user', [idCol])])
+		const diff = diffSchema(from, to)
+		expect(diff.hasChanges).toBe(true)
+		expect(diff.tables).toHaveLength(1)
+		expect(diff.tables[0].kind).toBe('added')
+		expect(diff.tables[0].confidence).toBe('safe')
+		expect(diff.tables[0].columns.every((c) => c.kind === 'added')).toBe(true)
+	})
+
+	it('marks a table only in `from` as removed + destructive', function () {
+		const from = schema([table('user', [idCol])])
+		const to = schema([])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].kind).toBe('removed')
+		expect(diff.tables[0].confidence).toBe('destructive')
+		expect(diff.tables[0].columns[0].kind).toBe('removed')
+	})
+
+	it('keeps added-table confidence safe even with a NOT NULL no-default column', function () {
+		// Whole-table CREATE carries the columns inline; the table verdict is safe.
+		const to = schema([table('user', [idCol, col('email', 'text')])])
+		const diff = diffSchema(schema([]), to)
+		expect(diff.tables[0].confidence).toBe('safe')
+	})
+})
+
+// ---- column add / remove ---------------------------------------------------
+
+describe('diffSchema — columns added / removed', function () {
+	it('adding a nullable column is safe', function () {
+		const from = schema([table('t', [idCol])])
+		const to = schema([table('t', [idCol, col('bio', 'text', { nullable: true })])])
+		const diff = diffSchema(from, to)
+		const c = diff.tables[0].columns.find((x) => x.name === 'bio')!
+		expect(c.kind).toBe('added')
+		expect(c.confidence).toBe('safe')
+	})
+
+	it('adding a NOT NULL column with a default is safe', function () {
+		const from = schema([table('t', [idCol])])
+		const to = schema([table('t', [idCol, col('active', 'bool', { default: 'true' })])])
+		const diff = diffSchema(from, to)
+		const c = diff.tables[0].columns.find((x) => x.name === 'active')!
+		expect(c.confidence).toBe('safe')
+	})
+
+	it('adding a NOT NULL column without a default is destructive', function () {
+		const from = schema([table('t', [idCol])])
+		const to = schema([table('t', [idCol, col('email', 'text')])])
+		const diff = diffSchema(from, to)
+		const c = diff.tables[0].columns.find((x) => x.name === 'email')!
+		expect(c.kind).toBe('added')
+		expect(c.confidence).toBe('destructive')
+		// the table inherits worst-of children
+		expect(diff.tables[0].confidence).toBe('destructive')
+	})
+
+	it('removing a column is destructive', function () {
+		const from = schema([table('t', [idCol, col('legacy', 'text', { nullable: true })])])
+		const to = schema([table('t', [idCol])])
+		const diff = diffSchema(from, to)
+		const c = diff.tables[0].columns.find((x) => x.name === 'legacy')!
+		expect(c.kind).toBe('removed')
+		expect(c.confidence).toBe('destructive')
+	})
+})
+
+// ---- per-field column changes ----------------------------------------------
+
+describe('diffSchema — column field changes', function () {
+	it('flags nullable change (NOT NULL -> nullable) as safe relaxation', function () {
+		const from = schema([table('t', [col('c', 'text', { nullable: false })])])
+		const to = schema([table('t', [col('c', 'text', { nullable: true })])])
+		const diff = diffSchema(from, to)
+		const c = diff.tables[0].columns[0]
+		expect(c.changedFields).toEqual(['nullable'])
+		expect(c.confidence).toBe('safe')
+	})
+
+	it('flags nullable change (nullable -> NOT NULL) as review', function () {
+		const from = schema([table('t', [col('c', 'text', { nullable: true })])])
+		const to = schema([table('t', [col('c', 'text', { nullable: false })])])
+		const diff = diffSchema(from, to)
+		const c = diff.tables[0].columns[0]
+		expect(c.changedFields).toEqual(['nullable'])
+		expect(c.confidence).toBe('review')
+	})
+
+	it('flags default change as review', function () {
+		const from = schema([table('t', [col('c', 'int', { default: '0' })])])
+		const to = schema([table('t', [col('c', 'int', { default: '1' })])])
+		const diff = diffSchema(from, to)
+		const c = diff.tables[0].columns[0]
+		expect(c.changedFields).toEqual(['default'])
+		expect(c.confidence).toBe('review')
+	})
+
+	it('flags autoIncrement change as review', function () {
+		const from = schema([table('t', [col('c', 'int', { autoIncrement: false })])])
+		const to = schema([table('t', [col('c', 'int', { autoIncrement: true })])])
+		const diff = diffSchema(from, to)
+		const c = diff.tables[0].columns[0]
+		expect(c.changedFields).toEqual(['autoIncrement'])
+		expect(c.confidence).toBe('review')
+	})
+
+	it('records multiple changed fields together', function () {
+		const from = schema([table('t', [col('c', 'int', { nullable: true, default: '0' })])])
+		const to = schema([table('t', [col('c', 'int', { nullable: false, default: '1' })])])
+		const diff = diffSchema(from, to)
+		const c = diff.tables[0].columns[0]
+		expect(c.changedFields).toEqual(['nullable', 'default'])
+		expect(c.confidence).toBe('review')
+	})
+})
+
+// ---- type changes ----------------------------------------------------------
+
+describe('diffSchema — type changes', function () {
+	it('narrowing numeric type (bigint -> int) is destructive', function () {
+		const from = schema([table('t', [col('c', 'bigint')])])
+		const to = schema([table('t', [col('c', 'int')])])
+		const diff = diffSchema(from, to)
+		const c = diff.tables[0].columns[0]
+		expect(c.changedFields).toContain('type')
+		expect(c.confidence).toBe('destructive')
+	})
+
+	it('widening numeric type (int -> bigint) is review', function () {
+		const from = schema([table('t', [col('c', 'int')])])
+		const to = schema([table('t', [col('c', 'bigint')])])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].columns[0].confidence).toBe('review')
+	})
+
+	it('non-numeric type change (text -> timestamp) is review', function () {
+		const from = schema([table('t', [col('c', 'text')])])
+		const to = schema([table('t', [col('c', 'timestamp')])])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].columns[0].confidence).toBe('review')
+	})
+
+	it('unknown type with differing rawType is at least review (never equal)', function () {
+		const from = schema([table('t', [col('c', 'unknown', { rawType: 'citext' })])])
+		const to = schema([table('t', [col('c', 'unknown', { rawType: 'hstore' })])])
+		const diff = diffSchema(from, to)
+		expect(diff.hasChanges).toBe(true)
+		const c = diff.tables[0].columns[0]
+		expect(c.changedFields).toContain('type')
+		expect(c.confidence).toBe('review')
+	})
+
+	it('unknown type with identical rawType is treated as equal', function () {
+		const from = schema([table('t', [col('c', 'unknown', { rawType: 'citext' })])])
+		const to = schema([table('t', [col('c', 'unknown', { rawType: 'citext' })])])
+		const diff = diffSchema(from, to)
+		expect(diff.hasChanges).toBe(false)
+	})
+
+	it('known -> unknown type change is review', function () {
+		const from = schema([table('t', [col('c', 'text', { rawType: 'text' })])])
+		const to = schema([table('t', [col('c', 'unknown', { rawType: 'geometry' })])])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].columns[0].confidence).toBe('review')
+	})
+})
+
+// ---- indexes ---------------------------------------------------------------
+
+describe('diffSchema — indexes', function () {
+	function idx(name: string, columns: string[], unique = false): IndexIR {
+		return { name, columns, unique }
+	}
+
+	it('added index is a safe-contributing Change', function () {
+		const from = schema([table('t', [idCol])])
+		const to = schema([table('t', [idCol], { indexes: [idx('t_id_idx', ['id'])] })])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].indexes).toEqual([
+			{ kind: 'added', after: idx('t_id_idx', ['id']) },
+		])
+		expect(diff.tables[0].confidence).toBe('safe')
+	})
+
+	it('removed index contributes review', function () {
+		const from = schema([table('t', [idCol], { indexes: [idx('t_id_idx', ['id'])] })])
+		const to = schema([table('t', [idCol])])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].indexes[0].kind).toBe('removed')
+		expect(diff.tables[0].confidence).toBe('review')
+	})
+
+	it('changed index (unique toggle) emits a changed Change', function () {
+		const from = schema([table('t', [idCol], { indexes: [idx('t_id_idx', ['id'], false)] })])
+		const to = schema([table('t', [idCol], { indexes: [idx('t_id_idx', ['id'], true)] })])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].indexes[0].kind).toBe('changed')
+		expect(diff.tables[0].indexes[0].before!.unique).toBe(false)
+		expect(diff.tables[0].indexes[0].after!.unique).toBe(true)
+	})
+})
+
+// ---- foreign keys ----------------------------------------------------------
+
+describe('diffSchema — foreign keys', function () {
+	function fk(columns: string[], refTable: string, refColumns: string[], over: Partial<ForeignKeyIR> = {}): ForeignKeyIR {
+		return { columns, refTable, refColumns, ...over }
+	}
+
+	it('added FK emits an added Change (review)', function () {
+		const from = schema([table('post', [idCol, col('author_id', 'int')])])
+		const to = schema([
+			table('post', [idCol, col('author_id', 'int')], {
+				foreignKeys: [fk(['author_id'], 'user', ['id'])],
+			}),
+		])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].foreignKeys[0].kind).toBe('added')
+		expect(diff.tables[0].confidence).toBe('review')
+	})
+
+	it('removed FK emits a removed Change', function () {
+		const from = schema([
+			table('post', [idCol, col('author_id', 'int')], {
+				foreignKeys: [fk(['author_id'], 'user', ['id'])],
+			}),
+		])
+		const to = schema([table('post', [idCol, col('author_id', 'int')])])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].foreignKeys[0].kind).toBe('removed')
+	})
+
+	it('changed FK (onDelete differs, same columns+refTable) emits a changed Change', function () {
+		const from = schema([
+			table('post', [idCol, col('author_id', 'int')], {
+				foreignKeys: [fk(['author_id'], 'user', ['id'], { onDelete: 'cascade' })],
+			}),
+		])
+		const to = schema([
+			table('post', [idCol, col('author_id', 'int')], {
+				foreignKeys: [fk(['author_id'], 'user', ['id'], { onDelete: 'restrict' })],
+			}),
+		])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].foreignKeys[0].kind).toBe('changed')
+	})
+})
+
+// ---- worst-of aggregation --------------------------------------------------
+
+describe('diffSchema — table confidence is worst-of children', function () {
+	it('a destructive column drives the table to destructive despite safe siblings', function () {
+		const from = schema([
+			table('t', [idCol, col('legacy', 'text', { nullable: true })]),
+		])
+		const to = schema([
+			table('t', [
+				idCol,
+				col('bio', 'text', { nullable: true }), // safe add
+			]),
+		])
+		const diff = diffSchema(from, to)
+		// bio added (safe) + legacy removed (destructive)
+		expect(diff.tables[0].confidence).toBe('destructive')
+	})
+
+	it('a review change wins over only-safe siblings', function () {
+		const from = schema([table('t', [idCol, col('c', 'int', { default: '0' })])])
+		const to = schema([
+			table('t', [
+				idCol,
+				col('c', 'int', { default: '1' }), // review
+				col('extra', 'text', { nullable: true }), // safe add
+			]),
+		])
+		const diff = diffSchema(from, to)
+		expect(diff.tables[0].confidence).toBe('review')
+	})
+})
+
+// ---- determinism -----------------------------------------------------------
+
+describe('diffSchema — output ordering', function () {
+	it('tables and columns come out sorted by name', function () {
+		const from = schema([])
+		const to = schema([
+			table('zebra', [col('beta', 'text', { nullable: true }), col('alpha', 'text', { nullable: true })]),
+			table('apple', [col('id', 'int')]),
+		])
+		const diff = diffSchema(from, to)
+		expect(diff.tables.map((t) => t.name)).toEqual(['apple', 'zebra'])
+		const zebra = diff.tables.find((t) => t.name === 'zebra')!
+		expect(zebra.columns.map((c) => c.name)).toEqual(['alpha', 'beta'])
+	})
+})

--- a/__tests__/packages/studio/orm-cockpit/drizzle/parse-drizzle-schema.test.ts
+++ b/__tests__/packages/studio/orm-cockpit/drizzle/parse-drizzle-schema.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest'
+import { parseDrizzleSchema } from '@studio/features/orm-cockpit/parsers/drizzle/parse-drizzle-schema'
+
+const PG_USERS = `
+import { pgTable, serial, varchar, text, boolean, timestamp, integer, uuid } from 'drizzle-orm/pg-core'
+
+export const user = pgTable('user', {
+	id: serial('id').primaryKey(),
+	email: varchar('email', { length: 255 }).notNull().unique(),
+	name: text('name'),
+	isActive: boolean('is_active').notNull().default(true),
+	createdAt: timestamp('created_at').defaultNow(),
+	role: text('role').default('member'),
+})
+`
+
+const PG_POSTS = `
+import { pgTable, serial, varchar, integer, timestamp } from 'drizzle-orm/pg-core'
+import { user } from './user'
+
+export const post = pgTable('post', {
+	id: serial('id').primaryKey(),
+	title: varchar('title', { length: 200 }).notNull(),
+	authorId: integer('author_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+	publishedAt: timestamp('published_at'),
+})
+`
+
+describe('parseDrizzleSchema (postgres, multi-file)', function () {
+	const result = parseDrizzleSchema(
+		[
+			{ path: 'schema/user.ts', text: PG_USERS },
+			{ path: 'schema/post.ts', text: PG_POSTS },
+		],
+		'postgres'
+	)
+
+	it('produces a postgres IR with tables sorted by name', function () {
+		expect(result.ir.dialect).toBe('postgres')
+		expect(result.ir.tables.map((t) => t.name)).toEqual(['post', 'user'])
+	})
+
+	it('maps column builders to normalized types and respects explicit DB names', function () {
+		const user = result.ir.tables.find((t) => t.name === 'user')!
+		const byName = Object.fromEntries(user.columns.map((c) => [c.name, c]))
+		expect(user.columns.map((c) => c.name)).toEqual([
+			'created_at',
+			'email',
+			'id',
+			'is_active',
+			'name',
+			'role',
+		])
+		expect(byName.id.type).toBe('int')
+		expect(byName.id.rawType).toBe('serial')
+		expect(byName.id.autoIncrement).toBe(true)
+		expect(byName.email.type).toBe('varchar')
+		expect(byName.is_active.type).toBe('bool')
+		expect(byName.created_at.type).toBe('timestamp')
+	})
+
+	it('tracks primary keys, nullability and defaults', function () {
+		const user = result.ir.tables.find((t) => t.name === 'user')!
+		const byName = Object.fromEntries(user.columns.map((c) => [c.name, c]))
+		expect(user.primaryKey).toEqual(['id'])
+		expect(byName.id.nullable).toBe(false)
+		expect(byName.name.nullable).toBe(true)
+		expect(byName.is_active.default).toBe('true')
+		expect(byName.role.default).toBe('member')
+		expect(byName.created_at.default).toBe('now()')
+		expect(byName.name.default).toBeNull()
+	})
+
+	it('records .unique() as a single-column unique index', function () {
+		const user = result.ir.tables.find((t) => t.name === 'user')!
+		expect(user.indexes).toEqual([
+			{ name: 'user_email_unique', columns: ['email'], unique: true },
+		])
+	})
+
+	it('defaults postgres tables to the public schema', function () {
+		const user = result.ir.tables.find((t) => t.name === 'user')!
+		expect(user.schema).toBe('public')
+	})
+
+	it('resolves a single-column .references() foreign key across files', function () {
+		const post = result.ir.tables.find((t) => t.name === 'post')!
+		expect(post.foreignKeys).toEqual([
+			{
+				columns: ['author_id'],
+				refTable: 'user',
+				refColumns: ['id'],
+				onDelete: 'cascade',
+			},
+		])
+	})
+
+	it('emits no warnings for a clean schema', function () {
+		expect(result.warnings).toEqual([])
+	})
+})
+
+const SQLITE_SCHEMA = `
+import { sqliteTable, integer, text, primaryKey, index, uniqueIndex } from 'drizzle-orm/sqlite-core'
+
+export const account = sqliteTable('account', {
+	id: integer('id').primaryKey({ autoIncrement: true }),
+	slug: text('slug').notNull(),
+})
+
+export const membership = sqliteTable('membership', {
+	accountId: integer('account_id').notNull(),
+	userId: integer('user_id').notNull(),
+	role: text('role').notNull().default('viewer'),
+}, (t) => ({
+	pk: primaryKey({ columns: [t.accountId, t.userId] }),
+	roleIdx: index('membership_role_idx').on(t.role),
+	userUnique: uniqueIndex('membership_user_unique').on(t.userId),
+}))
+`
+
+describe('parseDrizzleSchema (sqlite, table-level config)', function () {
+	const result = parseDrizzleSchema([{ path: 'schema.ts', text: SQLITE_SCHEMA }], 'sqlite')
+
+	it('parses both tables with no warnings', function () {
+		expect(result.warnings).toEqual([])
+		expect(result.ir.dialect).toBe('sqlite')
+		expect(result.ir.tables.map((t) => t.name)).toEqual(['account', 'membership'])
+	})
+
+	it('does not set a schema on sqlite tables', function () {
+		const account = result.ir.tables.find((t) => t.name === 'account')!
+		expect(account.schema).toBeUndefined()
+	})
+
+	it('captures composite primary keys preserving column order', function () {
+		const membership = result.ir.tables.find((t) => t.name === 'membership')!
+		expect(membership.primaryKey).toEqual(['account_id', 'user_id'])
+	})
+
+	it('captures table-level indexes (plain and unique) sorted by name', function () {
+		const membership = result.ir.tables.find((t) => t.name === 'membership')!
+		expect(membership.indexes).toEqual([
+			{ name: 'membership_role_idx', columns: ['role'], unique: false },
+			{ name: 'membership_user_unique', columns: ['user_id'], unique: true },
+		])
+	})
+})
+
+const COMPOSITE_FK = `
+import { pgTable, integer, text, foreignKey } from 'drizzle-orm/pg-core'
+
+export const parent = pgTable('parent', {
+	a: integer('a').notNull(),
+	b: integer('b').notNull(),
+})
+
+export const child = pgTable('child', {
+	pa: integer('pa').notNull(),
+	pb: integer('pb').notNull(),
+}, (t) => ({
+	fk: foreignKey({
+		columns: [t.pa, t.pb],
+		foreignColumns: [parent.a, parent.b],
+	}).onDelete('restrict'),
+}))
+`
+
+describe('parseDrizzleSchema (composite foreign key)', function () {
+	const result = parseDrizzleSchema([{ path: 'schema.ts', text: COMPOSITE_FK }], 'postgres')
+
+	it('resolves a composite foreignKey() with an onDelete action', function () {
+		const child = result.ir.tables.find((t) => t.name === 'child')!
+		expect(child.foreignKeys).toEqual([
+			{
+				columns: ['pa', 'pb'],
+				refTable: 'parent',
+				refColumns: ['a', 'b'],
+				onDelete: 'restrict',
+			},
+		])
+	})
+})
+
+const DIALECT_MISMATCH = `
+import { sqliteTable, integer } from 'drizzle-orm/sqlite-core'
+
+export const thing = sqliteTable('thing', {
+	id: integer('id').primaryKey(),
+})
+`
+
+describe('parseDrizzleSchema (dialect resolution)', function () {
+	it('warns but proceeds when the builder dialect disagrees with the arg', function () {
+		const result = parseDrizzleSchema([{ path: 'schema.ts', text: DIALECT_MISMATCH }], 'postgres')
+		expect(result.ir.tables.map((t) => t.name)).toEqual(['thing'])
+		expect(result.warnings.some((w) => w.includes('sqliteTable') && w.includes('sqlite'))).toBe(true)
+	})
+})
+
+const UNRECOGNIZED = `
+import { pgTable, integer, customVectorEmbedding } from 'drizzle-orm/pg-core'
+
+export const widget = pgTable('widget', {
+	id: integer('id').primaryKey(),
+	payload: customVectorEmbedding('payload').$defaultFn(() => ({})),
+})
+`
+
+describe('parseDrizzleSchema (conservative degradation)', function () {
+	const result = parseDrizzleSchema([{ path: 'schema.ts', text: UNRECOGNIZED }], 'postgres')
+
+	it('marks an unrecognized builder as unknown and warns', function () {
+		const widget = result.ir.tables.find((t) => t.name === 'widget')!
+		const payload = widget.columns.find((c) => c.name === 'payload')!
+		expect(payload.type).toBe('unknown')
+		expect(payload.rawType).toBe('customVectorEmbedding')
+		expect(result.warnings.some((w) => w.includes('unrecognized builder'))).toBe(true)
+	})
+
+	it('marks a runtime $defaultFn default as unknown', function () {
+		const widget = result.ir.tables.find((t) => t.name === 'widget')!
+		const payload = widget.columns.find((c) => c.name === 'payload')!
+		expect(payload.default).toBe('unknown')
+	})
+
+	it('still parses the rest of the table', function () {
+		const widget = result.ir.tables.find((t) => t.name === 'widget')!
+		expect(widget.primaryKey).toEqual(['id'])
+		const id = widget.columns.find((c) => c.name === 'id')!
+		expect(id.type).toBe('int')
+	})
+})
+
+describe('parseDrizzleSchema (known limitations)', function () {
+	it('warns on re-export barrel files', function () {
+		const result = parseDrizzleSchema(
+			[{ path: 'index.ts', text: `export * from './user'\nexport * from './post'` }],
+			'postgres'
+		)
+		expect(result.ir.tables).toEqual([])
+		expect(result.warnings.some((w) => w.includes('re-export'))).toBe(true)
+	})
+
+	it('never throws on malformed input', function () {
+		const result = parseDrizzleSchema(
+			[{ path: 'broken.ts', text: 'export const x = pgTable(' }],
+			'postgres'
+		)
+		expect(Array.isArray(result.ir.tables)).toBe(true)
+	})
+})

--- a/__tests__/packages/studio/orm-cockpit/link/detect-orm.test.ts
+++ b/__tests__/packages/studio/orm-cockpit/link/detect-orm.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import {
+	detectOrm,
+	type ProjectReader,
+} from '@studio/features/orm-cockpit/link/detect-orm'
+
+/** Build a ProjectReader from a flat path→text map (paths are absolute). */
+function makeReader(files: Record<string, string>): ProjectReader {
+	return {
+		async readFile(path) {
+			return Object.prototype.hasOwnProperty.call(files, path) ? files[path] : null
+		},
+		async listDir(dir) {
+			const prefix = `${dir.replace(/\/+$/, '')}/`
+			const out = new Set<string>()
+			for (const path of Object.keys(files)) {
+				if (path.startsWith(prefix) && !path.slice(prefix.length).includes('/')) {
+					out.add(path)
+				}
+			}
+			return Array.from(out)
+		},
+	}
+}
+
+const ROOT = '/proj'
+
+describe('detectOrm — prisma', function () {
+	it('detects a prisma/schema.prisma project', async function () {
+		const reader = makeReader({
+			'/proj/prisma/schema.prisma': 'model User { id Int @id }',
+		})
+		const result = await detectOrm(ROOT, reader)
+		expect(result.kind).toBe('linked')
+		if (result.kind !== 'linked') return
+		expect(result.link.orm).toBe('prisma')
+		expect(result.link.schemaFiles.map((f) => f.path)).toEqual(['/proj/prisma/schema.prisma'])
+	})
+
+	it('collects a multi-file prisma/schema directory', async function () {
+		const reader = makeReader({
+			'/proj/prisma/schema/user.prisma': 'model User { id Int @id }',
+			'/proj/prisma/schema/post.prisma': 'model Post { id Int @id }',
+			'/proj/prisma/schema/readme.md': 'ignore me',
+		})
+		const result = await detectOrm(ROOT, reader)
+		expect(result.kind).toBe('linked')
+		if (result.kind !== 'linked') return
+		expect(result.link.orm).toBe('prisma')
+		expect(result.link.schemaFiles.map((f) => f.path).sort()).toEqual([
+			'/proj/prisma/schema/post.prisma',
+			'/proj/prisma/schema/user.prisma',
+		])
+	})
+
+	it('honors a package.json prisma.schema field', async function () {
+		const reader = makeReader({
+			'/proj/package.json': JSON.stringify({ prisma: { schema: 'db/custom.prisma' } }),
+			'/proj/db/custom.prisma': 'model User { id Int @id }',
+		})
+		const result = await detectOrm(ROOT, reader)
+		expect(result.kind).toBe('linked')
+		if (result.kind !== 'linked') return
+		expect(result.link.schemaFiles.map((f) => f.path)).toContain('/proj/db/custom.prisma')
+	})
+})
+
+describe('detectOrm — drizzle', function () {
+	it('reads the schema path out of drizzle.config.ts', async function () {
+		const reader = makeReader({
+			'/proj/drizzle.config.ts': "export default { schema: './src/db/schema.ts' }",
+			'/proj/src/db/schema.ts': "export const users = pgTable('users', {})",
+		})
+		const result = await detectOrm(ROOT, reader)
+		expect(result.kind).toBe('linked')
+		if (result.kind !== 'linked') return
+		expect(result.link.orm).toBe('drizzle')
+		expect(result.link.configPath).toBe('/proj/drizzle.config.ts')
+		expect(result.link.schemaFiles.map((f) => f.path)).toEqual(['/proj/src/db/schema.ts'])
+	})
+
+	it('expands a glob schema path into directory files', async function () {
+		const reader = makeReader({
+			'/proj/drizzle.config.ts': "export default { schema: './src/db/schema/*.ts' }",
+			'/proj/src/db/schema/users.ts': 'export const users = {}',
+			'/proj/src/db/schema/posts.ts': 'export const posts = {}',
+		})
+		const result = await detectOrm(ROOT, reader)
+		expect(result.kind).toBe('linked')
+		if (result.kind !== 'linked') return
+		expect(result.link.schemaFiles.map((f) => f.path).sort()).toEqual([
+			'/proj/src/db/schema/posts.ts',
+			'/proj/src/db/schema/users.ts',
+		])
+	})
+
+	it('falls back to common locations when there is no config', async function () {
+		const reader = makeReader({
+			'/proj/src/db/schema.ts': "export const users = pgTable('users', {})",
+		})
+		const result = await detectOrm(ROOT, reader)
+		expect(result.kind).toBe('linked')
+		if (result.kind !== 'linked') return
+		expect(result.link.orm).toBe('drizzle')
+		expect(result.link.configPath).toBeUndefined()
+		expect(result.link.schemaFiles.map((f) => f.path)).toEqual(['/proj/src/db/schema.ts'])
+	})
+})
+
+describe('detectOrm — ambiguous and empty', function () {
+	it('offers a choice when both ORMs are present', async function () {
+		const reader = makeReader({
+			'/proj/prisma/schema.prisma': 'model User { id Int @id }',
+			'/proj/drizzle.config.ts': "export default { schema: './src/db/schema.ts' }",
+			'/proj/src/db/schema.ts': "export const users = pgTable('users', {})",
+		})
+		const result = await detectOrm(ROOT, reader)
+		expect(result.kind).toBe('choice')
+		if (result.kind !== 'choice') return
+		expect(result.options.map((o) => o.orm).sort()).toEqual(['drizzle', 'prisma'])
+	})
+
+	it('reports none with guidance when neither ORM is found', async function () {
+		const reader = makeReader({ '/proj/README.md': 'hello' })
+		const result = await detectOrm(ROOT, reader)
+		expect(result.kind).toBe('none')
+		if (result.kind !== 'none') return
+		expect(result.message).toMatch(/Drizzle or Prisma/)
+	})
+})

--- a/__tests__/packages/studio/orm-cockpit/prisma/parse-prisma-schema.test.ts
+++ b/__tests__/packages/studio/orm-cockpit/prisma/parse-prisma-schema.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest'
+import { parsePrismaSchema } from '@studio/features/orm-cockpit/parsers/prisma/parse-prisma-schema'
+
+const SCHEMA = `
+datasource db {
+	provider = "postgresql"
+	url      = env("DATABASE_URL")
+}
+
+generator client {
+	provider = "prisma-client-js"
+}
+
+enum Role {
+	USER
+	ADMIN
+}
+
+model User {
+	id        Int      @id @default(autoincrement())
+	email     String   @unique @db.VarChar(255)
+	fullName  String?  @map("full_name")
+	role      Role     @default(USER)
+	createdAt DateTime @default(now()) @map("created_at")
+	bio       String?
+	posts     Post[]
+
+	@@map("users")
+}
+
+model Post {
+	id       Int     @id @default(autoincrement())
+	title    String
+	authorId Int     @map("author_id")
+	author   User    @relation(fields: [authorId], references: [id], onDelete: Cascade)
+
+	@@index([authorId])
+}
+
+model PostTag {
+	postId Int @map("post_id")
+	tagId  Int @map("tag_id")
+
+	@@id([postId, tagId])
+	@@ignore
+}
+
+model Weird {
+	id   Int   @id
+	data Whatsit
+}
+`
+
+describe('parsePrismaSchema', function () {
+	const { ir, warnings } = parsePrismaSchema(SCHEMA)
+
+	it('infers the dialect from the datasource provider', function () {
+		expect(ir.dialect).toBe('postgres')
+	})
+
+	it('sorts tables by their DB name and uses @@map names', function () {
+		// localeCompare ordering (matches the live mapper's byName sort).
+		expect(ir.tables.map(function (t) { return t.name })).toEqual([
+			'Post',
+			'PostTag',
+			'users',
+			'Weird',
+		])
+	})
+
+	it('maps scalar columns, honoring @map and @db native types', function () {
+		const users = ir.tables.find(function (t) { return t.name === 'users' })!
+		expect(users.schema).toBe('public')
+		expect(users.columns.map(function (c) { return c.name })).toEqual([
+			'bio',
+			'created_at',
+			'email',
+			'full_name',
+			'id',
+			'role',
+		])
+
+		const id = users.columns.find(function (c) { return c.name === 'id' })!
+		expect(id.type).toBe('int')
+		expect(id.autoIncrement).toBe(true)
+		expect(id.nullable).toBe(false)
+		expect(id.default).toBe(null)
+
+		const email = users.columns.find(function (c) { return c.name === 'email' })!
+		expect(email.type).toBe('varchar')
+
+		const created = users.columns.find(function (c) { return c.name === 'created_at' })!
+		expect(created.type).toBe('timestamp')
+		expect(created.default).toBe('now()')
+
+		const fullName = users.columns.find(function (c) { return c.name === 'full_name' })!
+		expect(fullName.nullable).toBe(true)
+	})
+
+	it('treats enum-typed fields as text and warns', function () {
+		const users = ir.tables.find(function (t) { return t.name === 'users' })!
+		const role = users.columns.find(function (c) { return c.name === 'role' })!
+		expect(role.type).toBe('text')
+		expect(role.default).toBe('USER')
+		expect(warnings.some(function (w) {
+			return w.includes('User.role') && w.includes('enum')
+		})).toBe(true)
+	})
+
+	it('does not emit a column for relation/virtual fields', function () {
+		const users = ir.tables.find(function (t) { return t.name === 'users' })!
+		expect(users.columns.some(function (c) { return c.name === 'posts' })).toBe(false)
+		const post = ir.tables.find(function (t) { return t.name === 'Post' })!
+		expect(post.columns.some(function (c) { return c.name === 'author' })).toBe(false)
+	})
+
+	it('records a single-column @unique as a unique index', function () {
+		const users = ir.tables.find(function (t) { return t.name === 'users' })!
+		const idx = users.indexes.find(function (i) { return i.columns.join(',') === 'email' })!
+		expect(idx).toBeTruthy()
+		expect(idx.unique).toBe(true)
+	})
+
+	it('resolves a relation @relation into a foreign key with @map column names', function () {
+		const post = ir.tables.find(function (t) { return t.name === 'Post' })!
+		expect(post.foreignKeys).toHaveLength(1)
+		const fk = post.foreignKeys[0]
+		expect(fk.columns).toEqual(['author_id'])
+		expect(fk.refTable).toBe('users')
+		expect(fk.refColumns).toEqual(['id'])
+		expect(fk.onDelete).toBe('Cascade')
+	})
+
+	it('records @@index referencing @map columns, preserving order', function () {
+		const post = ir.tables.find(function (t) { return t.name === 'Post' })!
+		const idx = post.indexes.find(function (i) { return !i.unique })!
+		expect(idx.columns).toEqual(['author_id'])
+	})
+
+	it('builds a composite primary key from @@id, in order, using DB names', function () {
+		const tag = ir.tables.find(function (t) { return t.name === 'PostTag' })!
+		expect(tag.primaryKey).toEqual(['post_id', 'tag_id'])
+	})
+
+	it('warns on an unmodeled block attribute (@@ignore) without throwing', function () {
+		expect(warnings.some(function (w) {
+			return w.includes('PostTag') && w.includes('@@ignore')
+		})).toBe(true)
+	})
+
+	it('maps an unrecognized field type to unknown and warns (conservative rule)', function () {
+		const weird = ir.tables.find(function (t) { return t.name === 'Weird' })!
+		const data = weird.columns.find(function (c) { return c.name === 'data' })!
+		expect(data.type).toBe('unknown')
+		expect(warnings.some(function (w) {
+			return w.includes('Weird.data') && w.includes('unknown')
+		})).toBe(true)
+	})
+
+	it('handles sqlite and mysql provider dialects', function () {
+		const sqlite = parsePrismaSchema('datasource db {\n\tprovider = "sqlite"\n}\nmodel A {\n\tid Int @id\n}\n')
+		expect(sqlite.ir.dialect).toBe('sqlite')
+		const mysql = parsePrismaSchema('datasource db {\n\tprovider = "mysql"\n}\nmodel A {\n\tid Int @id\n\tname String\n}\n')
+		expect(mysql.ir.dialect).toBe('mysql')
+		const a = mysql.ir.tables[0]
+		expect(a.columns.find(function (c) { return c.name === 'name' })!.type).toBe('varchar')
+		// SQLite reports no schema.
+		expect(sqlite.ir.tables[0].schema).toBeUndefined()
+	})
+})

--- a/apps/desktop/src-tauri/src/bindings.rs
+++ b/apps/desktop/src-tauri/src/bindings.rs
@@ -16,6 +16,9 @@ pub fn generate_bindings() -> Builder<tauri::Wry> {
         window_commands::open_file,
         window_commands::open_data_files,
         window_commands::probe_database_file,
+        window_commands::pick_folder,
+        window_commands::read_project_file,
+        window_commands::list_dir,
         // Database commands
         db_commands::add_connection,
         db_commands::update_connection,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -301,6 +301,9 @@ pub fn run() {
             window::commands::open_file,
             window::commands::open_data_files,
             window::commands::probe_database_file,
+            window::commands::pick_folder,
+            window::commands::read_project_file,
+            window::commands::list_dir,
             // Commands system
             commands_system::get_all_commands,
             commands_system::get_command,

--- a/apps/desktop/src-tauri/src/window/commands.rs
+++ b/apps/desktop/src-tauri/src/window/commands.rs
@@ -130,6 +130,71 @@ pub async fn probe_database_file(path: String) -> Result<DatabaseFileKind, Error
     Ok(probe_database_file_header(&header[..read]))
 }
 
+/// Open a folder picker and return the chosen directory path. Used by the ORM
+/// cockpit to let the user link a project folder.
+#[tauri::command]
+#[specta::specta]
+pub async fn pick_folder(app: tauri::AppHandle) -> Result<Option<String>, Error> {
+    let chosen = run_dialog(app, || {
+        AsyncFileDialog::new()
+            .set_title("Select a project folder")
+            .pick_folder()
+    })
+    .await?
+    .map(|folder| folder.path().to_string_lossy().to_string());
+
+    Ok(chosen)
+}
+
+/// Largest project file we'll read into memory for schema parsing. A
+/// mistargeted path (e.g. a build artifact) shouldn't load something huge.
+const MAX_PROJECT_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Read a project schema/config file (Drizzle `.ts`, Prisma `.prisma`, …) as
+/// UTF-8 text, size-capped. Feeds the ORM detection + parsers.
+#[tauri::command]
+#[specta::specta]
+pub async fn read_project_file(path: String) -> Result<String, Error> {
+    let metadata = tokio::fs::metadata(&path)
+        .await
+        .with_context(|| format!("Failed to stat file: {path}"))?;
+    if !metadata.is_file() {
+        return Err(Error::Any(anyhow::anyhow!("Not a file: {path}")));
+    }
+    if metadata.len() > MAX_PROJECT_FILE_BYTES {
+        return Err(Error::Any(anyhow::anyhow!(
+            "File too large to read ({} bytes): {path}",
+            metadata.len()
+        )));
+    }
+    tokio::fs::read_to_string(&path)
+        .await
+        .with_context(|| format!("Failed to read file: {path}"))
+        .map_err(Error::from)
+}
+
+/// Shallowly list a directory's entries as absolute paths. ORM detection in TS
+/// filters these by extension / known names (e.g. a multi-file Drizzle
+/// `schema/` dir or Prisma `prisma/schema/` dir).
+#[tauri::command]
+#[specta::specta]
+pub async fn list_dir(path: String) -> Result<Vec<String>, Error> {
+    let mut entries = tokio::fs::read_dir(&path)
+        .await
+        .with_context(|| format!("Failed to read directory: {path}"))?;
+
+    let mut paths = Vec::new();
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .with_context(|| format!("Failed to read directory entry in: {path}"))?
+    {
+        paths.push(entry.path().to_string_lossy().to_string());
+    }
+
+    Ok(paths)
+}
+
 async fn run_dialog<F, Fut, T>(app: tauri::AppHandle, make_future: F) -> Result<Option<T>, Error>
 where
     F: FnOnce() -> Fut + Send + 'static,

--- a/apps/desktop/src/lib/bindings.ts
+++ b/apps/desktop/src/lib/bindings.ts
@@ -79,6 +79,43 @@ async probeDatabaseFile(path: string) : Promise<Result<DatabaseFileKind, { kind:
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Open a folder picker and return the chosen directory path. Used by the ORM
+ * cockpit to let the user link a project folder.
+ */
+async pickFolder() : Promise<Result<string | null, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("pick_folder") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Read a project schema/config file (Drizzle `.ts`, Prisma `.prisma`, …) as
+ * UTF-8 text, size-capped. Feeds the ORM detection + parsers.
+ */
+async readProjectFile(path: string) : Promise<Result<string, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("read_project_file", { path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Shallowly list a directory's entries as absolute paths. ORM detection in TS
+ * filters these by extension / known names (e.g. a multi-file Drizzle
+ * `schema/` dir or Prisma `prisma/schema/` dir).
+ */
+async listDir(path: string) : Promise<Result<string[], { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_dir", { path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async addConnection(name: string, databaseInfo: DatabaseInfo, color: number | null) : Promise<Result<ConnectionInfo, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("add_connection", { name, databaseInfo, color }) };

--- a/packages/studio/src/features/orm-cockpit/diff/diff-schema.ts
+++ b/packages/studio/src/features/orm-cockpit/diff/diff-schema.ts
@@ -1,0 +1,399 @@
+/**
+ * diffSchema — pure structural diff between two normalized SchemaIRs.
+ *
+ * Direction: `from` = current/live schema, `to` = desired/code schema. A
+ * table/column present in `to` but not `from` is `added` (needs CREATE / ALTER
+ * ADD); present in `from` but not `to` is `removed` (DROP).
+ *
+ * The IRs are already normalized and sorted by name, so matching is by name
+ * (and for FKs by columns + refTable). The output is confidence-aware: every
+ * change is tagged safe / review / destructive, and a table's confidence is the
+ * worst of its children.
+ */
+
+import type {
+	ColumnIR,
+	ForeignKeyIR,
+	IndexIR,
+	NormalizedType,
+	SchemaIR,
+	TableIR,
+} from '@studio/features/orm-cockpit/ir/types'
+import type {
+	Change,
+	ColumnDiff,
+	Confidence,
+	SchemaDiff,
+	TableDiff,
+} from './types'
+
+const CONFIDENCE_RANK: Record<Confidence, number> = {
+	safe: 0,
+	review: 1,
+	destructive: 2,
+}
+
+function worst(a: Confidence, b: Confidence): Confidence {
+	return CONFIDENCE_RANK[a] >= CONFIDENCE_RANK[b] ? a : b
+}
+
+function worstOf(values: Confidence[]): Confidence {
+	return values.reduce<Confidence>((acc, c) => worst(acc, c), 'safe')
+}
+
+/**
+ * Numeric width ordering for lossy/narrowing detection. A move to a strictly
+ * smaller capacity is narrowing (destructive); a move to a larger one is a
+ * widening (safe-ish, but we still flag any type change as at least review
+ * because dialect coercion is not guaranteed lossless).
+ */
+const NUMERIC_RANK: Partial<Record<NormalizedType, number>> = {
+	smallint: 1,
+	int: 2,
+	bigint: 3,
+	float: 4,
+	double: 5,
+	decimal: 6,
+}
+
+function byName<T extends { name: string }>(items: T[]): Map<string, T> {
+	const map = new Map<string, T>()
+	for (const item of items) {
+		map.set(item.name, item)
+	}
+	return map
+}
+
+function fkKey(fk: ForeignKeyIR): string {
+	return `${fk.refTable}::${fk.columns.join(',')}`
+}
+
+function indexesEqual(a: IndexIR, b: IndexIR): boolean {
+	return (
+		a.unique === b.unique &&
+		a.columns.length === b.columns.length &&
+		a.columns.every(function compare(col, i) {
+			return col === b.columns[i]
+		})
+	)
+}
+
+function fksEqual(a: ForeignKeyIR, b: ForeignKeyIR): boolean {
+	return (
+		a.refTable === b.refTable &&
+		(a.onDelete ?? null) === (b.onDelete ?? null) &&
+		(a.onUpdate ?? null) === (b.onUpdate ?? null) &&
+		a.columns.length === b.columns.length &&
+		a.columns.every(function compareCol(col, i) {
+			return col === b.columns[i]
+		}) &&
+		a.refColumns.length === b.refColumns.length &&
+		a.refColumns.every(function compareRef(col, i) {
+			return col === b.refColumns[i]
+		})
+	)
+}
+
+/**
+ * Classify a type change between two columns. Returns the confidence the change
+ * contributes (only called when `type` is in changedFields, i.e. the change is
+ * real — either normalized types differ, or one side is `unknown` with a
+ * differing rawType).
+ */
+function classifyTypeChange(before: ColumnIR, after: ColumnIR): Confidence {
+	// Either side unknown: we cannot reason about loss, so never confident.
+	if (before.type === 'unknown' || after.type === 'unknown') {
+		return 'review'
+	}
+
+	const fromRank = NUMERIC_RANK[before.type]
+	const toRank = NUMERIC_RANK[after.type]
+
+	// Narrowing within the numeric family loses data → destructive.
+	if (fromRank !== undefined && toRank !== undefined) {
+		return toRank < fromRank ? 'destructive' : 'review'
+	}
+
+	// Any other normalized type change (e.g. text→int, timestamp→date) is at
+	// best a possibly-lossy coercion. Treat as review; the migration layer can
+	// refine. (We do not claim destructive here without a known narrowing.)
+	return 'review'
+}
+
+function diffColumn(before: ColumnIR | undefined, after: ColumnIR | undefined): ColumnDiff {
+	if (before === undefined && after !== undefined) {
+		// Added column: nullable or with default = safe; NOT NULL without
+		// default = destructive (existing rows can't satisfy it).
+		const isSafe = after.nullable || after.default !== null
+		return {
+			name: after.name,
+			kind: 'added',
+			after,
+			confidence: isSafe ? 'safe' : 'destructive',
+		}
+	}
+
+	if (before !== undefined && after === undefined) {
+		// Dropping a column always risks data loss.
+		return {
+			name: before.name,
+			kind: 'removed',
+			before,
+			confidence: 'destructive',
+		}
+	}
+
+	// Both present → compare fields.
+	const b = before as ColumnIR
+	const a = after as ColumnIR
+	const changedFields: Array<'type' | 'nullable' | 'default' | 'autoIncrement'> = []
+	const confidences: Confidence[] = []
+
+	// Type. Normalized equality is authoritative EXCEPT when either side is
+	// unknown: never treat unknown as equal if rawTypes differ textually.
+	const typesDiffer =
+		b.type !== a.type ||
+		((b.type === 'unknown' || a.type === 'unknown') && b.rawType !== a.rawType)
+	if (typesDiffer) {
+		changedFields.push('type')
+		confidences.push(classifyTypeChange(b, a))
+	}
+
+	// Nullable. nullable→NOT NULL can fail on existing NULL rows → review.
+	// NOT NULL→nullable is a relaxation → safe.
+	if (b.nullable !== a.nullable) {
+		changedFields.push('nullable')
+		confidences.push(a.nullable ? 'safe' : 'review')
+	}
+
+	// Default. A pure default tweak is review (intent / existing-row ambiguity).
+	if (b.default !== a.default) {
+		changedFields.push('default')
+		confidences.push('review')
+	}
+
+	// Auto-increment toggles are sequence/identity reshapes → review.
+	if (b.autoIncrement !== a.autoIncrement) {
+		changedFields.push('autoIncrement')
+		confidences.push('review')
+	}
+
+	return {
+		name: a.name,
+		kind: 'changed',
+		before: b,
+		after: a,
+		changedFields,
+		confidence: worstOf(confidences),
+	}
+}
+
+function sortColumnDiffs(diffs: ColumnDiff[]): ColumnDiff[] {
+	return diffs.sort(function byColName(x, y) {
+		return x.name < y.name ? -1 : x.name > y.name ? 1 : 0
+	})
+}
+
+function diffColumns(from: ColumnIR[], to: ColumnIR[]): ColumnDiff[] {
+	const fromMap = byName(from)
+	const toMap = byName(to)
+	const names = new Set<string>([...fromMap.keys(), ...toMap.keys()])
+	const out: ColumnDiff[] = []
+
+	for (const name of names) {
+		const b = fromMap.get(name)
+		const a = toMap.get(name)
+		if (b !== undefined && a !== undefined && columnsIdentical(b, a)) {
+			continue
+		}
+		out.push(diffColumn(b, a))
+	}
+
+	return sortColumnDiffs(out)
+}
+
+function columnsIdentical(b: ColumnIR, a: ColumnIR): boolean {
+	if (b.type === 'unknown' || a.type === 'unknown') {
+		// Unknown is only identical when rawTypes match textually too.
+		if (b.rawType !== a.rawType) {
+			return false
+		}
+	}
+	return (
+		b.type === a.type &&
+		b.nullable === a.nullable &&
+		b.default === a.default &&
+		b.autoIncrement === a.autoIncrement
+	)
+}
+
+function diffIndexes(from: IndexIR[], to: IndexIR[]): Change<IndexIR>[] {
+	const fromMap = byName(from)
+	const toMap = byName(to)
+	const names = new Set<string>([...fromMap.keys(), ...toMap.keys()])
+	const out: Change<IndexIR>[] = []
+
+	for (const name of names) {
+		const b = fromMap.get(name)
+		const a = toMap.get(name)
+		if (b !== undefined && a !== undefined) {
+			if (!indexesEqual(b, a)) {
+				out.push({ kind: 'changed', before: b, after: a })
+			}
+		} else if (a !== undefined) {
+			out.push({ kind: 'added', after: a })
+		} else if (b !== undefined) {
+			out.push({ kind: 'removed', before: b })
+		}
+	}
+
+	return out
+}
+
+function diffForeignKeys(from: ForeignKeyIR[], to: ForeignKeyIR[]): Change<ForeignKeyIR>[] {
+	const fromMap = new Map<string, ForeignKeyIR>()
+	for (const fk of from) {
+		fromMap.set(fkKey(fk), fk)
+	}
+	const toMap = new Map<string, ForeignKeyIR>()
+	for (const fk of to) {
+		toMap.set(fkKey(fk), fk)
+	}
+	const keys = new Set<string>([...fromMap.keys(), ...toMap.keys()])
+	const out: Change<ForeignKeyIR>[] = []
+
+	for (const key of keys) {
+		const b = fromMap.get(key)
+		const a = toMap.get(key)
+		if (b !== undefined && a !== undefined) {
+			if (!fksEqual(b, a)) {
+				out.push({ kind: 'changed', before: b, after: a })
+			}
+		} else if (a !== undefined) {
+			out.push({ kind: 'added', after: a })
+		} else if (b !== undefined) {
+			out.push({ kind: 'removed', before: b })
+		}
+	}
+
+	return out
+}
+
+/**
+ * Confidence of an index change: adding is safe; removing or changing risks
+ * losing a uniqueness guarantee / query path → review (dropping an index does
+ * not lose row data, so not destructive).
+ */
+function indexConfidence(change: Change<IndexIR>): Confidence {
+	return change.kind === 'added' ? 'safe' : 'review'
+}
+
+/**
+ * Confidence of an FK change: adding/changing a constraint can reject existing
+ * rows; removing relaxes. All are review (no row data is lost).
+ */
+function fkConfidence(_change: Change<ForeignKeyIR>): Confidence {
+	return 'review'
+}
+
+function diffTable(before: TableIR | undefined, after: TableIR | undefined): TableDiff {
+	if (before === undefined && after !== undefined) {
+		// Whole table added → CREATE TABLE is safe. We still surface its columns
+		// (all as 'added') for downstream rendering, but the table verdict is safe.
+		const columns = sortColumnDiffs(
+			after.columns.map(function asAdded(col) {
+				return diffColumn(undefined, col)
+			}),
+		)
+		const indexes: Change<IndexIR>[] = after.indexes.map(function asAdded(idx) {
+			return { kind: 'added', after: idx }
+		})
+		const foreignKeys: Change<ForeignKeyIR>[] = after.foreignKeys.map(function asAdded(fk) {
+			return { kind: 'added', after: fk }
+		})
+		return {
+			name: after.name,
+			kind: 'added',
+			columns,
+			indexes,
+			foreignKeys,
+			confidence: 'safe',
+		}
+	}
+
+	if (before !== undefined && after === undefined) {
+		// Whole table dropped → destructive regardless of children.
+		const columns = sortColumnDiffs(
+			before.columns.map(function asRemoved(col) {
+				return diffColumn(col, undefined)
+			}),
+		)
+		const indexes: Change<IndexIR>[] = before.indexes.map(function asRemoved(idx) {
+			return { kind: 'removed', before: idx }
+		})
+		const foreignKeys: Change<ForeignKeyIR>[] = before.foreignKeys.map(function asRemoved(fk) {
+			return { kind: 'removed', before: fk }
+		})
+		return {
+			name: before.name,
+			kind: 'removed',
+			columns,
+			indexes,
+			foreignKeys,
+			confidence: 'destructive',
+		}
+	}
+
+	const b = before as TableIR
+	const a = after as TableIR
+	const columns = diffColumns(b.columns, a.columns)
+	const indexes = diffIndexes(b.indexes, a.indexes)
+	const foreignKeys = diffForeignKeys(b.foreignKeys, a.foreignKeys)
+
+	const confidences: Confidence[] = [
+		...columns.map(function pick(c) {
+			return c.confidence
+		}),
+		...indexes.map(indexConfidence),
+		...foreignKeys.map(fkConfidence),
+	]
+
+	return {
+		name: a.name,
+		kind: 'changed',
+		columns,
+		indexes,
+		foreignKeys,
+		confidence: worstOf(confidences),
+	}
+}
+
+function tableHasChanges(diff: TableDiff): boolean {
+	if (diff.kind !== 'changed') {
+		return true
+	}
+	return diff.columns.length > 0 || diff.indexes.length > 0 || diff.foreignKeys.length > 0
+}
+
+export function diffSchema(from: SchemaIR, to: SchemaIR): SchemaDiff {
+	const fromMap = byName(from.tables)
+	const toMap = byName(to.tables)
+	const names = new Set<string>([...fromMap.keys(), ...toMap.keys()])
+
+	const tables: TableDiff[] = []
+	for (const name of names) {
+		const diff = diffTable(fromMap.get(name), toMap.get(name))
+		if (tableHasChanges(diff)) {
+			tables.push(diff)
+		}
+	}
+
+	tables.sort(function byTableName(x, y) {
+		return x.name < y.name ? -1 : x.name > y.name ? 1 : 0
+	})
+
+	return {
+		tables,
+		hasChanges: tables.length > 0,
+	}
+}

--- a/packages/studio/src/features/orm-cockpit/diff/types.ts
+++ b/packages/studio/src/features/orm-cockpit/diff/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Schema diff result types — the FROZEN contract Wave C (migration gen) and
+ * Wave D (cockpit UI) import. Produced by `diffSchema(from, to)` where
+ * `from` = current/live schema and `to` = desired/code schema.
+ *
+ * Every change carries a `Confidence` so downstream consumers can surface
+ * safe/review/destructive operations differently (e.g. require confirmation
+ * before applying a destructive migration). Do not redefine these shapes
+ * downstream — import them from here.
+ */
+
+import type { ColumnIR, ForeignKeyIR, IndexIR } from '@studio/features/orm-cockpit/ir/types'
+
+/**
+ * How risky applying a change is.
+ * - `safe`       : non-lossy, reversible-ish (add table, add nullable column, add index).
+ * - `review`     : intent unclear or possibly lossy (unknown types, default tweaks, lossy type change).
+ * - `destructive`: data loss possible (drop table/column, narrowing, add NOT NULL without default).
+ */
+export type Confidence = 'safe' | 'review' | 'destructive'
+
+export type Change<T> = {
+	kind: 'added' | 'removed' | 'changed'
+	before?: T
+	after?: T
+}
+
+export type ColumnDiff = {
+	name: string
+	kind: 'added' | 'removed' | 'changed'
+	before?: ColumnIR
+	after?: ColumnIR
+	changedFields?: Array<'type' | 'nullable' | 'default' | 'autoIncrement'>
+	confidence: Confidence
+}
+
+export type TableDiff = {
+	name: string
+	kind: 'added' | 'removed' | 'changed'
+	columns: ColumnDiff[]
+	indexes: Change<IndexIR>[]
+	foreignKeys: Change<ForeignKeyIR>[]
+	confidence: Confidence
+}
+
+export type SchemaDiff = {
+	tables: TableDiff[]
+	hasChanges: boolean
+}

--- a/packages/studio/src/features/orm-cockpit/link/detect-orm.ts
+++ b/packages/studio/src/features/orm-cockpit/link/detect-orm.ts
@@ -1,0 +1,238 @@
+/**
+ * Project folder linking + ORM detection. Given a linked folder, work out
+ * whether it's a Drizzle or Prisma project and locate the schema file(s) so the
+ * parsers (plans 02/03) can turn them into a SchemaIR.
+ *
+ * Detection is a pure function over an injected {@link ProjectReader} so it can
+ * be unit-tested with fixture folders; the Tauri-backed reader lives in
+ * `link-api.ts`. Everything degrades gracefully — a missing/unreadable path
+ * just yields fewer files, never a throw.
+ */
+
+export type SchemaFile = { path: string; text: string }
+
+export type DetectedOrm = 'drizzle' | 'prisma'
+
+export type OrmLink = {
+	orm: DetectedOrm
+	schemaFiles: SchemaFile[]
+	/** The drizzle.config.* path, when detection went through it. */
+	configPath?: string
+}
+
+export type DetectOrmResult =
+	| { kind: 'linked'; link: OrmLink }
+	| { kind: 'choice'; options: OrmLink[] }
+	| { kind: 'none'; message: string }
+
+/**
+ * Reads the linked project. `readFile` returns null when the path is missing or
+ * unreadable; `listDir` returns absolute entry paths (shallow) or [].
+ */
+export type ProjectReader = {
+	readFile(path: string): Promise<string | null>
+	listDir(path: string): Promise<string[]>
+}
+
+const DRIZZLE_CONFIG_NAMES = [
+	'drizzle.config.ts',
+	'drizzle.config.js',
+	'drizzle.config.mjs',
+	'drizzle.config.cjs',
+]
+
+// Best-effort fallbacks when there's no config or its schema path doesn't resolve.
+const DRIZZLE_FALLBACK_FILES = ['src/db/schema.ts', 'src/schema.ts', 'db/schema.ts']
+const DRIZZLE_FALLBACK_DIRS = ['src/db/schema', 'db/schema', 'src/schema']
+
+const PRISMA_FILES = ['prisma/schema.prisma', 'schema.prisma']
+const PRISMA_SCHEMA_DIR = 'prisma/schema'
+
+export async function detectOrm(folder: string, reader: ProjectReader): Promise<DetectOrmResult> {
+	const [drizzle, prisma] = await Promise.all([
+		detectDrizzle(folder, reader),
+		detectPrisma(folder, reader),
+	])
+
+	if (drizzle && prisma) {
+		return { kind: 'choice', options: [drizzle, prisma] }
+	}
+	if (drizzle) {
+		return { kind: 'linked', link: drizzle }
+	}
+	if (prisma) {
+		return { kind: 'linked', link: prisma }
+	}
+	return {
+		kind: 'none',
+		message:
+			'No Drizzle or Prisma schema found in this folder. Expected a drizzle.config.* with a schema file, or a prisma/schema.prisma.',
+	}
+}
+
+async function detectDrizzle(folder: string, reader: ProjectReader): Promise<OrmLink | null> {
+	let configPath: string | undefined
+	let configText: string | null = null
+	for (const name of DRIZZLE_CONFIG_NAMES) {
+		const candidate = joinPath(folder, name)
+		const text = await reader.readFile(candidate)
+		if (text !== null) {
+			configPath = candidate
+			configText = text
+			break
+		}
+	}
+
+	const collected = new FileSet()
+
+	if (configText !== null) {
+		for (const entry of extractDrizzleSchemaEntries(configText)) {
+			collected.addAll(await readSchemaPath(folder, entry, reader, '.ts'))
+		}
+	}
+
+	if (collected.isEmpty()) {
+		for (const rel of DRIZZLE_FALLBACK_FILES) {
+			collected.addAll(await readSchemaPath(folder, rel, reader, '.ts'))
+		}
+		for (const dir of DRIZZLE_FALLBACK_DIRS) {
+			collected.addAll(await readFilesInDir(joinPath(folder, dir), reader, '.ts'))
+		}
+	}
+
+	// A config alone is enough to call it Drizzle (UI can ask for the file);
+	// otherwise we need at least one schema file.
+	if (configPath === undefined && collected.isEmpty()) {
+		return null
+	}
+	return { orm: 'drizzle', schemaFiles: collected.values(), configPath }
+}
+
+async function detectPrisma(folder: string, reader: ProjectReader): Promise<OrmLink | null> {
+	const collected = new FileSet()
+
+	for (const rel of PRISMA_FILES) {
+		collected.addAll(await readSchemaPath(folder, rel, reader, '.prisma'))
+	}
+
+	const pkgText = await reader.readFile(joinPath(folder, 'package.json'))
+	if (pkgText !== null) {
+		const schemaField = readPrismaSchemaField(pkgText)
+		if (schemaField !== null) {
+			collected.addAll(await readSchemaPath(folder, schemaField, reader, '.prisma'))
+		}
+	}
+
+	// Newer Prisma supports a multi-file `prisma/schema/` directory.
+	collected.addAll(await readFilesInDir(joinPath(folder, PRISMA_SCHEMA_DIR), reader, '.prisma'))
+
+	if (collected.isEmpty()) {
+		return null
+	}
+	return { orm: 'prisma', schemaFiles: collected.values() }
+}
+
+/**
+ * Resolve a single schema entry (file path, glob, or directory) into files. A
+ * `*` glob reads the matching extension in its directory; a plain path is tried
+ * as a file first, then as a directory.
+ */
+async function readSchemaPath(
+	folder: string,
+	entry: string,
+	reader: ProjectReader,
+	ext: string
+): Promise<SchemaFile[]> {
+	if (entry.includes('*')) {
+		return readFilesInDir(joinPath(folder, globDir(entry)), reader, ext)
+	}
+
+	const abs = joinPath(folder, entry)
+	const text = await reader.readFile(abs)
+	if (text !== null) {
+		return [{ path: abs, text }]
+	}
+	// Not a file — it may be a directory of schema files.
+	return readFilesInDir(abs, reader, ext)
+}
+
+async function readFilesInDir(
+	dir: string,
+	reader: ProjectReader,
+	ext: string
+): Promise<SchemaFile[]> {
+	const entries = await reader.listDir(dir)
+	const files: SchemaFile[] = []
+	for (const path of entries) {
+		if (!path.toLowerCase().endsWith(ext)) {
+			continue
+		}
+		const text = await reader.readFile(path)
+		if (text !== null) {
+			files.push({ path, text })
+		}
+	}
+	return files
+}
+
+function extractDrizzleSchemaEntries(configText: string): string[] {
+	// Best-effort static read of `schema: '...'` or `schema: ['...', '...']`.
+	// A computed/dynamic value won't match — callers fall back to common paths.
+	const match = configText.match(/schema\s*:\s*(\[[^\]]*\]|["'`][^"'`]+["'`])/)
+	if (!match) {
+		return []
+	}
+	const raw = match[1]
+	if (raw.startsWith('[')) {
+		return Array.from(raw.matchAll(/["'`]([^"'`]+)["'`]/g)).map(function (m) {
+			return m[1]
+		})
+	}
+	return [raw.slice(1, -1)]
+}
+
+function readPrismaSchemaField(pkgText: string): string | null {
+	try {
+		const pkg = JSON.parse(pkgText) as { prisma?: { schema?: unknown } }
+		const schema = pkg.prisma?.schema
+		return typeof schema === 'string' ? schema : null
+	} catch {
+		return null
+	}
+}
+
+function joinPath(base: string, rel: string): string {
+	const cleanBase = base.replace(/\/+$/, '')
+	const cleanRel = rel.replace(/^\.\//, '').replace(/^\/+/, '')
+	return `${cleanBase}/${cleanRel}`
+}
+
+function globDir(entry: string): string {
+	const star = entry.indexOf('*')
+	const prefix = entry.slice(0, star)
+	const slash = prefix.lastIndexOf('/')
+	return slash >= 0 ? prefix.slice(0, slash) : '.'
+}
+
+/** De-duplicating ordered set of schema files keyed by path. */
+class FileSet {
+	private readonly seen = new Set<string>()
+	private readonly files: SchemaFile[] = []
+
+	addAll(items: SchemaFile[]): void {
+		for (const item of items) {
+			if (!this.seen.has(item.path)) {
+				this.seen.add(item.path)
+				this.files.push(item)
+			}
+		}
+	}
+
+	isEmpty(): boolean {
+		return this.files.length === 0
+	}
+
+	values(): SchemaFile[] {
+		return this.files
+	}
+}

--- a/packages/studio/src/features/orm-cockpit/link/link-api.ts
+++ b/packages/studio/src/features/orm-cockpit/link/link-api.ts
@@ -1,0 +1,61 @@
+import { commands } from '@studio/lib/bindings'
+import {
+	detectOrm,
+	type DetectOrmResult,
+	type ProjectReader,
+} from '@studio/features/orm-cockpit/link/detect-orm'
+
+/**
+ * Tauri-backed wrappers over the `pick_folder` / `read_project_file` /
+ * `list_dir` commands, plus a convenience that picks a folder and detects its
+ * ORM in one call. The pure detection lives in `detect-orm.ts`.
+ */
+
+/** Open the folder picker. Returns null if the user cancels. */
+export async function pickProjectFolder(): Promise<string | null> {
+	try {
+		const result = await commands.pickFolder()
+		return result.status === 'ok' ? result.data : null
+	} catch {
+		return null
+	}
+}
+
+/** A {@link ProjectReader} backed by the Rust fs commands. */
+export function createTauriProjectReader(): ProjectReader {
+	return {
+		async readFile(path: string): Promise<string | null> {
+			try {
+				const result = await commands.readProjectFile(path)
+				return result.status === 'ok' ? result.data : null
+			} catch {
+				return null
+			}
+		},
+		async listDir(path: string): Promise<string[]> {
+			try {
+				const result = await commands.listDir(path)
+				return result.status === 'ok' ? result.data : []
+			} catch {
+				return []
+			}
+		},
+	}
+}
+
+/** Detect the ORM in an already-chosen folder using the live fs. */
+export async function detectProjectOrm(folder: string): Promise<DetectOrmResult> {
+	return detectOrm(folder, createTauriProjectReader())
+}
+
+/**
+ * Full flow for the cockpit: pick a folder, then detect. Returns null only when
+ * the user cancels the picker.
+ */
+export async function linkProject(): Promise<{ folder: string; result: DetectOrmResult } | null> {
+	const folder = await pickProjectFolder()
+	if (folder === null) {
+		return null
+	}
+	return { folder, result: await detectProjectOrm(folder) }
+}

--- a/packages/studio/src/features/orm-cockpit/parsers/drizzle/parse-drizzle-schema.ts
+++ b/packages/studio/src/features/orm-cockpit/parsers/drizzle/parse-drizzle-schema.ts
@@ -1,0 +1,820 @@
+import ts from 'typescript'
+import { normalizeDbType } from '@studio/features/orm-cockpit/ir/normalize-type'
+import type {
+	ColumnIR,
+	Dialect,
+	ForeignKeyIR,
+	IndexIR,
+	NormalizedType,
+	SchemaIR,
+	TableIR,
+} from '@studio/features/orm-cockpit/ir/types'
+
+/**
+ * Statically parse a project's Drizzle schema file(s) into the frozen
+ * {@link SchemaIR} so it can be diffed against the live DB.
+ *
+ * STATIC ONLY — we walk the TypeScript AST (`ts.createSourceFile`) and never
+ * execute user code. We recognize the common 80% of Drizzle idioms
+ * (`pgTable`/`sqliteTable`/`mysqlTable` with column builders + a table-level
+ * config callback) and degrade gracefully on the rest: anything unrecognized
+ * pushes a human-readable note to `warnings` and marks the affected
+ * column type/default `'unknown'`. A parse error in one table never kills the
+ * file — each table is parsed defensively.
+ *
+ * Output shape/sorting mirrors the live mapper (`from-live-schema.ts`): tables,
+ * columns, indexes and foreign keys are sorted by name; primary-key and index
+ * column ORDER is preserved.
+ *
+ * Known limitations (surfaced as warnings, not failures):
+ *   - barrel/re-export files (`export * from './x'`) — only declarations in the
+ *     given files are seen; re-exported tables defined elsewhere are missed.
+ *   - helper-wrapped table factories (`export const x = makeTable(...)`) — the
+ *     call must be a direct `pgTable(...)`/`sqliteTable(...)`/`mysqlTable(...)`.
+ */
+export function parseDrizzleSchema(
+	files: { path: string; text: string }[],
+	dialect: Dialect
+): { ir: SchemaIR; warnings: string[] } {
+	const warnings: string[] = []
+	const tables: TableIR[] = []
+
+	for (const file of files) {
+		try {
+			parseFile(file, dialect, tables, warnings)
+		} catch (error) {
+			warnings.push(`${file.path}: failed to parse file (${describeError(error)})`)
+		}
+	}
+
+	tables.sort(byName)
+	return { ir: { dialect, tables }, warnings }
+}
+
+const DIALECT_BUILDERS: Record<string, Dialect> = {
+	pgTable: 'postgres',
+	sqliteTable: 'sqlite',
+	mysqlTable: 'mysql',
+}
+
+function parseFile(
+	file: { path: string; text: string },
+	argDialect: Dialect,
+	out: TableIR[],
+	warnings: string[]
+): void {
+	const source = ts.createSourceFile(
+		file.path,
+		file.text,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS
+	)
+
+	let sawReExport = false
+
+	source.forEachChild(function (node) {
+		if (ts.isExportDeclaration(node) && node.moduleSpecifier && !node.exportClause) {
+			sawReExport = true
+			return
+		}
+
+		const found = findTableDeclaration(node)
+		if (!found) {
+			return
+		}
+
+		const builder = found.builderName
+		const tableDialect = DIALECT_BUILDERS[builder]
+		if (!tableDialect) {
+			return
+		}
+
+		if (tableDialect !== argDialect) {
+			warnings.push(
+				`${file.path}: table "${found.varName}" uses ${builder} (${tableDialect}) but the requested dialect was ${argDialect}; parsing it as ${tableDialect}`
+			)
+		}
+
+		try {
+			const table = parseTable(found.call, tableDialect, file.path, warnings)
+			if (table) {
+				out.push(table)
+			}
+		} catch (error) {
+			warnings.push(
+				`${file.path}: failed to parse table "${found.varName}" (${describeError(error)})`
+			)
+		}
+	})
+
+	if (sawReExport) {
+		warnings.push(
+			`${file.path}: re-export (\`export ... from\`) detected; tables defined in other modules are not followed — pass those files in directly`
+		)
+	}
+}
+
+type TFound = { varName: string; builderName: string; call: ts.CallExpression }
+
+/**
+ * Match `export const X = pgTable(...)` (or a plain `const X = pgTable(...)`)
+ * and return the call plus the builder identifier name.
+ */
+function findTableDeclaration(node: ts.Node): TFound | null {
+	if (!ts.isVariableStatement(node)) {
+		return null
+	}
+	for (const decl of node.declarationList.declarations) {
+		if (!decl.initializer || !ts.isCallExpression(decl.initializer)) {
+			continue
+		}
+		const callee = decl.initializer.expression
+		if (!ts.isIdentifier(callee)) {
+			continue
+		}
+		if (!DIALECT_BUILDERS[callee.text]) {
+			continue
+		}
+		const varName = ts.isIdentifier(decl.name) ? decl.name.text : '<anonymous>'
+		return { varName, builderName: callee.text, call: decl.initializer }
+	}
+	return null
+}
+
+function parseTable(
+	call: ts.CallExpression,
+	dialect: Dialect,
+	filePath: string,
+	warnings: string[]
+): TableIR | null {
+	const args = call.arguments
+	if (args.length < 2) {
+		warnings.push(`${filePath}: a table call had too few arguments; skipped`)
+		return null
+	}
+
+	const nameArg = args[0]
+	const tableName = literalString(nameArg)
+	if (tableName === null) {
+		warnings.push(`${filePath}: a table name was not a string literal; skipped`)
+		return null
+	}
+
+	const columnsArg = args[1]
+	if (!ts.isObjectLiteralExpression(columnsArg)) {
+		warnings.push(`${filePath}: table "${tableName}" columns argument was not an object literal; skipped`)
+		return null
+	}
+
+	const columns: ColumnIR[] = []
+	// Map of JS property key -> DB column name, for resolving FK/index refs.
+	const propToDbName = new Map<string, string>()
+	const primaryKey: string[] = []
+	const indexes: IndexIR[] = []
+	const foreignKeys: ForeignKeyIR[] = []
+
+	for (const prop of columnsArg.properties) {
+		if (!ts.isPropertyAssignment(prop)) {
+			warnings.push(`${filePath}: table "${tableName}" has a non-standard column property; skipped`)
+			continue
+		}
+		const propKey = propertyName(prop.name)
+		if (propKey === null) {
+			warnings.push(`${filePath}: table "${tableName}" has a column with a computed key; skipped`)
+			continue
+		}
+		if (!ts.isCallExpression(prop.initializer)) {
+			warnings.push(
+				`${filePath}: table "${tableName}".${propKey} is not a column builder call; type set to unknown`
+			)
+			continue
+		}
+
+		const parsed = parseColumn(prop.initializer, propKey, dialect, tableName, filePath, warnings)
+		columns.push(parsed.column)
+		propToDbName.set(propKey, parsed.column.name)
+		if (parsed.isPrimaryKey) {
+			primaryKey.push(parsed.column.name)
+		}
+		if (parsed.uniqueIndex) {
+			indexes.push(parsed.uniqueIndex)
+		}
+		if (parsed.foreignKey) {
+			foreignKeys.push(parsed.foreignKey)
+		}
+	}
+
+	// Third argument: the table-level config callback `(t) => ({ ... })`.
+	if (args.length >= 3) {
+		const configArg = args[2]
+		parseTableConfig(configArg, propToDbName, tableName, filePath, {
+			primaryKey,
+			indexes,
+			foreignKeys,
+		}, warnings)
+	}
+
+	const table: TableIR = {
+		name: tableName,
+		columns: columns.sort(byName),
+		primaryKey,
+		indexes: indexes.sort(byName),
+		foreignKeys: foreignKeys.sort(byForeignKey),
+	}
+	if (dialect === 'postgres') {
+		table.schema = 'public'
+	}
+	return table
+}
+
+type TColumnResult = {
+	column: ColumnIR
+	isPrimaryKey: boolean
+	uniqueIndex: IndexIR | null
+	foreignKey: ForeignKeyIR | null
+}
+
+/**
+ * Drizzle column builder name → {@link NormalizedType}. We map the builder
+ * (e.g. `varchar`, `timestamp`) rather than a SQL string, so this is separate
+ * from {@link normalizeDbType} (which keys off live DB type strings). Unknown
+ * builders fall back to `normalizeDbType(builder)` and finally `'unknown'`.
+ */
+const BUILDER_TYPES: Record<string, NormalizedType> = {
+	integer: 'int',
+	int: 'int',
+	tinyint: 'smallint',
+	smallint: 'smallint',
+	mediumint: 'int',
+	bigint: 'bigint',
+	serial: 'int',
+	bigserial: 'bigint',
+	smallserial: 'smallint',
+	text: 'text',
+	char: 'varchar',
+	varchar: 'varchar',
+	boolean: 'bool',
+	timestamp: 'timestamp',
+	datetime: 'timestamp',
+	date: 'date',
+	time: 'time',
+	uuid: 'uuid',
+	json: 'json',
+	jsonb: 'jsonb',
+	numeric: 'decimal',
+	decimal: 'decimal',
+	real: 'float',
+	float: 'float',
+	double: 'double',
+	doublePrecision: 'double',
+	bytea: 'bytes',
+	blob: 'bytes',
+	binary: 'bytes',
+	varbinary: 'bytes',
+}
+
+// Builders that imply an auto-incrementing column.
+const AUTO_INCREMENT_BUILDERS = new Set(['serial', 'bigserial', 'smallserial'])
+
+function parseColumn(
+	call: ts.CallExpression,
+	propKey: string,
+	dialect: Dialect,
+	tableName: string,
+	filePath: string,
+	warnings: string[]
+): TColumnResult {
+	// Unwind the modifier chain to find the base builder call and the list of
+	// applied modifier methods (in source order, outermost-last).
+	const chain = unwindChain(call)
+	const builderName = chain.builderName
+
+	// First builder argument may be the explicit DB column name.
+	let dbName = propKey
+	const baseArgs = chain.baseCall.arguments
+	if (baseArgs.length > 0) {
+		const explicit = literalString(baseArgs[0])
+		if (explicit !== null) {
+			dbName = explicit
+		}
+	}
+
+	let type: NormalizedType = 'unknown'
+	if (builderName && BUILDER_TYPES[builderName]) {
+		type = BUILDER_TYPES[builderName]
+	} else if (builderName) {
+		type = normalizeDbType(builderName, dialect)
+	}
+	const rawType = builderName ?? 'unknown'
+
+	if (type === 'unknown') {
+		warnings.push(
+			`${filePath}: table "${tableName}".${propKey} uses unrecognized builder "${rawType}"; type set to unknown`
+		)
+	}
+
+	let nullable = true
+	let isPrimaryKey = false
+	let autoIncrement = AUTO_INCREMENT_BUILDERS.has(builderName ?? '')
+	let defaultText: string | null = null
+	let uniqueIndex: IndexIR | null = null
+	let foreignKey: ForeignKeyIR | null = null
+
+	for (const mod of chain.modifiers) {
+		switch (mod.name) {
+			case 'primaryKey':
+				isPrimaryKey = true
+				nullable = false
+				break
+			case 'notNull':
+				nullable = false
+				break
+			case 'default':
+				defaultText = defaultLiteral(mod.args)
+				break
+			case 'defaultNow':
+				defaultText = 'now()'
+				break
+			case 'defaultRandom':
+				defaultText = 'gen_random_uuid()'
+				break
+			case '$default':
+			case '$defaultFn':
+			case '$onUpdate':
+			case '$onUpdateFn':
+				// Runtime functions — we cannot statically evaluate them.
+				defaultText = 'unknown'
+				break
+			case 'autoincrement':
+				autoIncrement = true
+				break
+			case 'unique':
+				uniqueIndex = {
+					name: uniqueIndexName(mod.args, tableName, dbName),
+					columns: [dbName],
+					unique: true,
+				}
+				break
+			case 'references':
+				foreignKey = parseReferences(mod, [dbName], tableName, filePath, warnings)
+				break
+			case 'generatedAlwaysAsIdentity':
+			case 'generatedByDefaultAsIdentity':
+				autoIncrement = true
+				break
+			default:
+				// Unhandled modifiers (.array(), .mode(), length args, etc.) are
+				// safely ignored — they don't change the IR fields we compare.
+				break
+		}
+	}
+
+	return {
+		column: { name: dbName, type, rawType, nullable, default: defaultText, autoIncrement },
+		isPrimaryKey,
+		uniqueIndex,
+		foreignKey,
+	}
+}
+
+type TModifier = { name: string; args: ts.NodeArray<ts.Expression> }
+type TChain = {
+	baseCall: ts.CallExpression
+	builderName: string | null
+	modifiers: TModifier[]
+}
+
+/**
+ * Walk a builder method chain `foo('x').notNull().default(1)` down to the base
+ * call and collect the modifiers in source order.
+ */
+function unwindChain(call: ts.CallExpression): TChain {
+	const modifiers: TModifier[] = []
+	let current: ts.Expression = call
+
+	while (
+		ts.isCallExpression(current) &&
+		ts.isPropertyAccessExpression(current.expression)
+	) {
+		modifiers.unshift({ name: current.expression.name.text, args: current.arguments })
+		current = current.expression.expression
+	}
+
+	let baseCall: ts.CallExpression
+	let builderName: string | null = null
+	if (ts.isCallExpression(current)) {
+		baseCall = current
+		if (ts.isIdentifier(current.expression)) {
+			builderName = current.expression.text
+		} else if (ts.isPropertyAccessExpression(current.expression)) {
+			// e.g. `t.integer(...)` style — take the trailing member name.
+			builderName = current.expression.name.text
+		}
+	} else {
+		baseCall = call
+	}
+
+	return { baseCall, builderName, modifiers }
+}
+
+function parseReferences(
+	mod: TModifier,
+	columns: string[],
+	tableName: string,
+	filePath: string,
+	warnings: string[]
+): ForeignKeyIR | null {
+	// `.references(() => other.col, { onDelete: 'cascade' })`
+	const refArg = mod.args[0]
+	const ref = refArg ? resolveColumnRef(refArg) : null
+	if (!ref) {
+		warnings.push(
+			`${filePath}: table "${tableName}" has a .references() that could not be resolved statically; foreign key skipped`
+		)
+		return null
+	}
+	const fk: ForeignKeyIR = {
+		columns,
+		refTable: ref.tableVar,
+		refColumns: [ref.column],
+	}
+	applyFkActions(mod.args[1], fk)
+	return fk
+}
+
+/**
+ * Resolve `() => other.col` (arrow returning a property access) or a bare
+ * `other.col` into its table-variable and column-property names. We use the
+ * referenced JS identifiers as a best-effort table/column name; the diff
+ * engine compares conservatively when names differ from the DB.
+ */
+function resolveColumnRef(
+	expr: ts.Expression
+): { tableVar: string; column: string } | null {
+	let body: ts.Expression = expr
+	if (ts.isArrowFunction(expr)) {
+		if (ts.isBlock(expr.body)) {
+			// `() => { return other.col }`
+			const ret = expr.body.statements.find(ts.isReturnStatement)
+			if (ret && ret.expression) {
+				body = ret.expression
+			} else {
+				return null
+			}
+		} else {
+			body = expr.body
+		}
+	}
+	if (ts.isPropertyAccessExpression(body) && ts.isIdentifier(body.expression)) {
+		return { tableVar: body.expression.text, column: body.name.text }
+	}
+	return null
+}
+
+function applyFkActions(optsExpr: ts.Expression | undefined, fk: ForeignKeyIR): void {
+	if (!optsExpr || !ts.isObjectLiteralExpression(optsExpr)) {
+		return
+	}
+	for (const prop of optsExpr.properties) {
+		if (!ts.isPropertyAssignment(prop)) {
+			continue
+		}
+		const key = propertyName(prop.name)
+		const value = literalString(prop.initializer)
+		if (value === null) {
+			continue
+		}
+		if (key === 'onDelete') {
+			fk.onDelete = value
+		} else if (key === 'onUpdate') {
+			fk.onUpdate = value
+		}
+	}
+}
+
+/**
+ * Parse the third callback argument `(t) => ({ pk: primaryKey({...}), ... })`
+ * and fold composite PKs, indexes and composite FKs into the table.
+ */
+function parseTableConfig(
+	configArg: ts.Expression,
+	propToDbName: Map<string, string>,
+	tableName: string,
+	filePath: string,
+	acc: { primaryKey: string[]; indexes: IndexIR[]; foreignKeys: ForeignKeyIR[] },
+	warnings: string[]
+): void {
+	const obj = configCallbackObject(configArg)
+	if (!obj) {
+		warnings.push(
+			`${filePath}: table "${tableName}" config callback could not be read statically; table-level constraints skipped`
+		)
+		return
+	}
+
+	const entries: ts.Expression[] = []
+	if (ts.isObjectLiteralExpression(obj)) {
+		for (const prop of obj.properties) {
+			if (ts.isPropertyAssignment(prop)) {
+				entries.push(prop.initializer)
+			}
+		}
+	} else if (ts.isArrayLiteralExpression(obj)) {
+		// Newer drizzle returns an array of builders.
+		for (const el of obj.elements) {
+			entries.push(el)
+		}
+	}
+
+	for (const entry of entries) {
+		if (!ts.isCallExpression(entry)) {
+			continue
+		}
+		const chain = unwindChain(entry)
+		const head = chain.builderName
+		if (head === 'primaryKey') {
+			const cols = resolvePrimaryKeyArg(chain.baseCall.arguments[0], propToDbName)
+			if (cols.length > 0) {
+				acc.primaryKey.push(...cols)
+			} else {
+				warnings.push(
+					`${filePath}: table "${tableName}" composite primaryKey columns could not be resolved`
+				)
+			}
+		} else if (head === 'index' || head === 'uniqueIndex') {
+			const idx = parseTableIndex(chain, head === 'uniqueIndex', propToDbName, tableName, filePath, warnings)
+			if (idx) {
+				acc.indexes.push(idx)
+			}
+		} else if (head === 'foreignKey') {
+			const fk = parseCompositeForeignKey(chain.baseCall.arguments[0], chain.modifiers, propToDbName, tableName, filePath, warnings)
+			if (fk) {
+				acc.foreignKeys.push(fk)
+			}
+		} else if (head === 'unique') {
+			const idx = parseTableIndex(chain, true, propToDbName, tableName, filePath, warnings)
+			if (idx) {
+				acc.indexes.push(idx)
+			}
+		}
+	}
+}
+
+/** Unwrap a `(t) => (...)`/`(t) => { return ... }` callback to its returned expr. */
+function configCallbackObject(configArg: ts.Expression): ts.Expression | null {
+	let fn: ts.Expression = configArg
+	if (ts.isArrowFunction(fn) || ts.isFunctionExpression(fn)) {
+		if (ts.isBlock(fn.body)) {
+			const ret = fn.body.statements.find(ts.isReturnStatement)
+			return ret && ret.expression ? ret.expression : null
+		}
+		// Arrow with an expression body. Parenthesized object: `(t) => ({...})`.
+		let body: ts.Expression = fn.body
+		while (ts.isParenthesizedExpression(body)) {
+			body = body.expression
+		}
+		return body
+	}
+	return null
+}
+
+function parseTableIndex(
+	chain: TChain,
+	unique: boolean,
+	propToDbName: Map<string, string>,
+	tableName: string,
+	filePath: string,
+	warnings: string[]
+): IndexIR | null {
+	// name comes from `index('name')` / `uniqueIndex('name')`.
+	let name = literalString(chain.baseCall.arguments[0]) ?? ''
+	// columns come from a `.on(t.a, t.b)` modifier.
+	const onMod = chain.modifiers.find(function (m) {
+		return m.name === 'on'
+	})
+	const columns = onMod ? resolveColumnArgs(onMod.args, propToDbName) : []
+	if (columns.length === 0) {
+		warnings.push(
+			`${filePath}: table "${tableName}" index columns could not be resolved; index skipped`
+		)
+		return null
+	}
+	if (name.length === 0) {
+		name = `${tableName}_${columns.join('_')}${unique ? '_unique' : '_idx'}`
+	}
+	return { name, columns, unique }
+}
+
+function parseCompositeForeignKey(
+	optsExpr: ts.Expression | undefined,
+	modifiers: TModifier[],
+	propToDbName: Map<string, string>,
+	tableName: string,
+	filePath: string,
+	warnings: string[]
+): ForeignKeyIR | null {
+	if (!optsExpr || !ts.isObjectLiteralExpression(optsExpr)) {
+		warnings.push(`${filePath}: table "${tableName}" foreignKey() options could not be read; skipped`)
+		return null
+	}
+	let columns: string[] = []
+	let refTable: string | null = null
+	let refColumns: string[] = []
+
+	for (const prop of optsExpr.properties) {
+		if (!ts.isPropertyAssignment(prop)) {
+			continue
+		}
+		const key = propertyName(prop.name)
+		if (key === 'columns') {
+			columns = resolveColumnArrayLocal(prop.initializer, propToDbName)
+		} else if (key === 'foreignColumns') {
+			const resolved = resolveForeignColumns(prop.initializer)
+			refTable = resolved.table
+			refColumns = resolved.columns
+		}
+	}
+
+	if (columns.length === 0 || refTable === null || refColumns.length === 0) {
+		warnings.push(`${filePath}: table "${tableName}" composite foreignKey could not be fully resolved; skipped`)
+		return null
+	}
+
+	const fk: ForeignKeyIR = { columns, refTable, refColumns }
+	const onDelete = modifiers.find(function (m) {
+		return m.name === 'onDelete'
+	})
+	const onUpdate = modifiers.find(function (m) {
+		return m.name === 'onUpdate'
+	})
+	if (onDelete) {
+		const v = literalString(onDelete.args[0])
+		if (v) fk.onDelete = v
+	}
+	if (onUpdate) {
+		const v = literalString(onUpdate.args[0])
+		if (v) fk.onUpdate = v
+	}
+	return fk
+}
+
+/**
+ * Resolve the first arg of a table-level `primaryKey(...)` into ordered local
+ * DB column names. Supports modern `primaryKey({ columns: [t.a, t.b] })`,
+ * a bare `[t.a, t.b]` array, and a single `t.a`.
+ */
+function resolvePrimaryKeyArg(
+	arg: ts.Expression | undefined,
+	propToDbName: Map<string, string>
+): string[] {
+	if (!arg) {
+		return []
+	}
+	if (ts.isObjectLiteralExpression(arg)) {
+		for (const prop of arg.properties) {
+			if (ts.isPropertyAssignment(prop) && propertyName(prop.name) === 'columns') {
+				return resolveColumnArrayLocal(prop.initializer, propToDbName)
+			}
+		}
+		return []
+	}
+	if (ts.isArrayLiteralExpression(arg)) {
+		return resolveColumnArrayLocal(arg, propToDbName)
+	}
+	const single = localColumnName(arg, propToDbName)
+	return single ? [single] : []
+}
+
+function resolveColumnArgs(
+	args: ts.NodeArray<ts.Expression>,
+	propToDbName: Map<string, string>
+): string[] {
+	const out: string[] = []
+	for (const a of args) {
+		const name = localColumnName(a, propToDbName)
+		if (name) {
+			out.push(name)
+		}
+	}
+	return out
+}
+
+function resolveColumnArrayLocal(
+	expr: ts.Expression,
+	propToDbName: Map<string, string>
+): string[] {
+	if (!ts.isArrayLiteralExpression(expr)) {
+		return []
+	}
+	const out: string[] = []
+	for (const el of expr.elements) {
+		const name = localColumnName(el, propToDbName)
+		if (name) {
+			out.push(name)
+		}
+	}
+	return out
+}
+
+/** `t.colKey` (or `table.colKey`) → the column's DB name via the prop map. */
+function localColumnName(
+	expr: ts.Expression,
+	propToDbName: Map<string, string>
+): string | null {
+	if (ts.isPropertyAccessExpression(expr)) {
+		const propKey = expr.name.text
+		return propToDbName.get(propKey) ?? propKey
+	}
+	return null
+}
+
+/** `[other.a, other.b]` (the referenced table's columns) → table var + columns. */
+function resolveForeignColumns(expr: ts.Expression): { table: string | null; columns: string[] } {
+	if (!ts.isArrayLiteralExpression(expr)) {
+		return { table: null, columns: [] }
+	}
+	let table: string | null = null
+	const columns: string[] = []
+	for (const el of expr.elements) {
+		if (ts.isPropertyAccessExpression(el) && ts.isIdentifier(el.expression)) {
+			table = el.expression.text
+			columns.push(el.name.text)
+		}
+	}
+	return { table, columns }
+}
+
+function uniqueIndexName(
+	args: ts.NodeArray<ts.Expression>,
+	tableName: string,
+	column: string
+): string {
+	const explicit = args.length > 0 ? literalString(args[0]) : null
+	return explicit ?? `${tableName}_${column}_unique`
+}
+
+/**
+ * Best-effort normalized text for `.default(x)`. String/number/boolean literals
+ * become their text; SQL-template tags and anything non-literal become
+ * `'unknown'` so the diff treats them as "review".
+ */
+function defaultLiteral(args: ts.NodeArray<ts.Expression>): string {
+	if (args.length === 0) {
+		return 'unknown'
+	}
+	const arg = args[0]
+	if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) {
+		return arg.text
+	}
+	if (ts.isNumericLiteral(arg)) {
+		return arg.text
+	}
+	if (arg.kind === ts.SyntaxKind.TrueKeyword) {
+		return 'true'
+	}
+	if (arg.kind === ts.SyntaxKind.FalseKeyword) {
+		return 'false'
+	}
+	if (ts.isPrefixUnaryExpression(arg) && ts.isNumericLiteral(arg.operand)) {
+		return arg.operator === ts.SyntaxKind.MinusToken ? `-${arg.operand.text}` : arg.operand.text
+	}
+	if (arg.kind === ts.SyntaxKind.NullKeyword) {
+		return 'null'
+	}
+	// sql`...`, arrays, objects, function calls — not statically comparable.
+	return 'unknown'
+}
+
+function literalString(node: ts.Expression | undefined): string | null {
+	if (!node) {
+		return null
+	}
+	if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+		return node.text
+	}
+	return null
+}
+
+function propertyName(name: ts.PropertyName): string | null {
+	if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+		return name.text
+	}
+	return null
+}
+
+function describeError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error)
+}
+
+function byName(a: { name: string }, b: { name: string }): number {
+	return a.name.localeCompare(b.name)
+}
+
+function byForeignKey(a: ForeignKeyIR, b: ForeignKeyIR): number {
+	const table = a.refTable.localeCompare(b.refTable)
+	if (table !== 0) {
+		return table
+	}
+	return a.columns.join(',').localeCompare(b.columns.join(','))
+}

--- a/packages/studio/src/features/orm-cockpit/parsers/prisma/parse-prisma-schema.ts
+++ b/packages/studio/src/features/orm-cockpit/parsers/prisma/parse-prisma-schema.ts
@@ -1,0 +1,658 @@
+import type { NormalizedType } from '@studio/features/orm-cockpit/ir/types'
+import type {
+	ColumnIR,
+	Dialect,
+	ForeignKeyIR,
+	IndexIR,
+	SchemaIR,
+	TableIR,
+} from '@studio/features/orm-cockpit/ir/types'
+
+/**
+ * Parse a Prisma `schema.prisma` document into the normalized {@link SchemaIR}.
+ *
+ * Why a hand-written line/block parser (and not `@prisma/internals`'s
+ * `getDMMF`)? `packages/studio` is a Vite RENDERER bundle that runs in the
+ * browser. `@prisma/internals` is Node-only, filesystem-dependent, and very
+ * heavy — it cannot run in this environment, and it is not a studio dependency.
+ * Adding it is out of scope (no new deps). The `.prisma` format is
+ * line-oriented and regular enough that a focused parser covers the common set
+ * deterministically; anything unrecognized is flagged as a warning and the
+ * affected type/default collapses to `'unknown'` rather than throwing.
+ *
+ * Output matches the live mapper (`fromLiveSchema`): tables/columns/indexes/
+ * foreignKeys sorted by name; primary-key and index column order preserved.
+ */
+export function parsePrismaSchema(text: string): { ir: SchemaIR; warnings: string[] } {
+	const warnings: string[] = []
+	const lines = stripComments(text).split('\n')
+
+	const blocks = collectBlocks(lines)
+
+	// Resolve the dialect from the datasource provider; default to postgres.
+	let dialect: Dialect = 'postgres'
+	const datasource = blocks.find(function (b) {
+		return b.kind === 'datasource'
+	})
+	if (datasource) {
+		dialect = providerToDialect(datasource.body, warnings)
+	}
+
+	// Enum names are needed up front so enum-typed fields are treated as text.
+	const enumNames = new Set<string>()
+	for (const block of blocks) {
+		if (block.kind === 'enum') {
+			enumNames.add(block.name)
+		}
+	}
+
+	// Model names: any field whose type is another model/enum-of-relation is a
+	// relation/virtual field, not a scalar column.
+	const modelNames = new Set<string>()
+	for (const block of blocks) {
+		if (block.kind === 'model') {
+			modelNames.add(block.name)
+		}
+	}
+
+	const tables: TableIR[] = []
+	for (const block of blocks) {
+		if (block.kind !== 'model') {
+			continue
+		}
+		tables.push(
+			parseModel(block, { dialect, enumNames, modelNames, blocks, warnings }),
+		)
+	}
+
+	tables.sort(byName)
+
+	return { ir: { dialect, tables }, warnings }
+}
+
+type TBlockKind = 'datasource' | 'generator' | 'model' | 'enum' | 'type' | 'view'
+
+type TBlock = {
+	kind: TBlockKind
+	name: string
+	body: string[]
+}
+
+type TParseCtx = {
+	dialect: Dialect
+	enumNames: Set<string>
+	modelNames: Set<string>
+	blocks: TBlock[]
+	warnings: string[]
+}
+
+/** Strip `//` line comments and `///` doc comments; leave string contents
+ * intact (a `//` inside a quoted default would be unusual in practice, and we
+ * keep the parser simple/conservative). */
+function stripComments(text: string): string {
+	return text
+		.split('\n')
+		.map(function (line) {
+			const idx = line.indexOf('//')
+			if (idx === -1) {
+				return line
+			}
+			return line.slice(0, idx)
+		})
+		.join('\n')
+}
+
+/** Split the document into top-level `keyword Name { ... }` blocks. */
+function collectBlocks(lines: string[]): TBlock[] {
+	const blocks: TBlock[] = []
+	let current: TBlock | null = null
+
+	for (const raw of lines) {
+		const line = raw.trim()
+		if (line.length === 0) {
+			continue
+		}
+
+		if (current === null) {
+			const header = matchBlockHeader(line)
+			if (header) {
+				current = { kind: header.kind, name: header.name, body: [] }
+			}
+			continue
+		}
+
+		if (line === '}') {
+			blocks.push(current)
+			current = null
+			continue
+		}
+
+		current.body.push(line)
+	}
+
+	return blocks
+}
+
+function matchBlockHeader(line: string): { kind: TBlockKind; name: string } | null {
+	const m = line.match(/^(datasource|generator|model|enum|type|view)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{/)
+	if (!m) {
+		return null
+	}
+	return { kind: m[1] as TBlockKind, name: m[2] }
+}
+
+function providerToDialect(body: string[], warnings: string[]): Dialect {
+	for (const line of body) {
+		const m = line.match(/^provider\s*=\s*"([^"]+)"/)
+		if (!m) {
+			continue
+		}
+		const provider = m[1].toLowerCase()
+		switch (provider) {
+			case 'postgresql':
+			case 'postgres':
+				return 'postgres'
+			case 'mysql':
+				return 'mysql'
+			case 'sqlite':
+				return 'sqlite'
+			case 'cockroachdb':
+				return 'postgres'
+			default:
+				warnings.push(
+					`datasource provider "${m[1]}" is not a recognized SQL dialect; defaulting to postgres`,
+				)
+				return 'postgres'
+		}
+	}
+	return 'postgres'
+}
+
+function parseModel(block: TBlock, ctx: TParseCtx): TableIR {
+	const columns: ColumnIR[] = []
+	const indexes: IndexIR[] = []
+	const foreignKeys: ForeignKeyIR[] = []
+	let primaryKey: string[] = []
+
+	// Map a Prisma field name -> DB column name (@map). Needed to translate
+	// block-level @@id/@@unique/@@index column references onto real DB names.
+	const fieldToColumn = new Map<string, string>()
+	// Track scalar field type per field (for FK relation resolution).
+	const fieldScalarType = new Map<string, string>()
+
+	const tableName = readBlockMap(block.body) ?? block.name
+
+	for (const line of block.body) {
+		if (line.startsWith('@@')) {
+			// Handled in a second pass once we know fieldToColumn mappings.
+			continue
+		}
+
+		const field = parseField(line, ctx, block.name)
+		if (!field) {
+			continue
+		}
+
+		fieldToColumn.set(field.fieldName, field.column ? field.column.name : field.dbName)
+		fieldScalarType.set(field.fieldName, field.scalarType)
+
+		if (field.column) {
+			columns.push(field.column)
+			if (field.isPrimaryKey) {
+				primaryKey.push(field.column.name)
+			}
+			if (field.isUnique) {
+				indexes.push({
+					name: `${tableName}_${field.column.name}_key`,
+					columns: [field.column.name],
+					unique: true,
+				})
+			}
+		}
+
+		if (field.foreignKey) {
+			foreignKeys.push(field.foreignKey)
+		}
+	}
+
+	// Second pass: block-level attributes referencing field names.
+	for (const line of block.body) {
+		if (!line.startsWith('@@')) {
+			continue
+		}
+		applyBlockAttribute(line, {
+			ctx,
+			tableName,
+			fieldToColumn,
+			onPrimaryKey(cols) {
+				primaryKey = cols
+			},
+			onIndex(index) {
+				indexes.push(index)
+			},
+		})
+	}
+
+	const ir: TableIR = {
+		name: tableName,
+		columns: columns.sort(byName),
+		primaryKey,
+		indexes: indexes.sort(byName),
+		foreignKeys: foreignKeys.sort(byForeignKey),
+	}
+
+	if (ctx.dialect === 'postgres') {
+		ir.schema = 'public'
+	}
+
+	return ir
+}
+
+type TParsedField = {
+	fieldName: string
+	dbName: string
+	scalarType: string
+	column: ColumnIR | null
+	isPrimaryKey: boolean
+	isUnique: boolean
+	foreignKey: ForeignKeyIR | null
+}
+
+function parseField(line: string, ctx: TParseCtx, modelName: string): TParsedField | null {
+	const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)(\[\])?(\?)?\s*(.*)$/)
+	if (!m) {
+		return null
+	}
+
+	const fieldName = m[1]
+	const baseType = m[2]
+	const isList = m[3] === '[]'
+	const nullable = m[4] === '?'
+	const attrs = m[5] ?? ''
+
+	const dbName = readMapAttr(attrs) ?? fieldName
+
+	// Relation/virtual field: type is another model. These never produce a
+	// scalar column; instead resolve the FK from @relation if present.
+	if (ctx.modelNames.has(baseType)) {
+		const fk = parseRelationFk(attrs, baseType, modelName, ctx)
+		return {
+			fieldName,
+			dbName,
+			scalarType: baseType,
+			column: null,
+			isPrimaryKey: false,
+			isUnique: false,
+			foreignKey: fk,
+		}
+	}
+
+	const isEnum = ctx.enumNames.has(baseType)
+	if (isEnum) {
+		ctx.warnings.push(
+			`field ${modelName}.${fieldName} uses enum type "${baseType}"; treated as text`,
+		)
+	}
+
+	// List scalar fields (e.g. String[]) are not a single column in a SQL
+	// table in the relational connectors; flag and skip producing a column.
+	if (isList) {
+		ctx.warnings.push(
+			`field ${modelName}.${fieldName} is a scalar list ("${baseType}[]"); skipped (not a single SQL column)`,
+		)
+		return {
+			fieldName,
+			dbName,
+			scalarType: baseType,
+			column: null,
+			isPrimaryKey: false,
+			isUnique: false,
+			foreignKey: null,
+		}
+	}
+
+	const native = readNativeType(attrs)
+	const normalized = isEnum
+		? 'text'
+		: mapPrismaScalar(baseType, native, ctx.dialect)
+
+	if (normalized === 'unknown' && !isEnum) {
+		ctx.warnings.push(
+			`field ${modelName}.${fieldName} has unrecognized type "${baseType}${native ? ` @db.${native}` : ''}"; mapped to 'unknown'`,
+		)
+	}
+
+	const def = parseDefault(attrs, ctx, modelName, fieldName)
+
+	const column: ColumnIR = {
+		name: dbName,
+		type: normalized,
+		rawType: native ? `${baseType} @db.${native}` : baseType,
+		nullable,
+		default: def.text,
+		autoIncrement: def.autoIncrement,
+	}
+
+	return {
+		fieldName,
+		dbName,
+		scalarType: baseType,
+		column,
+		isPrimaryKey: /@id\b/.test(attrs),
+		isUnique: /@unique\b/.test(attrs),
+		foreignKey: null,
+	}
+}
+
+/** Map a Prisma scalar (plus optional `@db.Native`) to a {@link NormalizedType}. */
+function mapPrismaScalar(
+	scalar: string,
+	native: string | null,
+	dialect: Dialect,
+): NormalizedType {
+	// Native type refinements where clear.
+	if (native) {
+		const refined = refineNative(native)
+		if (refined) {
+			return refined
+		}
+	}
+
+	switch (scalar) {
+		case 'Int':
+			return 'int'
+		case 'BigInt':
+			return 'bigint'
+		case 'Float':
+			return 'double'
+		case 'Decimal':
+			return 'decimal'
+		case 'Boolean':
+			return 'bool'
+		case 'String':
+			// Prisma maps String -> text on postgres, varchar(191) on mysql.
+			return dialect === 'mysql' ? 'varchar' : 'text'
+		case 'DateTime':
+			return 'timestamp'
+		case 'Json':
+			return dialect === 'postgres' ? 'jsonb' : 'json'
+		case 'Bytes':
+			return 'bytes'
+		default:
+			return 'unknown'
+	}
+}
+
+/** Refine a `@db.Native` type to a canonical type when unambiguous. */
+function refineNative(native: string): NormalizedType | null {
+	const t = native.toLowerCase()
+	if (t.startsWith('uuid')) return 'uuid'
+	if (t.startsWith('varchar') || t.startsWith('char') || t.startsWith('nvarchar')) return 'varchar'
+	if (t.startsWith('text') || t.startsWith('longtext') || t.startsWith('mediumtext')) return 'text'
+	if (t.startsWith('smallint')) return 'smallint'
+	if (t.startsWith('bigint')) return 'bigint'
+	if (t.startsWith('integer') || t.startsWith('int')) return 'int'
+	if (t.startsWith('jsonb')) return 'jsonb'
+	if (t.startsWith('json')) return 'json'
+	if (t.startsWith('timestamptz')) return 'timestamptz'
+	if (t.startsWith('timestamp')) return 'timestamp'
+	if (t.startsWith('date')) return 'date'
+	if (t.startsWith('time')) return 'time'
+	if (t.startsWith('decimal') || t.startsWith('numeric')) return 'decimal'
+	if (t.startsWith('double')) return 'double'
+	if (t.startsWith('real') || t.startsWith('float')) return 'float'
+	if (t.startsWith('boolean') || t.startsWith('bit')) return 'bool'
+	if (t.startsWith('bytea') || t.startsWith('blob') || t.startsWith('binary')) return 'bytes'
+	return null
+}
+
+function readNativeType(attrs: string): string | null {
+	const m = attrs.match(/@db\.([A-Za-z0-9_]+(?:\([^)]*\))?)/)
+	return m ? m[1] : null
+}
+
+type TDefault = { text: string | null; autoIncrement: boolean }
+
+function parseDefault(
+	attrs: string,
+	ctx: TParseCtx,
+	modelName: string,
+	fieldName: string,
+): TDefault {
+	const m = attrs.match(/@default\(([\s\S]*?)\)\s*(?:@|$)/) ?? attrs.match(/@default\((.*)\)/)
+	if (!m) {
+		return { text: null, autoIncrement: false }
+	}
+	const inner = m[1].trim()
+
+	if (/^autoincrement\(\)$/.test(inner)) {
+		return { text: null, autoIncrement: true }
+	}
+	if (/^now\(\)$/.test(inner)) {
+		return { text: 'now()', autoIncrement: false }
+	}
+	if (/^uuid\(/.test(inner)) {
+		return { text: 'uuid()', autoIncrement: false }
+	}
+	if (/^cuid\(/.test(inner)) {
+		return { text: 'cuid()', autoIncrement: false }
+	}
+	if (/^dbgenerated\(/.test(inner)) {
+		ctx.warnings.push(
+			`field ${modelName}.${fieldName} uses @default(dbgenerated(...)); default mapped to 'unknown'`,
+		)
+		return { text: 'unknown', autoIncrement: false }
+	}
+
+	// String literal default.
+	const str = inner.match(/^"([\s\S]*)"$/)
+	if (str) {
+		return { text: str[1], autoIncrement: false }
+	}
+
+	// Numeric / boolean / bare identifier (enum value) literal.
+	if (/^(true|false|-?\d+(\.\d+)?|[A-Za-z_][A-Za-z0-9_]*)$/.test(inner)) {
+		return { text: inner, autoIncrement: false }
+	}
+
+	ctx.warnings.push(
+		`field ${modelName}.${fieldName} has unrecognized @default(${inner}); default mapped to 'unknown'`,
+	)
+	return { text: 'unknown', autoIncrement: false }
+}
+
+/** Parse the FK described by a relation field's `@relation(...)`.
+ * Resolves referenced column names against the referenced model's @map'd
+ * scalar fields. */
+function parseRelationFk(
+	attrs: string,
+	refModelName: string,
+	localModelName: string,
+	ctx: TParseCtx,
+): ForeignKeyIR | null {
+	const m = attrs.match(/@relation\(([\s\S]*)\)/)
+	if (!m) {
+		return null
+	}
+	const inner = m[1]
+
+	const fields = readNameList(inner, 'fields')
+	const references = readNameList(inner, 'references')
+	if (fields.length === 0 || references.length === 0) {
+		// The owning side carries fields/references; the inverse side doesn't.
+		return null
+	}
+
+	const refTableName = resolveTableName(refModelName, ctx)
+
+	const fk: ForeignKeyIR = {
+		columns: fields.map(function (f) {
+			return resolveColumnName(localModelName, f, ctx)
+		}),
+		refTable: refTableName,
+		refColumns: references.map(function (ref) {
+			return resolveColumnName(refModelName, ref, ctx)
+		}),
+	}
+
+	const onDelete = readKeyword(inner, 'onDelete')
+	if (onDelete) {
+		fk.onDelete = onDelete
+	}
+	const onUpdate = readKeyword(inner, 'onUpdate')
+	if (onUpdate) {
+		fk.onUpdate = onUpdate
+	}
+
+	return fk
+}
+
+function readNameList(inner: string, key: string): string[] {
+	const m = inner.match(new RegExp(`${key}\\s*:\\s*\\[([^\\]]*)\\]`))
+	if (!m) {
+		return []
+	}
+	return m[1]
+		.split(',')
+		.map(function (s) {
+			return s.trim()
+		})
+		.filter(function (s) {
+			return s.length > 0
+		})
+}
+
+function readKeyword(inner: string, key: string): string | undefined {
+	const m = inner.match(new RegExp(`${key}\\s*:\\s*([A-Za-z]+)`))
+	return m ? m[1] : undefined
+}
+
+function resolveTableName(modelName: string, ctx: TParseCtx): string {
+	const block = ctx.blocks.find(function (b) {
+		return b.kind === 'model' && b.name === modelName
+	})
+	if (!block) {
+		return modelName
+	}
+	return readBlockMap(block.body) ?? modelName
+}
+
+/** Resolve a referenced field name to its DB column name (honoring @map). */
+function resolveColumnName(modelName: string, fieldName: string, ctx: TParseCtx): string {
+	const block = ctx.blocks.find(function (b) {
+		return b.kind === 'model' && b.name === modelName
+	})
+	if (!block) {
+		return fieldName
+	}
+	for (const line of block.body) {
+		const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s+/)
+		if (m && m[1] === fieldName) {
+			return readMapAttr(line) ?? fieldName
+		}
+	}
+	return fieldName
+}
+
+type TBlockAttrHandlers = {
+	ctx: TParseCtx
+	tableName: string
+	fieldToColumn: Map<string, string>
+	onPrimaryKey(cols: string[]): void
+	onIndex(index: IndexIR): void
+}
+
+function applyBlockAttribute(line: string, h: TBlockAttrHandlers): void {
+	if (line.startsWith('@@id')) {
+		const cols = readBracketList(line).map(function (f) {
+			return h.fieldToColumn.get(f) ?? f
+		})
+		h.onPrimaryKey(cols)
+		return
+	}
+	if (line.startsWith('@@unique')) {
+		const cols = readBracketList(line).map(function (f) {
+			return h.fieldToColumn.get(f) ?? f
+		})
+		h.onIndex({
+			name: namedIndex(line, h.tableName, cols, 'key'),
+			columns: cols,
+			unique: true,
+		})
+		return
+	}
+	if (line.startsWith('@@index')) {
+		const cols = readBracketList(line).map(function (f) {
+			return h.fieldToColumn.get(f) ?? f
+		})
+		h.onIndex({
+			name: namedIndex(line, h.tableName, cols, 'idx'),
+			columns: cols,
+			unique: false,
+		})
+		return
+	}
+	if (line.startsWith('@@map')) {
+		return
+	}
+	// Other block attributes (e.g. @@ignore, @@fulltext, @@schema) are not
+	// modeled; note them conservatively.
+	const attrName = line.match(/^@@[A-Za-z]+/)
+	h.ctx.warnings.push(
+		`model ${h.tableName}: block attribute "${attrName ? attrName[0] : line}" is not modeled and was ignored`,
+	)
+}
+
+function namedIndex(line: string, table: string, cols: string[], suffix: string): string {
+	const explicit = line.match(/(?:name|map)\s*:\s*"([^"]+)"/)
+	if (explicit) {
+		return explicit[1]
+	}
+	return `${table}_${cols.join('_')}_${suffix}`
+}
+
+/** Read the first `[...]` list of field names from a block attribute. */
+function readBracketList(line: string): string[] {
+	const m = line.match(/\[([^\]]*)\]/)
+	if (!m) {
+		return []
+	}
+	return m[1]
+		.split(',')
+		.map(function (s) {
+			// Drop per-column sort/length modifiers like `email(sort: Desc)`.
+			return s.trim().replace(/\(.*$/, '').trim()
+		})
+		.filter(function (s) {
+			return s.length > 0
+		})
+}
+
+function readBlockMap(body: string[]): string | null {
+	for (const line of body) {
+		if (line.startsWith('@@map')) {
+			const m = line.match(/@@map\(\s*"([^"]+)"\s*\)/)
+			if (m) {
+				return m[1]
+			}
+		}
+	}
+	return null
+}
+
+function readMapAttr(attrs: string): string | null {
+	const m = attrs.match(/@map\(\s*"([^"]+)"\s*\)/)
+	return m ? m[1] : null
+}
+
+function byName(a: { name: string }, b: { name: string }): number {
+	return a.name.localeCompare(b.name)
+}
+
+function byForeignKey(a: ForeignKeyIR, b: ForeignKeyIR): number {
+	const table = a.refTable.localeCompare(b.refTable)
+	if (table !== 0) {
+		return table
+	}
+	return a.columns.join(',').localeCompare(b.columns.join(','))
+}

--- a/packages/studio/src/lib/bindings.ts
+++ b/packages/studio/src/lib/bindings.ts
@@ -79,6 +79,30 @@ async probeDatabaseFile(path: string) : Promise<Result<DatabaseFileKind, { kind:
     else return { status: "error", error: e  as any };
 }
 },
+async pickFolder() : Promise<Result<string | null, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("pick_folder") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async readProjectFile(path: string) : Promise<Result<string, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("read_project_file", { path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async listDir(path: string) : Promise<Result<string[], { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_dir", { path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async addConnection(name: string, databaseInfo: DatabaseInfo, color: number | null) : Promise<Result<ConnectionInfo, { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("add_connection", { name, databaseInfo, color }) };


### PR DESCRIPTION
Replaces #152, which GitHub auto-closed when its base branch (the Wave A branch, #151) was deleted on merge. Same commits, now based on `master`.

## Pillar 2 — Wave B (#145). All four Wave B plans on the frozen Schema IR from #151 (merged):
- **02 Drizzle parser** — static TS-compiler-API AST → SchemaIR (18 tests)
- **03 Prisma parser** — hand-written (not @prisma/internals; renderer bundle) (12 tests)
- **05 Diff engine** — confidence-aware, freezes `SchemaDiff` (29 tests)
- **04 Folder linking** — Rust `pick_folder`/`read_project_file`/`list_dir` + `detect-orm.ts`; dual-bindings synced (8 tests)

Verified: both typechecks clean; full vitest 553 passed; `cargo test --lib` 174 passed (only the 2 pre-existing `pgtemp`/`initdb` Postgres tests fail — environmental).

Part of #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/remco-stoeten/codesmith/dora/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784486432&installation_id=140085766&pr_number=154&repository=remco-stoeten%2Fdora&return_to=https%3A%2F%2Fgithub.com%2Fremco-stoeten%2Fdora%2Fpull%2F154&signature=3da28263dfaa380144e5ed2a5f49e84456adb26143570f9c7c04445952f8f7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->