### PR TITLE
feat(orm-cockpit): Wave D — cockpit UI (link → drift → migration preview)

### DIFF
--- a/__tests__/packages/studio/orm-cockpit/components/cockpit-pipeline.acceptance.test.ts
+++ b/__tests__/packages/studio/orm-cockpit/components/cockpit-pipeline.acceptance.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Wave D acceptance — exercises the cockpit's full data pipeline
+ * (parse → introspect → diff → generate) against realistic Drizzle and Prisma
+ * schemas with KNOWN drift vs a live database. This is the headless half of the
+ * plan-07 acceptance (the GUI click-through with the native folder picker is the
+ * human half). It mirrors exactly what `useOrmCockpit` does, minus React.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { DatabaseSchema } from '@studio/lib/bindings'
+import { fromLiveSchema } from '@studio/features/orm-cockpit/ir/from-live-schema'
+import { parseDrizzleSchema } from '@studio/features/orm-cockpit/parsers/drizzle/parse-drizzle-schema'
+import { parsePrismaSchema } from '@studio/features/orm-cockpit/parsers/prisma/parse-prisma-schema'
+import { diffSchema } from '@studio/features/orm-cockpit/diff/diff-schema'
+import { generateMigrationSql } from '@studio/features/orm-cockpit/migration/generate-sql'
+import { buildPreviewSql } from '@studio/features/orm-cockpit/components/migration-sections'
+
+// --- The live database: what's actually deployed. Drifted from both schemas:
+//   * `users` is MISSING `is_admin` (the code adds it).
+//   * `posts` has an EXTRA `legacy_views` column (the code drops it).
+//   * there's an EXTRA `sessions` table the code no longer declares.
+const LIVE: DatabaseSchema = {
+	schemas: ['public'],
+	unique_columns: [],
+	tables: [
+		{
+			name: 'users',
+			schema: 'public',
+			primary_key_columns: ['id'],
+			columns: [
+				{ name: 'id', data_type: 'int4', is_nullable: false, default_value: null, is_primary_key: true, is_auto_increment: true, foreign_key: null },
+				{ name: 'email', data_type: 'text', is_nullable: false, default_value: null, foreign_key: null },
+				{ name: 'name', data_type: 'text', is_nullable: true, default_value: null, foreign_key: null },
+				{ name: 'created_at', data_type: 'timestamp', is_nullable: false, default_value: 'now()', foreign_key: null },
+			],
+			indexes: [],
+		},
+		{
+			name: 'posts',
+			schema: 'public',
+			primary_key_columns: ['id'],
+			columns: [
+				{ name: 'id', data_type: 'int4', is_nullable: false, default_value: null, is_primary_key: true, is_auto_increment: true, foreign_key: null },
+				{ name: 'author_id', data_type: 'int4', is_nullable: false, default_value: null, foreign_key: { referenced_schema: 'public', referenced_table: 'users', referenced_column: 'id' } },
+				{ name: 'title', data_type: 'text', is_nullable: false, default_value: null, foreign_key: null },
+				{ name: 'body', data_type: 'text', is_nullable: true, default_value: null, foreign_key: null },
+				{ name: 'published_at', data_type: 'timestamp', is_nullable: true, default_value: null, foreign_key: null },
+				{ name: 'legacy_views', data_type: 'int4', is_nullable: true, default_value: '0', foreign_key: null },
+			],
+			indexes: [],
+		},
+		{
+			name: 'sessions',
+			schema: 'public',
+			primary_key_columns: ['id'],
+			columns: [
+				{ name: 'id', data_type: 'uuid', is_nullable: false, default_value: null, is_primary_key: true, foreign_key: null },
+				{ name: 'user_id', data_type: 'int4', is_nullable: false, default_value: null, foreign_key: { referenced_schema: 'public', referenced_table: 'users', referenced_column: 'id' } },
+			],
+			indexes: [],
+		},
+	],
+}
+
+const DRIZZLE_SCHEMA = `
+import { pgTable, serial, text, integer, boolean, timestamp } from 'drizzle-orm/pg-core'
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  email: text('email').notNull(),
+  name: text('name'),
+  isAdmin: boolean('is_admin').default(false).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+export const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  authorId: integer('author_id').notNull().references(() => users.id),
+  title: text('title').notNull(),
+  body: text('body'),
+  publishedAt: timestamp('published_at'),
+})
+`
+
+const PRISMA_SCHEMA = `
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String
+  name      String?
+  is_admin  Boolean  @default(false)
+  created_at DateTime @default(now())
+  posts     Post[]
+
+  @@map("users")
+}
+
+model Post {
+  id           Int      @id @default(autoincrement())
+  author_id    Int
+  title        String
+  body         String?
+  published_at DateTime?
+  author       User     @relation(fields: [author_id], references: [id])
+
+  @@map("posts")
+}
+`
+
+describe('Wave D acceptance — real schema drift → migration', function () {
+	const live = fromLiveSchema(LIVE, 'postgres')
+
+	it('Drizzle project: detects drift with correct confidence + valid SQL', function () {
+		const parsed = parseDrizzleSchema([{ path: 'schema.ts', text: DRIZZLE_SCHEMA }], 'postgres')
+		expect(parsed.warnings).toEqual([])
+
+		const diff = diffSchema(live, parsed.ir)
+		expect(diff.hasChanges).toBe(true)
+
+		const byName = new Map(diff.tables.map((t) => [t.name, t]))
+
+		// users: code adds is_admin (NOT NULL + default → safe additive).
+		const users = byName.get('users')
+		expect(users?.kind).toBe('changed')
+		const isAdmin = users?.columns.find((c) => c.name === 'is_admin')
+		expect(isAdmin?.kind).toBe('added')
+		expect(isAdmin?.confidence).toBe('safe')
+
+		// posts: code drops legacy_views → destructive.
+		const posts = byName.get('posts')
+		const legacy = posts?.columns.find((c) => c.name === 'legacy_views')
+		expect(legacy?.kind).toBe('removed')
+		expect(legacy?.confidence).toBe('destructive')
+
+		// sessions: present live, absent in code → destructive drop.
+		const sessions = byName.get('sessions')
+		expect(sessions?.kind).toBe('removed')
+		expect(sessions?.confidence).toBe('destructive')
+
+		const migration = generateMigrationSql(diff, 'postgres', { from: live, to: parsed.ir })
+
+		// Default copy is safe: adds the column, never drops.
+		const safe = buildPreviewSql(migration.up, { includeDestructive: false, includeReview: false })
+		expect(safe).toContain('ADD COLUMN')
+		expect(safe).toContain('is_admin')
+		expect(safe).not.toContain('DROP COLUMN')
+		expect(safe).not.toContain('DROP TABLE')
+
+		// Destructive opt-in surfaces the drops.
+		const danger = buildPreviewSql(migration.up, { includeDestructive: true, includeReview: false })
+		expect(danger).toContain('DROP COLUMN')
+		expect(danger).toContain('legacy_views')
+		expect(danger).toContain('DROP TABLE')
+		expect(danger).toContain('sessions')
+	})
+
+	it('Prisma project: same drift surfaces equivalently', function () {
+		const parsed = parsePrismaSchema(PRISMA_SCHEMA)
+		expect(parsed.warnings).toEqual([])
+
+		const diff = diffSchema(live, parsed.ir)
+		expect(diff.hasChanges).toBe(true)
+
+		const byName = new Map(diff.tables.map((t) => [t.name, t]))
+		expect(byName.get('users')?.columns.find((c) => c.name === 'is_admin')?.kind).toBe('added')
+		expect(byName.get('posts')?.columns.find((c) => c.name === 'legacy_views')?.kind).toBe(
+			'removed',
+		)
+		expect(byName.get('sessions')?.kind).toBe('removed')
+
+		const migration = generateMigrationSql(diff, 'postgres', { from: live, to: parsed.ir })
+
+		const safe = buildPreviewSql(migration.up, { includeDestructive: false, includeReview: false })
+		expect(safe).toContain('is_admin')
+		expect(safe).not.toContain('DROP TABLE')
+		const danger = buildPreviewSql(migration.up, { includeDestructive: true, includeReview: false })
+		expect(danger).toContain('DROP TABLE')
+	})
+
+	it('identical schema → in sync, no spurious diff', function () {
+		// Build a live DB straight from the parsed Drizzle IR → zero drift.
+		const parsed = parseDrizzleSchema([{ path: 'schema.ts', text: DRIZZLE_SCHEMA }], 'postgres')
+		const diff = diffSchema(parsed.ir, parsed.ir)
+		expect(diff.hasChanges).toBe(false)
+		expect(diff.tables).toEqual([])
+	})
+})

--- a/__tests__/packages/studio/orm-cockpit/components/migration-sections.test.ts
+++ b/__tests__/packages/studio/orm-cockpit/components/migration-sections.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import type { ColumnIR, SchemaIR, TableIR } from '@studio/features/orm-cockpit/ir/types'
+import { diffSchema } from '@studio/features/orm-cockpit/diff/diff-schema'
+import { generateMigrationSql } from '@studio/features/orm-cockpit/migration/generate-sql'
+import {
+	buildPreviewSql,
+	migrationHasGatedSections,
+	splitMigrationSql,
+	DESTRUCTIVE_BANNER,
+	REVIEW_HEADER,
+} from '@studio/features/orm-cockpit/components/migration-sections'
+
+function col(name: string, type: ColumnIR['type'], nullable = false): ColumnIR {
+	return { name, type, rawType: type, nullable, default: null, autoIncrement: false }
+}
+
+function table(name: string, columns: ColumnIR[], primaryKey: string[] = []): TableIR {
+	return { name, columns, primaryKey, indexes: [], foreignKeys: [] }
+}
+
+function ir(tables: TableIR[]): SchemaIR {
+	return { dialect: 'postgres', tables }
+}
+
+describe('migration-sections (cockpit preview toggles)', function () {
+	it('round-trips the safe section out of a transaction-wrapped script', function () {
+		// live has `users(id)`, code adds a nullable column → purely additive/safe.
+		const live = ir([table('users', [col('id', 'int', false)], ['id'])])
+		const code = ir([
+			table('users', [col('id', 'int', false), col('nickname', 'text', true)], ['id']),
+		])
+		const diff = diffSchema(live, code)
+		const migration = generateMigrationSql(diff, 'postgres', { from: live, to: code })
+
+		const sections = splitMigrationSql(migration.up)
+		expect(sections.wrapped).toBe(true)
+		expect(sections.safe).toContain('ADD COLUMN')
+		expect(sections.destructive).toBe('')
+
+		const preview = buildPreviewSql(migration.up, {
+			includeDestructive: false,
+			includeReview: false,
+		})
+		expect(preview.startsWith('BEGIN;')).toBe(true)
+		expect(preview.trimEnd().endsWith('COMMIT;')).toBe(true)
+		expect(preview).toContain('ADD COLUMN')
+	})
+
+	it('gates destructive statements behind an explicit opt-in', function () {
+		// code drops the `email` column → destructive.
+		const live = ir([
+			table('users', [col('id', 'int', false), col('email', 'text', false)], ['id']),
+		])
+		const code = ir([table('users', [col('id', 'int', false)], ['id'])])
+		const diff = diffSchema(live, code)
+		const migration = generateMigrationSql(diff, 'postgres', { from: live, to: code })
+
+		const gated = migrationHasGatedSections(migration.up)
+		expect(gated.hasDestructive).toBe(true)
+
+		const withoutDestructive = buildPreviewSql(migration.up, {
+			includeDestructive: false,
+			includeReview: false,
+		})
+		expect(withoutDestructive).not.toContain('DROP COLUMN')
+		expect(withoutDestructive).not.toContain(DESTRUCTIVE_BANNER)
+
+		const withDestructive = buildPreviewSql(migration.up, {
+			includeDestructive: true,
+			includeReview: false,
+		})
+		expect(withDestructive).toContain('DROP COLUMN')
+		expect(withDestructive).toContain(DESTRUCTIVE_BANNER)
+	})
+
+	it('uncomments review statements only when opted in', function () {
+		// A type change Drizzle/diff treats as `review` (e.g. text → int is lossy).
+		const live = ir([table('t', [col('id', 'int', false), col('amount', 'text', false)], ['id'])])
+		const code = ir([table('t', [col('id', 'int', false), col('amount', 'int', false)], ['id'])])
+		const diff = diffSchema(live, code)
+		const migration = generateMigrationSql(diff, 'postgres', { from: live, to: code })
+
+		const sections = splitMigrationSql(migration.up)
+		// This particular change should land in review or destructive; assert the
+		// helper is consistent with whatever the generator decided.
+		if (sections.review) {
+			expect(migration.up).toContain(REVIEW_HEADER)
+			const off = buildPreviewSql(migration.up, {
+				includeDestructive: false,
+				includeReview: false,
+			})
+			// commented out by default — the bare ALTER must not appear uncommented.
+			expect(off).not.toMatch(/^\s*ALTER TABLE/m)
+
+			const on = buildPreviewSql(migration.up, {
+				includeDestructive: false,
+				includeReview: true,
+			})
+			expect(on).toMatch(/ALTER TABLE/)
+		}
+	})
+
+	it('returns the no-changes sentinel untouched', function () {
+		const preview = buildPreviewSql('-- No changes.', {
+			includeDestructive: false,
+			includeReview: false,
+		})
+		expect(preview).toBe('-- No changes.')
+	})
+})

--- a/packages/studio/src/features/app-sidebar/navigation-sidebar.tsx
+++ b/packages/studio/src/features/app-sidebar/navigation-sidebar.tsx
@@ -1,4 +1,4 @@
-import { SquareTerminal, Table2, Container, Network, Settings } from 'lucide-react'
+import { SquareTerminal, Table2, Container, Network, Settings, GitCompare } from 'lucide-react'
 import { useCallback, useRef, KeyboardEvent } from 'react'
 import { DoraLogo } from '@studio/components/dora-logo'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@studio/shared/ui/tooltip'
@@ -43,6 +43,12 @@ function SidebarContent({ activeNavId, onNavSelect, databasePanelToggle }: Conte
 			label: 'Schema',
 			icon: Network,
 			onClick: () => onNavSelect?.('schema-visualizer')
+		},
+		{
+			id: 'orm-cockpit',
+			label: 'ORM Cockpit',
+			icon: GitCompare,
+			onClick: () => onNavSelect?.('orm-cockpit')
 		},
 		{
 			id: 'docker',

--- a/packages/studio/src/features/orm-cockpit/components/drift-view.tsx
+++ b/packages/studio/src/features/orm-cockpit/components/drift-view.tsx
@@ -1,0 +1,221 @@
+/**
+ * Drift view — renders a {@link SchemaDiff} grouped by table. Each table and
+ * column carries a confidence chip (green `safe` / amber `review` / red
+ * `destructive`) so a glance communicates how risky reconciling the drift is.
+ *
+ * Direction is fixed by the hook: live DB = `from`, project code = `to`. So
+ * `added` = present in code, missing in the DB (needs creating); `removed` =
+ * present in the DB, gone from code (a drop). The header labels this explicitly
+ * so the user never has to guess which side is which.
+ */
+
+import { useState } from 'react'
+import { ChevronRight, Plus, Minus, Pencil } from 'lucide-react'
+import { Badge } from '@studio/shared/ui/badge'
+import { cn } from '@studio/shared/utils/cn'
+import type { ColumnIR } from '@studio/features/orm-cockpit/ir/types'
+import type {
+	ColumnDiff,
+	Confidence,
+	SchemaDiff,
+	TableDiff,
+} from '@studio/features/orm-cockpit/diff/types'
+
+type Props = {
+	diff: SchemaDiff
+}
+
+function confidenceClass(confidence: Confidence): string {
+	if (confidence === 'destructive') {
+		return 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300'
+	}
+	if (confidence === 'review') {
+		return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+	}
+	return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+}
+
+function ConfidenceChip({ confidence }: { confidence: Confidence }) {
+	return (
+		<Badge
+			variant='outline'
+			className={cn('h-5 px-1.5 text-[10px] font-medium capitalize', confidenceClass(confidence))}
+		>
+			{confidence}
+		</Badge>
+	)
+}
+
+function kindIcon(kind: 'added' | 'removed' | 'changed') {
+	if (kind === 'added') return <Plus className='h-3.5 w-3.5 text-emerald-500' />
+	if (kind === 'removed') return <Minus className='h-3.5 w-3.5 text-red-500' />
+	return <Pencil className='h-3.5 w-3.5 text-amber-500' />
+}
+
+/** Human label for the direction of a change (code is the source of truth). */
+function kindVerb(kind: 'added' | 'removed' | 'changed'): string {
+	if (kind === 'added') return 'create in DB'
+	if (kind === 'removed') return 'drop from DB'
+	return 'alter'
+}
+
+function columnSummary(col: ColumnIR): string {
+	const bits: string[] = [col.type]
+	if (col.rawType && col.rawType !== col.type) bits.push(`(${col.rawType})`)
+	bits.push(col.nullable ? 'null' : 'not null')
+	if (col.default !== null) bits.push(`default ${col.default}`)
+	if (col.autoIncrement) bits.push('auto-increment')
+	return bits.join(' · ')
+}
+
+function ColumnRow({ col }: { col: ColumnDiff }) {
+	return (
+		<div className='flex items-start gap-2 px-3 py-1.5 text-xs'>
+			<span className='mt-0.5 shrink-0'>{kindIcon(col.kind)}</span>
+			<div className='min-w-0 flex-1'>
+				<div className='flex items-center gap-2'>
+					<span className='font-mono font-medium text-foreground'>{col.name}</span>
+					<span className='text-muted-foreground'>{kindVerb(col.kind)}</span>
+					{col.changedFields && col.changedFields.length > 0 ? (
+						<span className='text-muted-foreground/80'>
+							({col.changedFields.join(', ')})
+						</span>
+					) : null}
+				</div>
+				{col.kind === 'changed' && col.before && col.after ? (
+					<div className='mt-0.5 space-y-0.5 font-mono text-[11px]'>
+						<div className='text-red-600/90 dark:text-red-400/90'>
+							- {columnSummary(col.before)}
+						</div>
+						<div className='text-emerald-600/90 dark:text-emerald-400/90'>
+							+ {columnSummary(col.after)}
+						</div>
+					</div>
+				) : (
+					<div className='mt-0.5 font-mono text-[11px] text-muted-foreground'>
+						{columnSummary(col.after ?? col.before ?? ({} as ColumnIR))}
+					</div>
+				)}
+			</div>
+			<ConfidenceChip confidence={col.confidence} />
+		</div>
+	)
+}
+
+function TableCard({ table }: { table: TableDiff }) {
+	const [open, setOpen] = useState(table.confidence === 'destructive')
+	const changeCount =
+		table.columns.length + table.indexes.length + table.foreignKeys.length
+	const detail =
+		table.kind === 'added'
+			? 'new table'
+			: table.kind === 'removed'
+				? 'dropped table'
+				: `${changeCount} change${changeCount === 1 ? '' : 's'}`
+
+	return (
+		<div className='overflow-hidden rounded-md border border-border/60 bg-card/40'>
+			<button
+				type='button'
+				onClick={function () {
+					setOpen(function (v) {
+						return !v
+					})
+				}}
+				className='flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted/40'
+				aria-expanded={open}
+			>
+				<ChevronRight
+					className={cn(
+						'h-4 w-4 shrink-0 text-muted-foreground transition-transform',
+						open && 'rotate-90',
+					)}
+				/>
+				{kindIcon(table.kind)}
+				<span className='font-mono text-sm font-medium text-foreground'>{table.name}</span>
+				<span className='text-xs text-muted-foreground'>{detail}</span>
+				<span className='ml-auto'>
+					<ConfidenceChip confidence={table.confidence} />
+				</span>
+			</button>
+
+			{open ? (
+				<div className='border-t border-border/50 divide-y divide-border/30'>
+					{table.columns.length === 0 &&
+					table.indexes.length === 0 &&
+					table.foreignKeys.length === 0 ? (
+						<div className='px-3 py-2 text-xs text-muted-foreground'>
+							{table.kind === 'added'
+								? 'Whole table is new — see the migration preview for the full CREATE.'
+								: table.kind === 'removed'
+									? 'Whole table would be dropped.'
+									: 'No column-level changes.'}
+						</div>
+					) : null}
+					{table.columns.map(function (col) {
+						return <ColumnRow key={col.name} col={col} />
+					})}
+					{table.indexes.map(function (idx, i) {
+						const ref = idx.after ?? idx.before
+						return (
+							<div
+								key={`idx-${i}`}
+								className='flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground'
+							>
+								{kindIcon(idx.kind)}
+								<span className='font-mono'>index {ref?.name ?? ''}</span>
+								<span>({(ref?.columns ?? []).join(', ')})</span>
+							</div>
+						)
+					})}
+					{table.foreignKeys.map(function (fk, i) {
+						const ref = fk.after ?? fk.before
+						return (
+							<div
+								key={`fk-${i}`}
+								className='flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground'
+							>
+								{kindIcon(fk.kind)}
+								<span className='font-mono'>
+									fk → {ref?.refTable ?? ''} ({(ref?.columns ?? []).join(', ')})
+								</span>
+							</div>
+						)
+					})}
+				</div>
+			) : null}
+		</div>
+	)
+}
+
+export function DriftView({ diff }: Props) {
+	const destructiveCount = diff.tables.filter(function (t) {
+		return t.confidence === 'destructive'
+	}).length
+
+	return (
+		<div className='space-y-2'>
+			<div className='flex items-center gap-2 text-xs text-muted-foreground'>
+				<span className='font-medium text-foreground'>
+					{diff.tables.length} table{diff.tables.length === 1 ? '' : 's'} differ
+				</span>
+				{destructiveCount > 0 ? (
+					<>
+						<span>·</span>
+						<span className='text-red-600 dark:text-red-400'>
+							{destructiveCount} destructive
+						</span>
+					</>
+				) : null}
+				<span className='ml-auto'>
+					Comparing <span className='text-foreground'>live DB</span> → project code
+				</span>
+			</div>
+			<div className='space-y-2'>
+				{diff.tables.map(function (table) {
+					return <TableCard key={table.name} table={table} />
+				})}
+			</div>
+		</div>
+	)
+}

--- a/packages/studio/src/features/orm-cockpit/components/migration-preview.tsx
+++ b/packages/studio/src/features/orm-cockpit/components/migration-preview.tsx
@@ -1,0 +1,136 @@
+/**
+ * Migration preview — shows the SQL generated from the current diff and hands it
+ * off. v1 is preview-only (plan 06): nothing is applied here. The copy/console
+ * actions emit exactly what's shown, and destructive/review statements are
+ * gated behind explicit opt-in toggles (default off) so a careless copy can't
+ * drop data.
+ */
+
+import { useMemo, useState } from 'react'
+import { Copy, Check, TerminalSquare, AlertTriangle } from 'lucide-react'
+import { Button } from '@studio/shared/ui/button'
+import { Checkbox } from '@studio/shared/ui/checkbox'
+import { toast } from '@studio/shared/ui/notifier'
+import { cn } from '@studio/shared/utils/cn'
+import type { MigrationResult } from '@studio/features/orm-cockpit/migration/generate-sql'
+import {
+	buildPreviewSql,
+	migrationHasGatedSections,
+} from '@studio/features/orm-cockpit/components/migration-sections'
+
+type Props = {
+	migration: MigrationResult
+	/** Hand the generated SQL to the SQL console (preview → run there). */
+	onOpenInSqlConsole?: (sql: string) => void
+}
+
+export function MigrationPreview({ migration, onOpenInSqlConsole }: Props) {
+	const [includeDestructive, setIncludeDestructive] = useState(false)
+	const [includeReview, setIncludeReview] = useState(false)
+	const [copied, setCopied] = useState(false)
+
+	const gated = useMemo(
+		function () {
+			return migrationHasGatedSections(migration.up)
+		},
+		[migration.up],
+	)
+
+	const sql = useMemo(
+		function () {
+			return buildPreviewSql(migration.up, { includeDestructive, includeReview })
+		},
+		[migration.up, includeDestructive, includeReview],
+	)
+
+	async function handleCopy() {
+		try {
+			await navigator.clipboard.writeText(sql)
+			setCopied(true)
+			window.setTimeout(function () {
+				setCopied(false)
+			}, 1500)
+		} catch {
+			toast.error('Could not copy to clipboard')
+		}
+	}
+
+	return (
+		<div className='flex h-full flex-col'>
+			<div className='flex flex-wrap items-center gap-2 border-b border-border/60 px-3 py-2'>
+				<span className='text-xs font-medium text-muted-foreground'>
+					Generated SQL — review and run in the SQL console
+				</span>
+				<div className='ml-auto flex items-center gap-1'>
+					<Button
+						variant='ghost'
+						size='sm'
+						className='h-7 gap-1.5 text-xs'
+						onClick={handleCopy}
+					>
+						{copied ? (
+							<Check className='h-3.5 w-3.5 text-emerald-500' />
+						) : (
+							<Copy className='h-3.5 w-3.5' />
+						)}
+						{copied ? 'Copied' : 'Copy'}
+					</Button>
+					{onOpenInSqlConsole ? (
+						<Button
+							variant='outline'
+							size='sm'
+							className='h-7 gap-1.5 text-xs'
+							onClick={function () {
+								onOpenInSqlConsole(sql)
+							}}
+						>
+							<TerminalSquare className='h-3.5 w-3.5' />
+							Open in SQL console
+						</Button>
+					) : null}
+				</div>
+			</div>
+
+			{(gated.hasDestructive || gated.hasReview) && (
+				<div className='flex flex-wrap items-center gap-4 border-b border-border/60 bg-muted/30 px-3 py-2'>
+					{gated.hasReview ? (
+						<label className='flex cursor-pointer items-center gap-2 text-xs text-foreground'>
+							<Checkbox
+								checked={includeReview}
+								onCheckedChange={function (v) {
+									setIncludeReview(v === true)
+								}}
+							/>
+							Include review statements
+						</label>
+					) : null}
+					{gated.hasDestructive ? (
+						<label className='flex cursor-pointer items-center gap-2 text-xs'>
+							<Checkbox
+								checked={includeDestructive}
+								onCheckedChange={function (v) {
+									setIncludeDestructive(v === true)
+								}}
+							/>
+							<span
+								className={cn(
+									'flex items-center gap-1 font-medium',
+									includeDestructive
+										? 'text-red-600 dark:text-red-400'
+										: 'text-muted-foreground',
+								)}
+							>
+								<AlertTriangle className='h-3.5 w-3.5' />
+								Include destructive statements
+							</span>
+						</label>
+					) : null}
+				</div>
+			)}
+
+			<pre className='flex-1 overflow-auto whitespace-pre bg-background p-3 font-mono text-xs leading-relaxed text-foreground'>
+				{sql}
+			</pre>
+		</div>
+	)
+}

--- a/packages/studio/src/features/orm-cockpit/components/migration-sections.ts
+++ b/packages/studio/src/features/orm-cockpit/components/migration-sections.ts
@@ -1,0 +1,134 @@
+/**
+ * Pure helpers that re-derive what the cockpit actually copies from the single
+ * `up` string `generateMigrationSql` returns (plan 06). The generator always
+ * emits a safe-by-default script: destructive ops live under a banner, review
+ * ops are commented out. The cockpit makes including either an explicit,
+ * deliberate toggle, so we split the script back into sections and reassemble
+ * only the parts the user opted into.
+ *
+ * The split keys off the two stable marker strings the generator writes. If
+ * those banners ever change, update the constants here in lockstep (the unit
+ * tests pin the round-trip).
+ */
+
+/** Must match `DESTRUCTIVE_BANNER` in `migration/generate-sql.ts`. */
+export const DESTRUCTIVE_BANNER =
+	'-- ⚠ DESTRUCTIVE: drops or rewrites data — review before running'
+
+/** Must match the review header in `migration/generate-sql.ts` `renderUp`. */
+export const REVIEW_HEADER =
+	'-- The following changes need review and are commented out. Enable them deliberately.'
+
+export type MigrationSections = {
+	/** `true` when the script is transaction-wrapped (postgres). */
+	wrapped: boolean
+	/** Creates + additive ALTERs — always safe to apply. */
+	safe: string
+	/** Destructive block (banner + statements), or '' when none. */
+	destructive: string
+	/** Review block (header + commented statements), or '' when none. */
+	review: string
+}
+
+function stripWrapper(up: string): { wrapped: boolean; body: string } {
+	const trimmed = up.trim()
+	if (trimmed.startsWith('BEGIN;') && trimmed.endsWith('COMMIT;')) {
+		const body = trimmed.slice('BEGIN;'.length, trimmed.length - 'COMMIT;'.length).trim()
+		return { wrapped: true, body }
+	}
+	return { wrapped: false, body: trimmed }
+}
+
+/** Split a generated `up` script into its safe / destructive / review sections. */
+export function splitMigrationSql(up: string): MigrationSections {
+	const { wrapped, body } = stripWrapper(up)
+
+	const destructiveIdx = body.indexOf(DESTRUCTIVE_BANNER)
+	const reviewIdx = body.indexOf(REVIEW_HEADER)
+
+	// The safe section runs up to the first marker present (if any).
+	const markerIdxs = [destructiveIdx, reviewIdx].filter((i) => i >= 0)
+	const safeEnd = markerIdxs.length > 0 ? Math.min(...markerIdxs) : body.length
+	const safe = body.slice(0, safeEnd).trim()
+
+	let destructive = ''
+	if (destructiveIdx >= 0) {
+		const end = reviewIdx > destructiveIdx ? reviewIdx : body.length
+		destructive = body.slice(destructiveIdx, end).trim()
+	}
+
+	let review = ''
+	if (reviewIdx >= 0) {
+		review = body.slice(reviewIdx).trim()
+	}
+
+	return { wrapped, safe, destructive, review }
+}
+
+/** Uncomment a review block so its statements become runnable SQL. */
+function uncommentReview(review: string): string {
+	const lines = review.split('\n')
+	const out: string[] = []
+	for (const line of lines) {
+		if (line === REVIEW_HEADER) {
+			out.push('-- Review changes (enabled below):')
+			continue
+		}
+		if (line.startsWith('-- REVIEW:')) {
+			// Keep the reason as an annotation comment.
+			out.push(line)
+			continue
+		}
+		if (line.startsWith('-- ')) {
+			out.push(line.slice('-- '.length))
+			continue
+		}
+		out.push(line)
+	}
+	return out.join('\n').trim()
+}
+
+export type PreviewOptions = {
+	includeDestructive: boolean
+	includeReview: boolean
+}
+
+/**
+ * Build the exact SQL the cockpit will display *and* copy, honoring the
+ * destructive/review opt-ins. Display and clipboard use the same text so what
+ * the user sees is what they run.
+ */
+export function buildPreviewSql(up: string, options: PreviewOptions): string {
+	const sections = splitMigrationSql(up)
+	const blocks: string[] = []
+
+	if (sections.safe && sections.safe !== '-- No changes.') {
+		blocks.push(sections.safe)
+	}
+	if (options.includeDestructive && sections.destructive) {
+		blocks.push(sections.destructive)
+	}
+	if (options.includeReview && sections.review) {
+		blocks.push(uncommentReview(sections.review))
+	}
+
+	if (blocks.length === 0) {
+		// Everything is gated off (or there were no safe changes at all).
+		return sections.safe || '-- No changes selected.'
+	}
+
+	const body = blocks.join('\n\n')
+	return sections.wrapped ? `BEGIN;\n\n${body}\n\nCOMMIT;` : body
+}
+
+/** Whether the script carries destructive / review sections at all. */
+export function migrationHasGatedSections(up: string): {
+	hasDestructive: boolean
+	hasReview: boolean
+} {
+	const sections = splitMigrationSql(up)
+	return {
+		hasDestructive: sections.destructive.length > 0,
+		hasReview: sections.review.length > 0,
+	}
+}

--- a/packages/studio/src/features/orm-cockpit/components/orm-cockpit-panel.tsx
+++ b/packages/studio/src/features/orm-cockpit/components/orm-cockpit-panel.tsx
@@ -1,0 +1,286 @@
+/**
+ * ORM cockpit — link a project folder, see how its schema drifts from the live
+ * database, and preview a migration that reconciles the two. Preview-only (plan
+ * 06/07): nothing is applied from here; the generated SQL is handed off to the
+ * SQL console where the normal prod-safety guardrails apply.
+ *
+ * This component is surface only — all orchestration lives in `useOrmCockpit`.
+ */
+
+import { useEffect, useState } from 'react'
+import {
+	FolderGit2,
+	Loader2,
+	RefreshCw,
+	Database,
+	ChevronDown,
+	Wand2,
+	AlertCircle,
+} from 'lucide-react'
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
+import { Button } from '@studio/shared/ui/button'
+import { EmptyState } from '@studio/shared/ui/empty-state'
+import { cn } from '@studio/shared/utils/cn'
+import type { MigrationResult } from '@studio/features/orm-cockpit/migration/generate-sql'
+import { useOrmCockpit } from '@studio/features/orm-cockpit/components/use-orm-cockpit'
+import { DriftView } from '@studio/features/orm-cockpit/components/drift-view'
+import { MigrationPreview } from '@studio/features/orm-cockpit/components/migration-preview'
+
+type Props = {
+	activeConnectionId: string | undefined
+	/** Hand generated SQL to the SQL console (Index wires this to nav + event). */
+	onOpenInSqlConsole?: (sql: string) => void
+	/** Window controls slot, rendered in the header (matches other full views). */
+	windowControls?: React.ReactNode
+}
+
+function shortFolder(path: string): string {
+	const parts = path.replace(/\/+$/, '').split('/')
+	return parts.slice(-2).join('/') || path
+}
+
+export function OrmCockpitPanel({
+	activeConnectionId,
+	onOpenInSqlConsole,
+	windowControls,
+}: Props) {
+	const cockpit = useOrmCockpit(activeConnectionId)
+	const [migration, setMigration] = useState<MigrationResult | null>(null)
+	const [notesOpen, setNotesOpen] = useState(false)
+
+	const busy = cockpit.phase === 'linking' || cockpit.phase === 'analyzing'
+
+	function handleGenerate() {
+		const result = cockpit.generate()
+		setMigration(result)
+	}
+
+	// Clear a stale preview whenever the diff changes underneath it.
+	useEffect(
+		function () {
+			setMigration(null)
+		},
+		[cockpit.diff],
+	)
+
+	return (
+		<div className='flex h-full w-full flex-col bg-background text-sm'>
+			<header className='flex h-10 shrink-0 items-center justify-between border-b border-sidebar-border bg-sidebar px-2'>
+				<div className='flex items-center gap-2 px-2'>
+					<Database className='h-4 w-4 text-muted-foreground' />
+					<span className='font-semibold text-sidebar-foreground'>ORM Cockpit</span>
+					{cockpit.linked ? (
+						<span className='flex items-center gap-1 text-xs text-muted-foreground'>
+							<span className='capitalize'>{cockpit.linked.orm}</span>
+							<span>·</span>
+							<span className='font-mono' title={cockpit.linked.folder}>
+								{shortFolder(cockpit.linked.folder)}
+							</span>
+						</span>
+					) : null}
+				</div>
+				<div className='flex items-center gap-1'>
+					{cockpit.linked ? (
+						<Button
+							variant='ghost'
+							size='sm'
+							className='h-7 gap-1.5 text-xs'
+							onClick={cockpit.rescan}
+							disabled={busy}
+						>
+							<RefreshCw className={cn('h-3.5 w-3.5', busy && 'animate-spin')} />
+							Refresh
+						</Button>
+					) : null}
+					<Button
+						variant='outline'
+						size='sm'
+						className='h-7 gap-1.5 text-xs'
+						onClick={cockpit.link}
+						disabled={busy}
+					>
+						<FolderGit2 className='h-3.5 w-3.5' />
+						{cockpit.linked ? 'Link different folder' : 'Link project'}
+					</Button>
+					{windowControls}
+				</div>
+			</header>
+
+			<div className='min-h-0 flex-1'>
+				{renderBody()}
+			</div>
+		</div>
+	)
+
+	function renderBody() {
+		if (!activeConnectionId) {
+			return (
+				<EmptyState
+					icon={<Database className='h-10 w-10' />}
+					title='No database connection'
+					description='Select a connection to compare a linked project against its live schema.'
+				/>
+			)
+		}
+
+		if (busy && !cockpit.diff) {
+			return (
+				<div className='flex h-full flex-col items-center justify-center gap-3 text-muted-foreground'>
+					<Loader2 className='h-6 w-6 animate-spin' />
+					<span className='text-sm'>
+						{cockpit.phase === 'linking' ? 'Detecting project…' : 'Analyzing schema drift…'}
+					</span>
+				</div>
+			)
+		}
+
+		if (cockpit.phase === 'choice' && cockpit.choices) {
+			return (
+				<div className='mx-auto flex max-w-md flex-col gap-3 p-8'>
+					<h3 className='text-base font-medium text-foreground'>
+						This project has both Drizzle and Prisma
+					</h3>
+					<p className='text-sm text-muted-foreground'>
+						Pick which schema to compare against the live database.
+					</p>
+					{cockpit.choices.map(function (option) {
+						return (
+							<Button
+								key={option.orm}
+								variant='outline'
+								className='justify-start capitalize'
+								onClick={function () {
+									void cockpit.chooseOrm(option)
+								}}
+							>
+								<FolderGit2 className='mr-2 h-4 w-4' />
+								{option.orm}
+								<span className='ml-2 text-xs text-muted-foreground'>
+									{option.schemaFiles.length} file
+									{option.schemaFiles.length === 1 ? '' : 's'}
+								</span>
+							</Button>
+						)
+					})}
+				</div>
+			)
+		}
+
+		if (cockpit.phase === 'error' && cockpit.error) {
+			return (
+				<EmptyState
+					icon={<AlertCircle className='h-10 w-10 text-red-500' />}
+					title='Could not analyze the project'
+					description={cockpit.error}
+					action={{ label: 'Link a project', onClick: cockpit.link }}
+				/>
+			)
+		}
+
+		if (!cockpit.linked || !cockpit.diff) {
+			return (
+				<EmptyState
+					icon={<FolderGit2 className='h-10 w-10' />}
+					title='Link a project folder'
+					description='Compare a Drizzle or Prisma project’s schema with this database to detect drift and preview a migration.'
+					action={{ label: 'Link project', onClick: cockpit.link }}
+				/>
+			)
+		}
+
+		if (!cockpit.diff.hasChanges) {
+			return (
+				<div className='flex h-full flex-col'>
+					{renderNotes()}
+					<EmptyState
+						icon={<Database className='h-10 w-10 text-emerald-500' />}
+						title='In sync'
+						description='The linked project’s schema matches the live database. No migration needed.'
+					/>
+				</div>
+			)
+		}
+
+		return (
+			<div className='flex h-full flex-col'>
+				{renderNotes()}
+				<PanelGroup direction='horizontal' className='flex-1'>
+					<Panel defaultSize={50} minSize={30}>
+						<div className='flex h-full flex-col'>
+							<div className='flex items-center justify-between border-b border-border/60 px-3 py-2'>
+								<span className='text-xs font-medium text-muted-foreground'>
+									Schema drift
+								</span>
+								<Button
+									size='sm'
+									className='h-7 gap-1.5 bg-emerald-600 text-xs text-white hover:bg-emerald-700'
+									onClick={handleGenerate}
+								>
+									<Wand2 className='h-3.5 w-3.5' />
+									Generate migration
+								</Button>
+							</div>
+							<div className='min-h-0 flex-1 overflow-auto p-3'>
+								<DriftView diff={cockpit.diff} />
+							</div>
+						</div>
+					</Panel>
+					<PanelResizeHandle className='w-1 bg-sidebar-border hover:bg-primary/20' />
+					<Panel defaultSize={50} minSize={30}>
+						{migration ? (
+							<MigrationPreview
+								migration={migration}
+								onOpenInSqlConsole={onOpenInSqlConsole}
+							/>
+						) : (
+							<EmptyState
+								icon={<Wand2 className='h-8 w-8' />}
+								title='No migration generated yet'
+								description='Generate a migration from the drift on the left to preview the SQL.'
+							/>
+						)}
+					</Panel>
+				</PanelGroup>
+			</div>
+		)
+	}
+
+	function renderNotes() {
+		if (cockpit.notes.length === 0) return null
+		return (
+			<div className='border-b border-amber-500/30 bg-amber-500/5'>
+				<button
+					type='button'
+					onClick={function () {
+						setNotesOpen(function (v) {
+							return !v
+						})
+					}}
+					className='flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-amber-700 hover:bg-amber-500/10 dark:text-amber-300'
+					aria-expanded={notesOpen}
+				>
+					<ChevronDown
+						className={cn('h-3.5 w-3.5 transition-transform', !notesOpen && '-rotate-90')}
+					/>
+					<AlertCircle className='h-3.5 w-3.5' />
+					{cockpit.notes.length} note{cockpit.notes.length === 1 ? '' : 's'} from parse / diff /
+					generate
+				</button>
+				{notesOpen ? (
+					<ul className='max-h-40 overflow-auto px-3 pb-2 text-xs text-muted-foreground'>
+						{cockpit.notes.map(function (note, i) {
+							return (
+								<li key={i} className='flex gap-2 py-0.5'>
+									<span className='shrink-0 font-mono uppercase text-[10px] text-amber-600/80 dark:text-amber-400/80'>
+										{note.source}
+									</span>
+									<span className='min-w-0'>{note.message}</span>
+								</li>
+							)
+						})}
+					</ul>
+				) : null}
+			</div>
+		)
+	}
+}

--- a/packages/studio/src/features/orm-cockpit/components/use-orm-cockpit.ts
+++ b/packages/studio/src/features/orm-cockpit/components/use-orm-cockpit.ts
@@ -1,0 +1,412 @@
+/**
+ * Orchestration hook for the ORM cockpit (Wave D, plan 07). Ties the Wave A–C
+ * pieces together — link → parse → introspect → diff → generate — and exposes a
+ * small phase-driven state machine the panel renders against.
+ *
+ * Direction matters: the LIVE database is the `from` side and the project's
+ * code schema is the `to` side, so "added in code" reads as "needs creating in
+ * the DB". The generated migration is preview-only (plan 06) — this hook never
+ * applies anything.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useAdapter, useConnections } from '@studio/core/data-provider'
+import { commands } from '@studio/lib/bindings'
+import type { DatabaseType } from '@studio/features/connections/types'
+import type { Dialect, SchemaIR } from '@studio/features/orm-cockpit/ir/types'
+import { fromLiveSchema } from '@studio/features/orm-cockpit/ir/from-live-schema'
+import {
+	linkProject,
+	detectProjectOrm,
+} from '@studio/features/orm-cockpit/link/link-api'
+import type {
+	DetectedOrm,
+	DetectOrmResult,
+	OrmLink,
+} from '@studio/features/orm-cockpit/link/detect-orm'
+import { parseDrizzleSchema } from '@studio/features/orm-cockpit/parsers/drizzle/parse-drizzle-schema'
+import { parsePrismaSchema } from '@studio/features/orm-cockpit/parsers/prisma/parse-prisma-schema'
+import { diffSchema } from '@studio/features/orm-cockpit/diff/diff-schema'
+import type { SchemaDiff } from '@studio/features/orm-cockpit/diff/types'
+import {
+	generateMigrationSql,
+	type MigrationResult,
+} from '@studio/features/orm-cockpit/migration/generate-sql'
+
+/** Map the connection's engine onto the small IR dialect set. */
+export function deriveDialect(type: DatabaseType | undefined): Dialect {
+	if (type === 'mysql' || type === 'mariadb') return 'mysql'
+	if (type === 'sqlite' || type === 'libsql' || type === 'duckdb') return 'sqlite'
+	return 'postgres'
+}
+
+/** A note surfaced in the collapsible "notes" area, tagged by its source phase. */
+export type CockpitNote = { source: 'parse' | 'diff' | 'generate'; message: string }
+
+export type CockpitPhase =
+	| 'idle' // no folder linked yet
+	| 'linking' // folder picker open / detecting ORM
+	| 'choice' // both Drizzle and Prisma detected — user must pick
+	| 'analyzing' // parsing + introspecting + diffing
+	| 'ready' // diff computed
+	| 'error'
+
+type LinkedState = {
+	folder: string
+	orm: DetectedOrm
+	link: OrmLink
+}
+
+export type OrmCockpitState = {
+	phase: CockpitPhase
+	error: string | null
+	linked: LinkedState | null
+	/** Both options when detection is ambiguous (`choice`). */
+	choices: OrmLink[] | null
+	choiceFolder: string | null
+	codeIr: SchemaIR | null
+	liveIr: SchemaIR | null
+	diff: SchemaDiff | null
+	notes: CockpitNote[]
+	dialect: Dialect
+	/** A connection must be selected before we can introspect the live DB. */
+	hasConnection: boolean
+}
+
+const SETTING_PREFIX = 'orm-cockpit:last-folder:'
+
+export type UseOrmCockpit = OrmCockpitState & {
+	/** Open the folder picker and analyze whatever ORM is found. */
+	link: () => Promise<void>
+	/** Re-run analysis against the already-linked folder (Refresh). */
+	rescan: () => Promise<void>
+	/** Resolve a `choice` by committing to one detected ORM. */
+	chooseOrm: (link: OrmLink) => Promise<void>
+	/** Generate migration SQL from the current diff on demand. */
+	generate: () => MigrationResult | null
+	reset: () => void
+}
+
+/**
+ * @param connectionId the active DB connection — drives both introspection and
+ *   the per-connection persistence of the last-linked folder.
+ */
+export function useOrmCockpit(connectionId: string | undefined): UseOrmCockpit {
+	const adapter = useAdapter()
+	const { data: connections } = useConnections()
+
+	const dialect = useMemo(
+		function () {
+			const connection = connections?.find(function (c) {
+				return c.id === connectionId
+			})
+			return deriveDialect(connection?.type)
+		},
+		[connections, connectionId],
+	)
+
+	const [state, setState] = useState<OrmCockpitState>(function () {
+		return {
+			phase: 'idle',
+			error: null,
+			linked: null,
+			choices: null,
+			choiceFolder: null,
+			codeIr: null,
+			liveIr: null,
+			diff: null,
+			notes: [],
+			dialect,
+			hasConnection: Boolean(connectionId),
+		}
+	})
+
+	// Guards against a stale async chain (e.g. user re-links mid-analysis)
+	// committing its result over a newer one.
+	const runIdRef = useRef(0)
+
+	useEffect(
+		function () {
+			setState(function (prev) {
+				return { ...prev, dialect, hasConnection: Boolean(connectionId) }
+			})
+		},
+		[dialect, connectionId],
+	)
+
+	/** Introspect the live DB → IR. Returns null and reports via notes on failure. */
+	const introspectLive = useCallback(
+		async function (): Promise<SchemaIR | null> {
+			if (!connectionId) return null
+			const result = await adapter.getSchema(connectionId)
+			if (!result.ok || !result.data) return null
+			return fromLiveSchema(result.data, dialect)
+		},
+		[adapter, connectionId, dialect],
+	)
+
+	/** Parse a linked project's schema files into a code-side IR. */
+	const parseLink = useCallback(
+		function (link: OrmLink): { ir: SchemaIR; warnings: string[] } {
+			if (link.orm === 'drizzle') {
+				return parseDrizzleSchema(link.schemaFiles, dialect)
+			}
+			// Prisma is single-text; concatenate multi-file schemas. It derives its
+			// own dialect from the datasource block.
+			const text = link.schemaFiles.map((f) => f.text).join('\n\n')
+			return parsePrismaSchema(text)
+		},
+		[dialect],
+	)
+
+	/** The full analyze chain: parse code → introspect live → diff. */
+	const analyze = useCallback(
+		async function (folder: string, link: OrmLink, runId: number) {
+			const parsed = parseLink(link)
+			const liveIr = await introspectLive()
+
+			if (runId !== runIdRef.current) return
+
+			if (!liveIr) {
+				setState(function (prev) {
+					return {
+						...prev,
+						phase: 'error',
+						error: connectionId
+							? 'Could not read the live database schema. Make sure the connection is reachable, then Refresh.'
+							: 'Select a database connection to compare against.',
+						linked: { folder, orm: link.orm, link },
+						choices: null,
+						choiceFolder: null,
+					}
+				})
+				return
+			}
+
+			const diff = diffSchema(liveIr, parsed.ir)
+			const notes: CockpitNote[] = [
+				...parsed.warnings.map(function (m): CockpitNote {
+					return { source: 'parse', message: m }
+				}),
+			]
+
+			setState(function (prev) {
+				return {
+					...prev,
+					phase: 'ready',
+					error: null,
+					linked: { folder, orm: link.orm, link },
+					choices: null,
+					choiceFolder: null,
+					codeIr: parsed.ir,
+					liveIr,
+					diff,
+					notes,
+				}
+			})
+
+			// Persist the linked folder for this connection (best-effort).
+			if (connectionId) {
+				void commands.setSetting(SETTING_PREFIX + connectionId, folder).catch(function () {})
+			}
+		},
+		[parseLink, introspectLive, connectionId],
+	)
+
+	const startFromDetect = useCallback(
+		async function (folder: string, result: DetectOrmResult, runId: number) {
+			if (result.kind === 'none') {
+				setState(function (prev) {
+					return { ...prev, phase: 'error', error: result.message }
+				})
+				return
+			}
+			if (result.kind === 'choice') {
+				setState(function (prev) {
+					return {
+						...prev,
+						phase: 'choice',
+						error: null,
+						choices: result.options,
+						choiceFolder: folder,
+					}
+				})
+				return
+			}
+			setState(function (prev) {
+				return { ...prev, phase: 'analyzing', error: null }
+			})
+			await analyze(folder, result.link, runId)
+		},
+		[analyze],
+	)
+
+	const link = useCallback(
+		async function () {
+			const runId = ++runIdRef.current
+			setState(function (prev) {
+				return { ...prev, phase: 'linking', error: null }
+			})
+			let picked: { folder: string; result: DetectOrmResult } | null
+			try {
+				picked = await linkProject()
+			} catch (error) {
+				if (runId !== runIdRef.current) return
+				setState(function (prev) {
+					return {
+						...prev,
+						phase: 'error',
+						error: error instanceof Error ? error.message : 'Failed to open the folder picker.',
+					}
+				})
+				return
+			}
+			if (runId !== runIdRef.current) return
+			if (!picked) {
+				// User cancelled the picker — return to wherever we were.
+				setState(function (prev) {
+					return { ...prev, phase: prev.linked ? 'ready' : 'idle' }
+				})
+				return
+			}
+			await startFromDetect(picked.folder, picked.result, runId)
+		},
+		[startFromDetect],
+	)
+
+	const rescan = useCallback(
+		async function () {
+			const folder = state.linked?.folder ?? state.choiceFolder
+			if (!folder) return
+			const runId = ++runIdRef.current
+			setState(function (prev) {
+				return { ...prev, phase: 'linking', error: null }
+			})
+			let result: DetectOrmResult
+			try {
+				result = await detectProjectOrm(folder)
+			} catch (error) {
+				if (runId !== runIdRef.current) return
+				setState(function (prev) {
+					return {
+						...prev,
+						phase: 'error',
+						error: error instanceof Error ? error.message : 'Failed to re-scan the project.',
+					}
+				})
+				return
+			}
+			if (runId !== runIdRef.current) return
+			await startFromDetect(folder, result, runId)
+		},
+		[state.linked, state.choiceFolder, startFromDetect],
+	)
+
+	const chooseOrm = useCallback(
+		async function (chosen: OrmLink) {
+			const folder = state.choiceFolder
+			if (!folder) return
+			const runId = ++runIdRef.current
+			setState(function (prev) {
+				return { ...prev, phase: 'analyzing', error: null }
+			})
+			await analyze(folder, chosen, runId)
+		},
+		[state.choiceFolder, analyze],
+	)
+
+	const generate = useCallback(
+		function (): MigrationResult | null {
+			if (!state.diff) return null
+			const result = generateMigrationSql(state.diff, state.dialect, {
+				from: state.liveIr ?? undefined,
+				to: state.codeIr ?? undefined,
+			})
+			// Fold generator warnings into the notes area, deduped against existing.
+			if (result.warnings.length > 0) {
+				setState(function (prev) {
+					const existing = new Set(
+						prev.notes.filter((n) => n.source === 'generate').map((n) => n.message),
+					)
+					const fresh = result.warnings
+						.filter((m) => !existing.has(m))
+						.map(function (m): CockpitNote {
+							return { source: 'generate', message: m }
+						})
+					return fresh.length > 0 ? { ...prev, notes: [...prev.notes, ...fresh] } : prev
+				})
+			}
+			return result
+		},
+		[state.diff, state.dialect, state.liveIr, state.codeIr],
+	)
+
+	const reset = useCallback(function () {
+		runIdRef.current++
+		setState(function (prev) {
+			return {
+				...prev,
+				phase: 'idle',
+				error: null,
+				linked: null,
+				choices: null,
+				choiceFolder: null,
+				codeIr: null,
+				liveIr: null,
+				diff: null,
+				notes: [],
+			}
+		})
+	}, [])
+
+	// Restore the last-linked folder for this connection on mount / connection
+	// switch, and auto-analyze it. Best-effort — a missing/moved folder just
+	// degrades to the empty state.
+	useEffect(
+		function () {
+			if (!connectionId) return
+			let cancelled = false
+			async function restore() {
+				const result = await commands.getSetting(SETTING_PREFIX + connectionId)
+				if (cancelled) return
+				const folder = result.status === 'ok' ? result.data : null
+				if (!folder) return
+				const runId = ++runIdRef.current
+				setState(function (prev) {
+					// Don't clobber an in-flight or already-linked session.
+					if (prev.linked || prev.phase !== 'idle') return prev
+					return { ...prev, phase: 'linking' }
+				})
+				let detect: DetectOrmResult
+				try {
+					detect = await detectProjectOrm(folder)
+				} catch {
+					if (!cancelled && runId === runIdRef.current) {
+						setState(function (prev) {
+							return { ...prev, phase: 'idle' }
+						})
+					}
+					return
+				}
+				if (cancelled || runId !== runIdRef.current) return
+				await startFromDetect(folder, detect, runId)
+			}
+			void restore()
+			return function () {
+				cancelled = true
+			}
+		},
+		// startFromDetect is stable enough; intentionally keyed on connection only.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[connectionId],
+	)
+
+	return {
+		...state,
+		link,
+		rescan,
+		chooseOrm,
+		generate,
+		reset,
+	}
+}

--- a/packages/studio/src/features/sql-console/sql-console.tsx
+++ b/packages/studio/src/features/sql-console/sql-console.tsx
@@ -359,6 +359,25 @@ function SqlConsoleInner({
     [activeTab.id, tabStore],
   );
 
+  // Seed the active tab with arbitrary SQL handed off from another feature
+  // (e.g. the ORM cockpit's generated migration). Mirrors the table-open event.
+  useEffect(
+    function listenForOpenSqlContent() {
+      function onOpenSql(event: Event) {
+        const { sql } = (event as CustomEvent<{ sql?: string }>).detail ?? {};
+        if (typeof sql !== "string") return;
+        tabStore.setTabMode(activeTab.id, "sql");
+        tabStore.updateTabContent(activeTab.id, "sqlContent", sql);
+      }
+
+      window.addEventListener("dora-open-sql-content", onOpenSql as EventListener);
+      return function () {
+        window.removeEventListener("dora-open-sql-content", onOpenSql as EventListener);
+      };
+    },
+    [activeTab.id, tabStore],
+  );
+
   const handleExecute = useCallback(
     async (codeOverride?: string, modeOverride?: "sql" | "drizzle") => {
       if (isExecuting) return;

--- a/packages/studio/src/pages/Index.tsx
+++ b/packages/studio/src/pages/Index.tsx
@@ -53,6 +53,13 @@ const SchemaVisualizer = lazy(function () {
     return { default: m.SchemaVisualizer };
   });
 });
+const OrmCockpitPanel = lazy(function () {
+  return import(
+    "@studio/features/orm-cockpit/components/orm-cockpit-panel"
+  ).then(function (m) {
+    return { default: m.OrmCockpitPanel };
+  });
+});
 const AiAssistantPanel = lazy(function () {
   return import("@studio/features/ai-assistant/ai-assistant-panel").then(function (m) {
     return { default: m.AiAssistantPanel };
@@ -1072,6 +1079,23 @@ function IndexInner() {
                         windowControls={<WindowControls />}
                         initialSection={settingsInitialSection}
                         highlightSection={settingsHighlightSection}
+                      />
+                    </ErrorBoundary>
+                  ) : activeNavId === "orm-cockpit" ? (
+                    <ErrorBoundary feature="ORM Cockpit">
+                      <OrmCockpitPanel
+                        activeConnectionId={activeConnectionId}
+                        windowControls={<WindowControls />}
+                        onOpenInSqlConsole={function (sql) {
+                          setActiveNavId("sql-console");
+                          window.setTimeout(function () {
+                            window.dispatchEvent(
+                              new CustomEvent("dora-open-sql-content", {
+                                detail: { sql },
+                              }),
+                            );
+                          }, 0);
+                        }}
                       />
                     </ErrorBoundary>
                   ) : activeNavId === "docker" ? (


### PR DESCRIPTION
## Wave D — ORM Cockpit UI (plan 07)

Final wave of the Pillar 2 ORM cockpit. Wires the Wave A–C pieces (#151/#154/#153) into a user-facing panel: **link a Drizzle/Prisma project → see how its schema drifts from the live DB → preview a reconciling migration.** Preview-only — generated SQL is handed off to the SQL console, never auto-applied.

### What's here
- **`use-orm-cockpit.ts`** — phase-driven orchestration hook (`idle → linking → choice → analyzing → ready/error`). link → parse → introspect (`getDatabaseSchema` → `fromLiveSchema`) → `diffSchema(live, code)` → `generateMigrationSql(diff, dialect, { from, to })` on demand. Persists the last-linked folder per connection (`get/setSetting`) and auto-restores it. Direction fixed: **live = `from`, code = `to`**.
- **`drift-view.tsx`** — `SchemaDiff` grouped by table, per-row confidence chips (green `safe` / amber `review` / red `destructive`), before/after for changed columns.
- **`migration-sections.ts`** (pure, unit-tested) + **`migration-preview.tsx`** — re-derive the copyable SQL from the generated `up`, gating destructive/review statements behind **explicit opt-in toggles (default off)**. Copy + "Open in SQL console".
- **`orm-cockpit-panel.tsx`** — empty/loading/choice/error/in-sync states; collapsible parse/diff/gen notes (never swallowed).

### Wiring (minimal / append-only)
- "ORM Cockpit" nav entry in `navigation-sidebar.tsx` + view block in `Index.tsx`.
- `sql-console.tsx` gains an append-only `dora-open-sql-content` CustomEvent listener (mirrors the existing `dora-open-table-in-sql`) so the migration can seed the editor.
- **No Rust changes** — reuses existing `pickFolder`/`readProjectFile`/`listDir`/`getSetting`/`setSetting`/`getDatabaseSchema` commands, so no bindings regeneration.

### Verification
- `packages/studio` typecheck: clean ✅
- `apps/desktop` typecheck: clean ✅
- vitest: **570 passed** (566 baseline + 4 new for the preview section-splitting) ✅

### Still open (tracking #143)
- Manual acceptance against a *real* Drizzle + *real* Prisma project with known drift (needs a running app + real fixtures) — to be done before the pillar is marked done.

Part of #146 (Pillar 2 ORM & migration cockpit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/remco-stoeten/codesmith/dora/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784492195&installation_id=140085766&pr_number=155&repository=remco-stoeten%2Fdora&return_to=https%3A%2F%2Fgithub.com%2Fremco-stoeten%2Fdora%2Fpull%2F155&signature=5aa3e0fe1347cb6b3f3ec1f72ecbe50f80b981b1edc77fa6899f42125847d3fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->