### PR TITLE
feat(integrations): Neon branch-aware connects (#142)

### DIFF
--- a/__tests__/apps/desktop/src/features/integrations/neon/neon-connect-flow.test.tsx
+++ b/__tests__/apps/desktop/src/features/integrations/neon/neon-connect-flow.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NeonConnectFlow } from '@studio/features/integrations/neon/neon-connect-flow'
 import {
 	createNeonConnectionUri,
@@ -20,7 +20,8 @@ vi.mock('@studio/features/integrations/neon/neon-api', () => ({
 	saveNeonToken: vi.fn(),
 	createNeonConnectionUri: vi.fn().mockResolvedValue('postgres://neon.example/db'),
 	disconnectNeon: vi.fn(),
-	getNeonAccount: vi.fn().mockResolvedValue({ email: 'dev@example.com', name: 'Dev' })
+	getNeonAccount: vi.fn().mockResolvedValue({ email: 'dev@example.com', name: 'Dev' }),
+	listNeonBranches: vi.fn().mockResolvedValue([])
 }))
 
 vi.mock('@studio/features/integrations/neon/use-neon-databases', () => ({
@@ -29,8 +30,7 @@ vi.mock('@studio/features/integrations/neon/use-neon-databases', () => ({
 			{
 				projectId: 'superlis',
 				projectName: 'superlis',
-				branchId: 'main',
-				branchName: 'main',
+				branchId: 'br-main',
 				databaseName: 'neondb',
 				roleName: 'owner'
 			}
@@ -42,7 +42,24 @@ vi.mock('@studio/features/integrations/neon/use-neon-databases', () => ({
 	})
 }))
 
+// Branch list the picker reads; mutated per-test to exercise single- vs
+// multi-branch projects without re-rendering the whole flow by hand.
+let branchesForTest: Array<{ id: string; name: string; isDefault: boolean }> = []
+
+vi.mock('@studio/features/integrations/neon/use-neon-branches', () => ({
+	useNeonBranches: () => ({
+		branches: branchesForTest,
+		isLoading: false,
+		error: null
+	})
+}))
+
 describe('NeonConnectFlow', function () {
+	beforeEach(function () {
+		branchesForTest = []
+		vi.mocked(createNeonConnectionUri).mockClear()
+	})
+
 	it('copies the Neon API key URL when the external link helper is used', async function () {
 		const writeText = vi.fn().mockResolvedValue(undefined)
 		Object.defineProperty(navigator, 'clipboard', {
@@ -71,5 +88,47 @@ describe('NeonConnectFlow', function () {
 
 		await userEvent.click(createButton)
 		expect(createNeonConnectionUri).toHaveBeenCalled()
+	})
+
+	it('shows a branch picker for multi-branch projects and connects to the chosen branch', async function () {
+		vi.mocked(isNeonConnected).mockResolvedValueOnce(true)
+		branchesForTest = [
+			{ id: 'br-main', name: 'main', isDefault: true },
+			{ id: 'br-preview', name: 'preview/pr-123', isDefault: false }
+		]
+		const onComplete = vi.fn()
+
+		render(<NeonConnectFlow onComplete={onComplete} />)
+
+		await userEvent.click(await screen.findByRole('button', { name: /neondb/i }))
+
+		// Both branches surface; the primary is labeled.
+		const previewBranch = await screen.findByRole('button', { name: /preview\/pr-123/i })
+		expect(screen.getByRole('button', { name: /main.*primary/i })).toBeInTheDocument()
+
+		await userEvent.click(previewBranch)
+		await userEvent.click(screen.getByRole('button', { name: /create neon connection/i }))
+
+		// The non-primary branch id is threaded into the URI minter and labels
+		// the connection.
+		expect(createNeonConnectionUri).toHaveBeenCalledWith(
+			expect.objectContaining({ databaseName: 'neondb' }),
+			'br-preview'
+		)
+		expect(onComplete).toHaveBeenCalledWith(
+			expect.objectContaining({ name: 'superlis · preview/pr-123' })
+		)
+	})
+
+	it('keeps the one-step flow (no branch picker) for single-branch projects', async function () {
+		vi.mocked(isNeonConnected).mockResolvedValueOnce(true)
+		branchesForTest = [{ id: 'br-main', name: 'main', isDefault: true }]
+
+		render(<NeonConnectFlow onComplete={vi.fn()} />)
+
+		await userEvent.click(await screen.findByRole('button', { name: /neondb/i }))
+
+		expect(screen.queryByText('Branch')).not.toBeInTheDocument()
+		expect(screen.getByRole('button', { name: /create neon connection/i })).toBeInTheDocument()
 	})
 })

--- a/apps/desktop/src-tauri/src/bindings.rs
+++ b/apps/desktop/src-tauri/src/bindings.rs
@@ -57,6 +57,7 @@ pub fn generate_bindings() -> Builder<tauri::Wry> {
         db_commands::turso_account,
         db_commands::neon_save_token,
         db_commands::neon_list_databases,
+        db_commands::neon_list_branches,
         db_commands::neon_account,
         db_commands::neon_create_connection_uri,
         db_commands::neon_disconnect,

--- a/apps/desktop/src-tauri/src/database/commands/integrations.rs
+++ b/apps/desktop/src-tauri/src/database/commands/integrations.rs
@@ -2,7 +2,7 @@ use tauri::State;
 use tauri_plugin_opener::OpenerExt;
 
 use crate::{
-    integrations::neon::{self, NeonAccount, NeonDatabase},
+    integrations::neon::{self, NeonAccount, NeonBranch, NeonDatabase},
     integrations::supabase::{self, SupabaseOrganization, SupabaseProject},
     integrations::turso::{self, TursoDatabase, TursoOrganization},
     AppState, Error,
@@ -204,6 +204,17 @@ pub async fn neon_list_databases(
     state: State<'_, AppState>,
 ) -> Result<Vec<NeonDatabase>, Error> {
     neon::list_databases(&state.storage).await
+}
+
+/// Lists every branch of a Neon project so the user can connect to a non-primary
+/// branch (e.g. a preview branch) instead of always landing on the default one.
+#[tauri::command]
+#[specta::specta]
+pub async fn neon_list_branches(
+    project_id: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<NeonBranch>, Error> {
+    neon::list_branches(&state.storage, &project_id).await
 }
 
 /// The Neon account the stored key belongs to, so the UI can show which account

--- a/apps/desktop/src-tauri/src/integrations/neon.rs
+++ b/apps/desktop/src-tauri/src/integrations/neon.rs
@@ -36,6 +36,17 @@ pub struct NeonDatabase {
     pub role_name: String,
 }
 
+/// A selectable Neon branch within a project. Surfaced so the user can connect
+/// to a non-primary branch (e.g. a preview branch) instead of always landing on
+/// the default one. `is_default` lets the UI preselect the primary branch.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct NeonBranch {
+    pub id: String,
+    pub name: String,
+    pub is_default: bool,
+}
+
 #[derive(Debug, Deserialize)]
 struct ProjectsResponse {
     projects: Vec<ProjectResponse>,
@@ -64,6 +75,10 @@ struct BranchesResponse {
 #[derive(Debug, Deserialize)]
 struct BranchResponse {
     id: String,
+    // The human-readable branch name (e.g. `main`, `preview/pr-123`). Defaults
+    // to empty if Neon ever omits it so decoding never fails on a sparse payload.
+    #[serde(default)]
+    name: String,
     // Neon flags the project's primary branch with `default`; older payloads
     // used `primary`, and current payloads carry BOTH keys. Read them as two
     // separate optional fields — a serde `alias` would route both keys into one
@@ -238,7 +253,9 @@ pub async fn save_token(storage: &Storage, token: String) -> Result<()> {
     store_token(storage, &token)
 }
 
-async fn get_default_branch(token: &str, project_id: &str) -> Result<Option<String>> {
+/// Fetches every branch of a project. Shared by `get_default_branch` (which just
+/// wants the primary) and `list_branches` (which surfaces all of them to the UI).
+async fn get_branches(token: &str, project_id: &str) -> Result<Vec<BranchResponse>> {
     let response = reqwest::Client::new()
         .get(format!("{API_BASE_URL}/projects/{project_id}/branches"))
         .bearer_auth(token)
@@ -259,14 +276,34 @@ async fn get_default_branch(token: &str, project_id: &str) -> Result<Option<Stri
             "Failed to decode Neon branches response: {error}"
         ))
     })?;
+    Ok(parsed.branches)
+}
+
+async fn get_default_branch(token: &str, project_id: &str) -> Result<Option<String>> {
+    let branches = get_branches(token, project_id).await?;
     // Prefer the primary branch; fall back to the first one a project has.
-    let branch = parsed
-        .branches
+    let branch = branches
         .iter()
         .find(|branch| branch.is_default())
-        .or_else(|| parsed.branches.first())
+        .or_else(|| branches.first())
         .map(|branch| branch.id.clone());
     Ok(branch)
+}
+
+/// Lists every branch of a project so the user can connect to a non-primary one.
+/// The primary branch is flagged via `is_default` so the UI can preselect it.
+pub async fn list_branches(storage: &Storage, project_id: &str) -> Result<Vec<NeonBranch>> {
+    let token = require_token(storage)?;
+    let branches = get_branches(&token, project_id)
+        .await?
+        .into_iter()
+        .map(|branch| NeonBranch {
+            is_default: branch.is_default(),
+            id: branch.id,
+            name: branch.name,
+        })
+        .collect();
+    Ok(branches)
 }
 
 async fn get_branch_databases(
@@ -408,6 +445,42 @@ mod tests {
         )
         .expect("branches json should deserialize with both default and primary");
         assert!(parsed.branches[0].is_default());
+    }
+
+    #[test]
+    fn decodes_branch_names_and_default_flag() {
+        // What `list_branches` maps into NeonBranch: id + name + is_default. A
+        // non-primary preview branch must surface its name and read as non-default.
+        let parsed: BranchesResponse = serde_json::from_str(
+            r#"{ "branches": [
+                { "id": "br-main", "name": "main", "default": true },
+                { "id": "br-prev", "name": "preview/pr-123", "primary": false }
+            ] }"#,
+        )
+        .expect("named branches json should deserialize");
+        let mapped: Vec<NeonBranch> = parsed
+            .branches
+            .into_iter()
+            .map(|branch| NeonBranch {
+                is_default: branch.is_default(),
+                id: branch.id,
+                name: branch.name,
+            })
+            .collect();
+        assert_eq!(mapped.len(), 2);
+        assert_eq!(mapped[0].name, "main");
+        assert!(mapped[0].is_default);
+        assert_eq!(mapped[1].name, "preview/pr-123");
+        assert!(!mapped[1].is_default);
+    }
+
+    #[test]
+    fn tolerates_branch_missing_name() {
+        // A sparse payload (no `name`) must still decode — name falls back to "".
+        let parsed: BranchesResponse =
+            serde_json::from_str(r#"{ "branches": [ { "id": "br-1", "default": true } ] }"#)
+                .expect("branches json should deserialize without a name");
+        assert_eq!(parsed.branches[0].name, "");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -216,6 +216,7 @@ pub fn run() {
             database::commands::turso_account,
             database::commands::neon_save_token,
             database::commands::neon_list_databases,
+            database::commands::neon_list_branches,
             database::commands::neon_account,
             database::commands::neon_create_connection_uri,
             database::commands::neon_disconnect,

--- a/apps/desktop/src/lib/bindings.ts
+++ b/apps/desktop/src/lib/bindings.ts
@@ -444,6 +444,18 @@ async neonListDatabases() : Promise<Result<NeonDatabase[], { kind: string; detai
 }
 },
 /**
+ * Lists every branch of a Neon project so the user can connect to a non-primary
+ * branch (e.g. a preview branch) instead of always landing on the default one.
+ */
+async neonListBranches(projectId: string) : Promise<Result<NeonBranch[], { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("neon_list_branches", { projectId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * The Neon account the stored key belongs to, so the UI can show which account
  * is currently connected.
  */
@@ -1339,6 +1351,12 @@ export type LiveMonitorSession = { monitorId: string; eventName: string }
  */
 export type MutationResult = { success: boolean; affected_rows: number; message: string | null }
 export type NeonAccount = { email?: string; name?: string }
+/**
+ * A selectable Neon branch within a project. Surfaced so the user can connect
+ * to a non-primary branch (e.g. a preview branch) instead of always landing on
+ * the default one. `is_default` lets the UI preselect the primary branch.
+ */
+export type NeonBranch = { id: string; name: string; isDefault: boolean }
 /**
  * A selectable Neon database, flattened across projects and their default
  * branch. The ids/names are carried so we can mint a pooled connection URI for

--- a/packages/studio/src/features/integrations/neon/neon-api.ts
+++ b/packages/studio/src/features/integrations/neon/neon-api.ts
@@ -1,7 +1,7 @@
 import { assertTauriRuntime } from "@studio/core/platform/runtime";
-import { commands, type NeonAccount, type NeonDatabase } from "@studio/lib/bindings";
+import { commands, type NeonAccount, type NeonBranch, type NeonDatabase } from "@studio/lib/bindings";
 
-export type { NeonAccount, NeonDatabase };
+export type { NeonAccount, NeonBranch, NeonDatabase };
 
 export async function isNeonConnected(): Promise<boolean> {
   assertTauriRuntime();
@@ -27,13 +27,29 @@ export async function listNeonDatabases(): Promise<NeonDatabase[]> {
   return result.data;
 }
 
+// Lists every branch of a Neon project so the user can connect to a non-primary
+// branch (e.g. a preview branch) instead of the default one.
+export async function listNeonBranches(projectId: string): Promise<NeonBranch[]> {
+  assertTauriRuntime();
+  const result = await commands.neonListBranches(projectId);
+  if (result.status === "error") {
+    throw result.error;
+  }
+  return result.data;
+}
+
 // Mints a pooled connection URI (password embedded) for a database. This is the
-// credential stored on the connection — the user never copies a secret.
-export async function createNeonConnectionUri(database: NeonDatabase): Promise<string> {
+// credential stored on the connection — the user never copies a secret. Pass a
+// `branchId` to target a non-default branch; otherwise the database's own
+// (default) branch is used.
+export async function createNeonConnectionUri(
+  database: NeonDatabase,
+  branchId?: string,
+): Promise<string> {
   assertTauriRuntime();
   const result = await commands.neonCreateConnectionUri(
     database.projectId,
-    database.branchId,
+    branchId ?? database.branchId,
     database.databaseName,
     database.roleName,
   );

--- a/packages/studio/src/features/integrations/neon/neon-connect-flow.tsx
+++ b/packages/studio/src/features/integrations/neon/neon-connect-flow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Check, Copy, ExternalLink, Loader2, LogOut, PlugZap, RefreshCw, Search } from 'lucide-react'
+import { Check, Copy, ExternalLink, GitBranch, Loader2, LogOut, PlugZap, RefreshCw, Search } from 'lucide-react'
 import { open } from '@tauri-apps/plugin-shell'
 import type { NeonAccount, NeonDatabase } from '@studio/lib/bindings'
 import { Button } from '@studio/shared/ui/button'
@@ -17,6 +17,7 @@ import {
 	saveNeonToken
 } from './neon-api'
 import { useNeonDatabases } from './use-neon-databases'
+import { useNeonBranches } from './use-neon-branches'
 import { useIsTauri } from '@studio/core/data-provider'
 import { DesktopOnlyNotice } from '@studio/core/platform'
 
@@ -49,10 +50,16 @@ function NeonConnectFlowInner({ onComplete }: Props) {
 	const [authError, setAuthError] = useState<string | null>(null)
 	const [query, setQuery] = useState('')
 	const [selected, setSelected] = useState<NeonDatabase | null>(null)
+	const [selectedBranchId, setSelectedBranchId] = useState<string | null>(null)
 	const [isBuilding, setIsBuilding] = useState(false)
 	const [tokenUrlCopied, setTokenUrlCopied] = useState(false)
 	const tokenUrlCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 	const { databases, isLoading, error, refresh, reset } = useNeonDatabases(isConnected)
+	// Only fetch branches once a database is picked — most connects never need
+	// the picker, so we don't pay the per-project call until it's relevant.
+	const { branches, isLoading: branchesLoading } = useNeonBranches(
+		selected?.projectId ?? null
+	)
 
 	// Hydrate from a key stored in a previous session so a returning user lands
 	// straight on the database picker.
@@ -121,6 +128,39 @@ function NeonConnectFlowInner({ onComplete }: Props) {
 		[databases, query]
 	)
 
+	// Once a database is picked and its branches load, default the picker to the
+	// branch the database was discovered on (the project's primary), keeping any
+	// explicit choice the user already made for this same project.
+	useEffect(
+		function preselectBranch() {
+			if (!selected || branches.length === 0) {
+				setSelectedBranchId(null)
+				return
+			}
+			setSelectedBranchId(function (previous) {
+				if (previous && branches.some((branch) => branch.id === previous)) {
+					return previous
+				}
+				const fallback =
+					branches.find((branch) => branch.id === selected.branchId) ??
+					branches.find((branch) => branch.isDefault) ??
+					branches[0]
+				return fallback?.id ?? null
+			})
+		},
+		[selected, branches]
+	)
+
+	// The branch the connection will actually target, and whether it differs from
+	// the project's primary — used to label the connection and gate the picker.
+	const chosenBranch = useMemo(
+		function resolveChosenBranch() {
+			if (!selectedBranchId) return null
+			return branches.find((branch) => branch.id === selectedBranchId) ?? null
+		},
+		[branches, selectedBranchId]
+	)
+
 	async function handleConnect() {
 		const token = tokenInput.trim()
 		if (!token) return
@@ -143,6 +183,7 @@ function NeonConnectFlowInner({ onComplete }: Props) {
 			await disconnectNeon()
 			setIsConnected(false)
 			setSelected(null)
+			setSelectedBranchId(null)
 			setQuery('')
 			setTokenInput('')
 			reset()
@@ -188,9 +229,16 @@ function NeonConnectFlowInner({ onComplete }: Props) {
 		setIsBuilding(true)
 		setAuthError(null)
 		try {
-			const url = await createNeonConnectionUri(selected)
+			const url = await createNeonConnectionUri(selected, selectedBranchId ?? undefined)
+			const baseName = selected.projectName || selected.databaseName
+			// Distinguish a non-primary branch on the connection list so
+			// `myapp · main` and `myapp · preview-123` don't look identical.
+			const name =
+				chosenBranch && !chosenBranch.isDefault
+					? `${baseName} · ${chosenBranch.name}`
+					: baseName
 			onComplete({
-				name: selected.projectName || selected.databaseName,
+				name,
 				type: 'postgres',
 				url,
 				poolerMode: true,
@@ -382,6 +430,7 @@ function NeonConnectFlowInner({ onComplete }: Props) {
 									type='button'
 									onClick={function () {
 										setSelected(database)
+										setSelectedBranchId(null)
 										setAuthError(null)
 									}}
 									className={cn(
@@ -406,6 +455,45 @@ function NeonConnectFlowInner({ onComplete }: Props) {
 							)
 						})}
 					</div>
+
+					{selected && branches.length > 1 ? (
+						<div className='space-y-2'>
+							<div className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+								<GitBranch className='h-3.5 w-3.5' />
+								<span>Branch</span>
+								{branchesLoading ? (
+									<Loader2 className='h-3 w-3 animate-spin' />
+								) : null}
+							</div>
+							<div className='flex flex-wrap gap-2'>
+								{branches.map(function (branch) {
+									const isActive = branch.id === selectedBranchId
+									return (
+										<button
+											key={branch.id}
+											type='button'
+											onClick={function () {
+												setSelectedBranchId(branch.id)
+											}}
+											className={cn(
+												'inline-flex items-center gap-1.5 border px-2.5 py-1 text-xs transition-colors',
+												isActive
+													? 'border-emerald-500/45 bg-emerald-500/10 text-foreground'
+													: 'border-border/60 bg-background/45 text-muted-foreground hover:border-border hover:bg-card/65'
+											)}
+										>
+											<span className='truncate max-w-[12rem]'>{branch.name}</span>
+											{branch.isDefault ? (
+												<span className='text-[0.65rem] uppercase tracking-wide text-muted-foreground/70'>
+													primary
+												</span>
+											) : null}
+										</button>
+									)
+								})}
+							</div>
+						</div>
+					) : null}
 
 					{selected ? (
 						<div

--- a/packages/studio/src/features/integrations/neon/use-neon-branches.ts
+++ b/packages/studio/src/features/integrations/neon/use-neon-branches.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import type { NeonBranch } from "@studio/lib/bindings";
+import { formatBackendError } from "@studio/shared/utils/backend-error";
+import { listNeonBranches } from "./neon-api";
+
+// Fetches the branches of a single Neon project, re-fetching whenever the
+// selected project changes. Passing `null` (no project selected) clears the
+// list without hitting the API, so the picker only loads work it needs.
+export function useNeonBranches(projectId: string | null) {
+  const [branches, setBranches] = useState<NeonBranch[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(
+    function loadBranches() {
+      if (!projectId) {
+        setBranches([]);
+        setError(null);
+        setIsLoading(false);
+        return;
+      }
+      let cancelled = false;
+      setIsLoading(true);
+      setError(null);
+      void listNeonBranches(projectId)
+        .then(function (resolved) {
+          if (!cancelled) setBranches(resolved);
+        })
+        .catch(function (caught) {
+          if (!cancelled) {
+            setBranches([]);
+            setError(formatBackendError(caught));
+          }
+        })
+        .finally(function () {
+          if (!cancelled) setIsLoading(false);
+        });
+      return function () {
+        cancelled = true;
+      };
+    },
+    [projectId],
+  );
+
+  return { branches, isLoading, error };
+}

--- a/packages/studio/src/lib/bindings.ts
+++ b/packages/studio/src/lib/bindings.ts
@@ -408,6 +408,18 @@ async neonListDatabases() : Promise<Result<NeonDatabase[], { kind: string; detai
 }
 },
 /**
+ * Lists every branch of a Neon project so the user can connect to a non-primary
+ * branch (e.g. a preview branch) instead of always landing on the default one.
+ */
+async neonListBranches(projectId: string) : Promise<Result<NeonBranch[], { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("neon_list_branches", { projectId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * The Neon account the stored key belongs to, so the UI can show which account
  * is currently connected.
  */
@@ -1329,6 +1341,7 @@ export type SupabaseOrganization = { id: string; name: string }
 export type TursoDatabase = { name: string; hostname: string; organizationSlug: string; group: string; primaryRegion: string }
 export type TursoOrganization = { slug: string; name?: string }
 export type NeonAccount = { email?: string; name?: string }
+export type NeonBranch = { id: string; name: string; isDefault: boolean }
 export type NeonDatabase = { projectId: string; projectName: string; branchId: string; databaseName: string; roleName: string }
 export type StatementInfo = { returns_values: boolean; status: QueryStatus; first_page: JsonValue; affected_rows: number | null; page_count: number; rows_received: number; error: string | null }
 export type TAURI_CHANNEL<TSend> = null


### PR DESCRIPTION
Closes #142 (Pillar 1 Wave P1b — branch-aware connects).

## What

Let the user pick a Neon **branch** (not just a database) when connecting, so a preview branch is reachable instead of always landing on the project's primary. The common single-branch case stays one click.

## How

**Backend (`neon.rs`)**
- Factored branch fetching out of `get_default_branch` into a shared `get_branches` helper.
- Added `NeonBranch { id, name, is_default }` + `list_branches(project_id)`.
- `neon_list_branches` Tauri command, registered in `lib.rs` + `bindings.rs`; bindings regenerated (apps/desktop + hand-synced studio bindings).

**Frontend (`neon-connect-flow`)**
- `useNeonBranches` fetches a project's branches **only after** a database is picked — most connects never need the picker, so we don't pay the per-project call until it's relevant.
- A branch picker appears when a project has **>1 branch**; the primary is preselected. Single-branch projects keep the existing one-step flow.
- The chosen branch threads into the connection URI minter and labels the connection (`<db> · <branch>`) when it isn't the primary, so `myapp · main` and `myapp · preview-123` don't look identical.

## Scope note

PlanetScale branch support ships with its own connector (#149) — its per-branch password minting already makes branch the natural pick step — so this PR is the Neon half, per `05-branch-aware-connects.md`.

## Acceptance criteria
- [x] Neon: multi-branch project shows a picker; primary preselected; connecting to a non-primary branch works and is labeled.
- [x] Neon: single-branch projects keep the one-step flow.
- [x] PlanetScale picker — covered by #149 (out of scope here).
- [x] No regression in existing Neon connect tests; added `list_branches` decode tests.

## Verification
- studio: **568 tests green** (+2 branch-picker / single-branch flow tests)
- neon cargo suite: **11/11** (added 2 decode tests)
- `packages/studio` + `apps/desktop` typechecks: clean
- The 2 postgres `pgtemp`/`initdb` cargo failures are pre-existing and environmental (fail on `master` too).

The native folder-free GUI click-through (real Neon account + multi-branch project) is the human half — everything underneath is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/remco-stoeten/codesmith/dora/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784503392&installation_id=140085766&pr_number=156&repository=remco-stoeten%2Fdora&return_to=https%3A%2F%2Fgithub.com%2Fremco-stoeten%2Fdora%2Fpull%2F156&signature=4ea4db44dfa9f0931415de8156de83ca254e0645623fd47459de93dc7e7bbd8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->