### PR TITLE
feat(drizzle-runner): align translator with LSP, add $count, fix Prisma toolbar

### DIFF
--- a/__tests__/apps/desktop/features/drizzle-runner/lsp-patterns.test.ts
+++ b/__tests__/apps/desktop/features/drizzle-runner/lsp-patterns.test.ts
@@ -9,6 +9,7 @@ import {
 	isInsideFromParens,
 	isInsideWhereParens,
 	isInsideJoinParens,
+	isInsideCountParens,
 	getTableMatch,
 	getColumnMatch
 } from '@/features/drizzle-runner/utils/lsp-patterns'
@@ -26,6 +27,32 @@ describe('Drizzle LSP Patterns', () => {
 
 		it('returns null for unrelated text', () => {
 			expect(getDbName('const x = ')).toBeNull()
+		})
+
+		it('detects $-prefixed members like $count while typing', () => {
+			expect(getDbName('db.$')).toBe('db')
+			expect(getDbName('db.$c')).toBe('db')
+			expect(getDbName('await db.$count')).toBe('db')
+		})
+
+		it('does not match once the call is closed', () => {
+			expect(getDbName('db.$count(messages).')).toBeNull()
+		})
+	})
+
+	describe('isInsideCountParens', () => {
+		it('matches empty and partial parens', () => {
+			expect(isInsideCountParens('db.$count(')).toBe(true)
+			expect(isInsideCountParens('db.$count(mess')).toBe(true)
+			expect(isInsideCountParens('await tx.$count(')).toBe(true)
+		})
+
+		it('does not match closed parens', () => {
+			expect(isInsideCountParens('db.$count(messages)')).toBe(false)
+		})
+
+		it('does not match a second-arg condition', () => {
+			expect(isInsideCountParens('db.$count(messages, eq(')).toBe(false)
 		})
 	})
 

--- a/__tests__/apps/desktop/src/features/drizzle-runner/utils/drizzle-query.test.ts
+++ b/__tests__/apps/desktop/src/features/drizzle-runner/utils/drizzle-query.test.ts
@@ -34,16 +34,113 @@ describe('drizzleQueryToSql', function () {
 		)
 	})
 
-	it('rejects .where() chains with a specific message', function () {
-		expect(function () {
-			drizzleQueryToSql('db.select().from(messages).where(eq(messages.id, 1))')
-		}).toThrow('Queries with .where() are not auto-translated')
+	it('converts .where(eq(...)) chains', function () {
+		expect(drizzleQueryToSql('db.select().from(messages).where(eq(messages.id, 1))')).toBe(
+			'SELECT * FROM messages WHERE id = 1'
+		)
 	})
 
-	it('rejects .orderBy() chains with a specific message', function () {
+	it('converts .where(eq(...)) with .limit(n)', function () {
+		expect(
+			drizzleQueryToSql('db.select().from(users).where(eq(users.id, 1)).limit(10)')
+		).toBe('SELECT * FROM users WHERE id = 1 LIMIT 10')
+	})
+
+	it('converts multi-condition .where(and(...))', function () {
+		expect(
+			drizzleQueryToSql(
+				'db.select().from(messages).where(and(eq(messages.id, 1), eq(messages.active, true)))'
+			)
+		).toBe('SELECT * FROM messages WHERE (id = 1 AND active = true)')
+	})
+
+	it('converts nested and/or/not conditions', function () {
+		expect(
+			drizzleQueryToSql(
+				'db.select().from(users).where(or(eq(users.role, "admin"), not(isNull(users.email))))'
+			)
+		).toBe("SELECT * FROM users WHERE (role = 'admin' OR (NOT email IS NULL))")
+	})
+
+	it('converts inArray and between conditions', function () {
+		expect(drizzleQueryToSql('db.select().from(users).where(inArray(users.id, [1, 2, 3]))')).toBe(
+			'SELECT * FROM users WHERE id IN (1, 2, 3)'
+		)
+		expect(drizzleQueryToSql('db.select().from(users).where(between(users.age, 18, 65))')).toBe(
+			'SELECT * FROM users WHERE age BETWEEN 18 AND 65'
+		)
+	})
+
+	it('converts .orderBy() with asc/desc and column refs', function () {
+		expect(drizzleQueryToSql('db.select().from(messages).orderBy(messages.createdAt)')).toBe(
+			'SELECT * FROM messages ORDER BY createdAt'
+		)
+		expect(
+			drizzleQueryToSql('db.select().from(messages).orderBy(desc(messages.createdAt), asc(messages.id))')
+		).toBe('SELECT * FROM messages ORDER BY createdAt DESC, id ASC')
+	})
+
+	it('orders SQL clauses as WHERE, ORDER BY, LIMIT, OFFSET regardless of chain order', function () {
+		expect(
+			drizzleQueryToSql(
+				'db.select().from(users).limit(5).orderBy(users.id).where(eq(users.active, true))'
+			)
+		).toBe('SELECT * FROM users WHERE active = true ORDER BY id LIMIT 5')
+	})
+
+	it('rejects joins/grouping/set-ops with a precise, method-named message', function () {
 		expect(function () {
-			drizzleQueryToSql('db.select().from(messages).orderBy(messages.createdAt)')
-		}).toThrow('Queries with .orderBy() are not auto-translated')
+			drizzleQueryToSql('db.select().from(messages).groupBy(messages.id)')
+		}).toThrow('.groupBy() is not auto-translated')
+		expect(function () {
+			drizzleQueryToSql('db.select().from(users).leftJoin(orders, eq(orders.userId, users.id))')
+		}).toThrow('.leftJoin() is not auto-translated')
+	})
+
+	it('converts insert with a single values object', function () {
+		expect(drizzleQueryToSql('db.insert(users).values({ name: "Ada", age: 36 })')).toBe(
+			"INSERT INTO users (name, age) VALUES ('Ada', 36)"
+		)
+	})
+
+	it('converts insert with .returning() and multiple rows', function () {
+		expect(
+			drizzleQueryToSql('db.insert(users).values([{ name: "a" }, { name: "b" }]).returning()')
+		).toBe("INSERT INTO users (name) VALUES ('a'), ('b') RETURNING *")
+	})
+
+	it('converts delete with a where clause', function () {
+		expect(drizzleQueryToSql('db.delete(users).where(eq(users.id, 1))')).toBe(
+			'DELETE FROM users WHERE id = 1'
+		)
+	})
+
+	it('rejects delete without a where clause (whole-table guard)', function () {
+		expect(function () {
+			drizzleQueryToSql('db.delete(users)')
+		}).toThrow('without .where() is rejected')
+	})
+
+	it('rejects update without a where clause (whole-table guard)', function () {
+		expect(function () {
+			drizzleQueryToSql('db.update(users).set({ name: "a" })')
+		}).toThrow('without .where() is rejected')
+	})
+
+	it('converts update with .returning()', function () {
+		expect(
+			drizzleQueryToSql('db.update(users).set({ name: "a" }).where(eq(users.id, 1)).returning()')
+		).toBe("UPDATE users SET name = 'a' WHERE id = 1 RETURNING *")
+	})
+
+	it('strips .toSQL() before translating', function () {
+		expect(drizzleQueryToSql('db.select().from(users).toSQL()')).toBe('SELECT * FROM users')
+	})
+
+	it('strips .toSQL() from a query with .where()', function () {
+		expect(
+			drizzleQueryToSql('db.select().from(users).where(eq(users.id, 1)).toSQL()')
+		).toBe('SELECT * FROM users WHERE id = 1')
 	})
 
 	it('accepts tx.execute(sql) patterns', function () {
@@ -85,9 +182,35 @@ describe('drizzleQueryToSql', function () {
 		).toBe('UPDATE users SET active = true, age = 42, deletedAt = NULL WHERE id != 1')
 	})
 
-	it('rejects unsupported chains instead of sending JavaScript to the SQL backend', function () {
+	it('converts db.$count(table)', function () {
+		expect(drizzleQueryToSql('db.$count(messages)')).toBe('SELECT count(*) FROM messages')
+	})
+
+	it('converts db.$count(table, eq(...))', function () {
+		expect(drizzleQueryToSql('db.$count(messages, eq(messages.active, true))')).toBe(
+			'SELECT count(*) FROM messages WHERE active = true'
+		)
+	})
+
+	it('converts db.$count with .toSQL()', function () {
+		expect(drizzleQueryToSql('db.$count(users).toSQL()')).toBe('SELECT count(*) FROM users')
+	})
+
+	it('tolerates whitespace and await in db.$count', function () {
+		expect(drizzleQueryToSql('await db.$count(  messages  )')).toBe(
+			'SELECT count(*) FROM messages'
+		)
+	})
+
+	it('converts db.$count(table, and(...)) with a multi-condition filter', function () {
+		expect(
+			drizzleQueryToSql('db.$count(messages, and(eq(messages.a, 1), eq(messages.b, 2)))')
+		).toBe('SELECT count(*) FROM messages WHERE (a = 1 AND b = 2)')
+	})
+
+	it('rejects a db.$count condition it cannot translate', function () {
 		expect(function () {
-			drizzleQueryToSql('db.select().from(messages).groupBy(messages.id)')
-		}).toThrow('Unsupported Drizzle query')
+			drizzleQueryToSql('db.$count(messages, sql`a = 1`)')
+		}).toThrow('Unsupported db.$count() condition')
 	})
 })

--- a/packages/studio/src/features/drizzle-runner/components/code-editor.tsx
+++ b/packages/studio/src/features/drizzle-runner/components/code-editor.tsx
@@ -19,6 +19,7 @@ import {
   isInsideDeleteParens,
   isInsideFromParens,
   isInsideJoinParens,
+  isInsideCountParens,
 } from "../utils/lsp-patterns";
 
 type Props = {
@@ -745,27 +746,56 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
               },
             },
             {
+              label: "$count",
+              kind: monaco.languages.CompletionItemKind.Method,
+              insertText: "$count(",
+              detail: "Count rows in a table",
+              range: range,
+              sortText: "4",
+              command: {
+                id: "editor.action.triggerSuggest",
+                title: "Trigger Suggest",
+              },
+            },
+            {
               label: "batch",
               kind: monaco.languages.CompletionItemKind.Method,
               insertText: "batch([$0])",
               insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
               detail: "Run a batch of queries",
               range: range,
-              sortText: "4",
+              sortText: "5",
             },
           ];
           if (dbName === "db") {
-            suggestions.splice(4, 0, {
+            suggestions.splice(5, 0, {
               label: "transaction",
               kind: monaco.languages.CompletionItemKind.Method,
               insertText: "transaction(async tx => {\n  $0\n})",
               insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
               detail: "Run queries in a transaction",
               range: range,
-              sortText: "4",
+              sortText: "6",
             });
           }
           return buildSuggestions(range, suggestions);
+        }
+
+        if (isInsideCountParens(textUntilPosition)) {
+          return buildSuggestions(
+            range,
+            currentTables.map(function (table, index) {
+              return {
+                label: table.name,
+                kind: monaco.languages.CompletionItemKind.Variable,
+                insertText: `${table.name})$0`,
+                insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                detail: "Table to count",
+                range: range,
+                sortText: String(index).padStart(3, "0"),
+              };
+            }),
+          );
         }
 
         if (isInsideSelectParens(textUntilPosition)) {
@@ -775,15 +805,11 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
               return {
                 label: table.name,
                 kind: monaco.languages.CompletionItemKind.Variable,
-                insertText: tableSnippet(table),
+                insertText: `).from(${table.name})$0`,
                 insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
                 detail: "Table",
                 range: range,
                 sortText: String(index).padStart(3, "0"),
-                command: {
-                  id: "editor.action.triggerSuggest",
-                  title: "Trigger Suggest",
-                },
               };
             }),
           );
@@ -1026,29 +1052,9 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
             },
           ];
 
-          const directComparisonSuggestions: Suggestion[] = [];
-
           if (fromMatch) {
             const table = getTable(currentTables, normalizeTableReference(fromMatch[1]));
             if (table) {
-              table.columns.forEach(function (column, index) {
-                directComparisonSuggestions.push({
-                  label: `${column.name} =`,
-                  kind: monaco.languages.CompletionItemKind.Field,
-                  insertText: `'${column.name}', '=', \${1:${getValueSnippet(
-                    getTypeKind(column.type),
-                  )}}`,
-                  insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-                  detail: "Direct comparison",
-                  range: range,
-                  sortText: `8${String(index).padStart(3, "0")}`,
-                  command: {
-                    id: "editor.action.triggerSuggest",
-                    title: "Trigger Suggest",
-                  },
-                });
-              });
-
               const tableSuggestions: Suggestion[] = table.columns.map(function (column, index) {
                 return {
                   label: `${table.name}.${column.name}`,
@@ -1060,13 +1066,10 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
                   sortText: `9${String(index).padStart(3, "0")}`,
                 };
               });
-              return buildSuggestions(
-                range,
-                baseSuggestions.concat(directComparisonSuggestions).concat(tableSuggestions),
-              );
+              return buildSuggestions(range, baseSuggestions.concat(tableSuggestions));
             }
           }
-          return buildSuggestions(range, baseSuggestions.concat(directComparisonSuggestions));
+          return buildSuggestions(range, baseSuggestions);
         }
 
         if (
@@ -1420,6 +1423,7 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
               },
             });
           } else {
+            // Executable chain methods first — these auto-translate to SQL.
             suggestions.push(
               {
                 label: "where",
@@ -1435,87 +1439,13 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
                 },
               },
               {
-                label: "leftJoin",
-                kind: monaco.languages.CompletionItemKind.Method,
-                insertText: "leftJoin(",
-                detail: "Left join",
-                range: range,
-                sortText: "2",
-                command: {
-                  id: "editor.action.triggerSuggest",
-                  title: "Trigger Suggest",
-                },
-              },
-              {
-                label: "rightJoin",
-                kind: monaco.languages.CompletionItemKind.Method,
-                insertText: "rightJoin(",
-                detail: "Right join",
-                range: range,
-                sortText: "3",
-                command: {
-                  id: "editor.action.triggerSuggest",
-                  title: "Trigger Suggest",
-                },
-              },
-              {
-                label: "innerJoin",
-                kind: monaco.languages.CompletionItemKind.Method,
-                insertText: "innerJoin(",
-                detail: "Inner join",
-                range: range,
-                sortText: "4",
-                command: {
-                  id: "editor.action.triggerSuggest",
-                  title: "Trigger Suggest",
-                },
-              },
-              {
-                label: "fullJoin",
-                kind: monaco.languages.CompletionItemKind.Method,
-                insertText: "fullJoin(",
-                detail: "Full join",
-                range: range,
-                sortText: "5",
-                command: {
-                  id: "editor.action.triggerSuggest",
-                  title: "Trigger Suggest",
-                },
-              },
-              {
-                label: "groupBy",
-                kind: monaco.languages.CompletionItemKind.Method,
-                insertText: "groupBy(${1:column})$0",
-                insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-                detail: "Group results",
-                range: range,
-                sortText: "6",
-                command: {
-                  id: "editor.action.triggerSuggest",
-                  title: "Trigger Suggest",
-                },
-              },
-              {
-                label: "having",
-                kind: monaco.languages.CompletionItemKind.Method,
-                insertText: "having($0)",
-                insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-                detail: "Filter groups",
-                range: range,
-                sortText: "7",
-                command: {
-                  id: "editor.action.triggerSuggest",
-                  title: "Trigger Suggest",
-                },
-              },
-              {
                 label: "orderBy",
                 kind: monaco.languages.CompletionItemKind.Method,
                 insertText: "orderBy(${1:column})$0",
                 insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
                 detail: "Order results",
                 range: range,
-                sortText: "8",
+                sortText: "2",
                 command: {
                   id: "editor.action.triggerSuggest",
                   title: "Trigger Suggest",
@@ -1528,7 +1458,7 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
                 insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
                 detail: "Limit rows",
                 range: range,
-                sortText: "9",
+                sortText: "3",
               },
               {
                 label: "offset",
@@ -1537,17 +1467,70 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
                 insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
                 detail: "Skip rows",
                 range: range,
-                sortText: "10",
+                sortText: "4",
               },
             );
 
+            // Methods below are valid Drizzle but not auto-translated by the
+            // runner — they require db.execute(sql`...`). Flagged + sorted last.
+            const rawSqlOnly = "raw SQL only · use db.execute(sql``)";
             suggestions.push(
+              {
+                label: "leftJoin",
+                kind: monaco.languages.CompletionItemKind.Method,
+                insertText: "leftJoin(",
+                detail: `Left join — ${rawSqlOnly}`,
+                range: range,
+                sortText: "5",
+              },
+              {
+                label: "rightJoin",
+                kind: monaco.languages.CompletionItemKind.Method,
+                insertText: "rightJoin(",
+                detail: `Right join — ${rawSqlOnly}`,
+                range: range,
+                sortText: "6",
+              },
+              {
+                label: "innerJoin",
+                kind: monaco.languages.CompletionItemKind.Method,
+                insertText: "innerJoin(",
+                detail: `Inner join — ${rawSqlOnly}`,
+                range: range,
+                sortText: "7",
+              },
+              {
+                label: "fullJoin",
+                kind: monaco.languages.CompletionItemKind.Method,
+                insertText: "fullJoin(",
+                detail: `Full join — ${rawSqlOnly}`,
+                range: range,
+                sortText: "8",
+              },
+              {
+                label: "groupBy",
+                kind: monaco.languages.CompletionItemKind.Method,
+                insertText: "groupBy(${1:column})$0",
+                insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                detail: `Group results — ${rawSqlOnly}`,
+                range: range,
+                sortText: "9",
+              },
+              {
+                label: "having",
+                kind: monaco.languages.CompletionItemKind.Method,
+                insertText: "having($0)",
+                insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+                detail: `Filter groups — ${rawSqlOnly}`,
+                range: range,
+                sortText: "10",
+              },
               {
                 label: "union",
                 kind: monaco.languages.CompletionItemKind.Method,
                 insertText: "union(${1:query})",
                 insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-                detail: "Union",
+                detail: `Union — ${rawSqlOnly}`,
                 range: range,
                 sortText: "11",
               },
@@ -1556,7 +1539,7 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
                 kind: monaco.languages.CompletionItemKind.Method,
                 insertText: "unionAll(${1:query})",
                 insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-                detail: "Union All",
+                detail: `Union All — ${rawSqlOnly}`,
                 range: range,
                 sortText: "12",
               },
@@ -1565,7 +1548,7 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
                 kind: monaco.languages.CompletionItemKind.Method,
                 insertText: "intersect(${1:query})",
                 insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-                detail: "Intersect",
+                detail: `Intersect — ${rawSqlOnly}`,
                 range: range,
                 sortText: "13",
               },
@@ -1574,7 +1557,7 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
                 kind: monaco.languages.CompletionItemKind.Method,
                 insertText: "except(${1:query})",
                 insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-                detail: "Except",
+                detail: `Except — ${rawSqlOnly}`,
                 range: range,
                 sortText: "14",
               },
@@ -1611,7 +1594,7 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
               kind: monaco.languages.CompletionItemKind.Method,
               insertText: "onConflictDoUpdate({ target: ${1:column}, set: { $0 } })",
               insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-              detail: "Upsert (Update on conflict)",
+              detail: "Upsert (update on conflict) — raw SQL only · use db.execute(sql``)",
               range: range,
               sortText: "2",
             },
@@ -1620,7 +1603,7 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
               kind: monaco.languages.CompletionItemKind.Method,
               insertText: "onConflictDoNothing()",
               insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
-              detail: "Ignore conflict",
+              detail: "Ignore conflict — raw SQL only · use db.execute(sql``)",
               range: range,
               sortText: "3",
             },

--- a/packages/studio/src/features/drizzle-runner/utils/drizzle-query.ts
+++ b/packages/studio/src/features/drizzle-runner/utils/drizzle-query.ts
@@ -2,6 +2,84 @@ function trimTrailingSemicolon(value: string): string {
 	return value.trim().replace(/;\s*$/, '').trim()
 }
 
+function extractBalancedParens(source: string, startIndex: number): string | undefined {
+	if (source[startIndex] !== '(') return undefined
+	let depth = 0
+	let quote: string | null = null
+	let escape = false
+	for (let i = startIndex; i < source.length; i++) {
+		const char = source[i]
+		if (escape) {
+			escape = false
+			continue
+		}
+		if (quote) {
+			if (char === '\\') {
+				escape = true
+			} else if (char === quote) {
+				quote = null
+			}
+			continue
+		}
+		if (char === "'" || char === '"' || char === '`') {
+			quote = char
+			continue
+		}
+		if (char === '(') depth++
+		else if (char === ')') {
+			depth--
+			if (depth === 0) return source.slice(startIndex + 1, i)
+		}
+	}
+	return undefined
+}
+
+function splitArgsRespectingDepth(source: string): string[] {
+	const parts: string[] = []
+	let depth = 0
+	let quote: string | null = null
+	let escape = false
+	let current = ''
+
+	for (const char of source) {
+		if (escape) {
+			current += char
+			escape = false
+			continue
+		}
+		if (quote) {
+			current += char
+			if (char === '\\') escape = true
+			else if (char === quote) quote = null
+			continue
+		}
+		if (char === "'" || char === '"' || char === '`') {
+			quote = char
+			current += char
+			continue
+		}
+		if (char === '(' || char === '[' || char === '{') {
+			depth++
+			current += char
+			continue
+		}
+		if (char === ')' || char === ']' || char === '}') {
+			depth--
+			current += char
+			continue
+		}
+		if (char === ',' && depth === 0) {
+			parts.push(current.trim())
+			current = ''
+			continue
+		}
+		current += char
+	}
+
+	if (current.trim()) parts.push(current.trim())
+	return parts
+}
+
 function stripLeadingComments(value: string): string {
 	let next = value.trim()
 	let changed = true
@@ -62,45 +140,6 @@ function sqlIdentifier(identifier: string): string {
 		.join('.')
 }
 
-function splitTopLevelList(source: string): string[] {
-	const parts: string[] = []
-	let current = ''
-	let quote: string | null = null
-	let escape = false
-
-	for (const char of source) {
-		if (escape) {
-			current += char
-			escape = false
-			continue
-		}
-		if (char === '\\') {
-			current += char
-			escape = true
-			continue
-		}
-		if (quote) {
-			current += char
-			if (char === quote) quote = null
-			continue
-		}
-		if (char === "'" || char === '"' || char === '`') {
-			current += char
-			quote = char
-			continue
-		}
-		if (char === ',') {
-			parts.push(current.trim())
-			current = ''
-			continue
-		}
-		current += char
-	}
-
-	if (current.trim()) parts.push(current.trim())
-	return parts
-}
-
 function parseSqlLiteral(source: string): string | undefined {
 	const value = source.trim()
 	const quoted = value.match(/^(['"`])([\s\S]*)\1$/)
@@ -113,61 +152,221 @@ function parseSqlLiteral(source: string): string | undefined {
 	return undefined
 }
 
-function parseObjectAssignments(source: string): string[] | undefined {
-	const body = source.trim().replace(/^\{/, '').replace(/\}$/, '').trim()
+function parseColumnRef(source: string): string | undefined {
+	const match = source.trim().match(/^([A-Za-z_$][\w$]*)(?:\.([A-Za-z_$][\w$]*))?$/)
+	if (!match) return undefined
+	const column = match[2] ?? match[1]
+	return sqlIdentifier(column)
+}
+
+function parseArrayLiteral(source: string): string[] | undefined {
+	const trimmed = source.trim()
+	if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return undefined
+	const body = trimmed.slice(1, -1).trim()
+	if (!body) return []
+	const items = splitArgsRespectingDepth(body).map(parseSqlLiteral)
+	if (items.some((item) => item === undefined)) return undefined
+	return items as string[]
+}
+
+const COMPARISON_OPERATORS: Record<string, string> = {
+	eq: '=',
+	ne: '!=',
+	gt: '>',
+	gte: '>=',
+	lt: '<',
+	lte: '<=',
+	like: 'LIKE',
+	ilike: 'ILIKE'
+}
+
+function extractCall(source: string): { name: string; args: string[] } | undefined {
+	const trimmed = source.trim()
+	const head = trimmed.match(/^([A-Za-z_$][\w$]*)\s*\(/)
+	if (!head) return undefined
+	const open = head[0].length - 1
+	const inner = extractBalancedParens(trimmed, open)
+	if (inner === undefined) return undefined
+	if (trimmed.slice(open + inner.length + 2).trim() !== '') return undefined
+	return { name: head[1], args: splitArgsRespectingDepth(inner) }
+}
+
+/**
+ * Recursively converts a Drizzle filter expression (eq/ne/.../and/or/not/
+ * inArray/isNull/between, arbitrarily nested) into a SQL boolean expression.
+ * Returns undefined when any leaf falls outside the supported literal grammar.
+ */
+function parseConditionExpression(source: string): string | undefined {
+	const call = extractCall(source)
+	if (!call) return undefined
+	const { name, args } = call
+
+	if (name === 'and' || name === 'or') {
+		if (args.length === 0) return undefined
+		const parts = args.map(parseConditionExpression)
+		if (parts.some((part) => part === undefined)) return undefined
+		return `(${parts.join(name === 'and' ? ' AND ' : ' OR ')})`
+	}
+
+	if (name === 'not') {
+		if (args.length !== 1) return undefined
+		const inner = parseConditionExpression(args[0])
+		if (!inner) return undefined
+		return `(NOT ${inner})`
+	}
+
+	if (name in COMPARISON_OPERATORS) {
+		if (args.length !== 2) return undefined
+		const column = parseColumnRef(args[0])
+		const value = parseSqlLiteral(args[1])
+		if (!column || value === undefined) return undefined
+		return `${column} ${COMPARISON_OPERATORS[name]} ${value}`
+	}
+
+	if (name === 'isNull' || name === 'isNotNull') {
+		if (args.length !== 1) return undefined
+		const column = parseColumnRef(args[0])
+		if (!column) return undefined
+		return `${column} IS ${name === 'isNull' ? 'NULL' : 'NOT NULL'}`
+	}
+
+	if (name === 'inArray' || name === 'notInArray') {
+		if (args.length !== 2) return undefined
+		const column = parseColumnRef(args[0])
+		const list = parseArrayLiteral(args[1])
+		if (!column || !list || list.length === 0) return undefined
+		return `${column} ${name === 'inArray' ? 'IN' : 'NOT IN'} (${list.join(', ')})`
+	}
+
+	if (name === 'between') {
+		if (args.length !== 3) return undefined
+		const column = parseColumnRef(args[0])
+		const low = parseSqlLiteral(args[1])
+		const high = parseSqlLiteral(args[2])
+		if (!column || low === undefined || high === undefined) return undefined
+		return `${column} BETWEEN ${low} AND ${high}`
+	}
+
+	return undefined
+}
+
+function parseOrderTerm(source: string): string | undefined {
+	const call = extractCall(source)
+	if (call && (call.name === 'asc' || call.name === 'desc')) {
+		if (call.args.length !== 1) return undefined
+		const column = parseColumnRef(call.args[0])
+		if (!column) return undefined
+		return `${column} ${call.name.toUpperCase()}`
+	}
+	return parseColumnRef(source)
+}
+
+function parseOrderByTerms(source: string): string[] | undefined {
+	let body = source.trim()
+	if (body.startsWith('[') && body.endsWith(']')) body = body.slice(1, -1).trim()
+	if (!body) return undefined
+	const terms = splitArgsRespectingDepth(body).map(parseOrderTerm)
+	if (terms.some((term) => term === undefined)) return undefined
+	return terms as string[]
+}
+
+function parseObjectLiteral(source: string): { keys: string[]; values: string[] } | undefined {
+	const trimmed = source.trim()
+	if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return undefined
+	const body = trimmed.slice(1, -1).trim()
 	if (!body) return undefined
 
-	const assignments: string[] = []
-	for (const entry of splitTopLevelList(body)) {
-		const match = entry.match(/^([A-Za-z_][\w$]*|['"`][^'"`]+['"`])\s*:\s*([\s\S]+)$/)
+	const keys: string[] = []
+	const values: string[] = []
+	for (const entry of splitArgsRespectingDepth(body)) {
+		const match = entry.match(/^([A-Za-z_$][\w$]*|['"`][^'"`]+['"`])\s*:\s*([\s\S]+)$/)
 		if (!match) return undefined
 		const key = match[1].replace(/^['"`]|['"`]$/g, '')
 		const value = parseSqlLiteral(match[2])
 		if (value === undefined) return undefined
-		assignments.push(`${sqlIdentifier(key)} = ${value}`)
+		keys.push(key)
+		values.push(value)
 	}
 
-	return assignments
+	return { keys, values }
 }
 
-function parseWhereExpression(source: string): string | undefined {
-	const match = source
-		.trim()
-		.match(/^(eq|ne|gt|gte|lt|lte|like|ilike)\(\s*([A-Za-z_][\w$]*)\.([A-Za-z_][\w$]*)\s*,\s*([\s\S]+)\)$/)
-	if (!match) return undefined
+function parseObjectAssignments(source: string): string[] | undefined {
+	const object = parseObjectLiteral(source)
+	if (!object) return undefined
+	return object.keys.map((key, index) => `${sqlIdentifier(key)} = ${object.values[index]}`)
+}
 
-	const operatorMap: Record<string, string> = {
-		eq: '=',
-		ne: '!=',
-		gt: '>',
-		gte: '>=',
-		lt: '<',
-		lte: '<=',
-		like: 'LIKE',
-		ilike: 'ILIKE'
+function parseValuesRows(source: string): { columns: string[]; tuples: string[][] } | undefined {
+	const trimmed = source.trim()
+	let objectSources: string[]
+	if (trimmed.startsWith('[')) {
+		if (!trimmed.endsWith(']')) return undefined
+		const body = trimmed.slice(1, -1).trim()
+		if (!body) return undefined
+		objectSources = splitArgsRespectingDepth(body)
+	} else {
+		objectSources = [trimmed]
 	}
-	const value = parseSqlLiteral(match[4])
-	if (value === undefined) return undefined
 
-	return `${sqlIdentifier(match[3])} ${operatorMap[match[1]]} ${value}`
+	const parsed = objectSources.map(parseObjectLiteral)
+	if (parsed.some((object) => object === undefined)) return undefined
+
+	const rows = parsed as { keys: string[]; values: string[] }[]
+	const columns = rows[0].keys
+	for (const row of rows) {
+		if (row.keys.length !== columns.length) return undefined
+		for (let i = 0; i < columns.length; i++) {
+			if (row.keys[i] !== columns[i]) return undefined
+		}
+	}
+
+	return { columns, tuples: rows.map((row) => row.values) }
+}
+
+type ChainCall = { inner: string; full: string }
+
+function extractChainCall(chain: string, method: string): ChainCall | undefined {
+	const match = chain.match(new RegExp(`\\.${method}\\s*\\(`))
+	if (!match || match.index === undefined) return undefined
+	const open = match.index + match[0].length - 1
+	const inner = extractBalancedParens(chain, open)
+	if (inner === undefined) return undefined
+	return { inner, full: chain.slice(match.index, open + inner.length + 2) }
+}
+
+function parseTrailingReturning(rest: string): boolean {
+	const trimmed = rest.trim()
+	if (!trimmed) return false
+	if (/^\.returning\s*\(\s*\)$/.test(trimmed)) return true
+	throw new Error(
+		'Unsupported chain segment. Only an optional .returning() may follow. ' +
+		'For onConflict / upsert / RETURNING projections, use db.execute(sql`...`).'
+	)
 }
 
 /**
  * Converts a Drizzle ORM query expression to a plain SQL string.
  *
  * Supported patterns:
- *   - sql`SELECT ...`
- *   - db.execute(sql`SELECT ...`)
- *   - tx.execute(sql`SELECT ...`)
- *   - db.execute('SELECT ...')
- *   - (db|tx).select().from(table) [optional .limit(n), .offset(n)]
- *   - (db|tx).update(table).set({ column: value }).where(eq(table.column, value))
+ *   - sql`SELECT ...`, (db|tx).execute(sql`SELECT ...`), (db|tx).execute('SELECT ...')
+ *   - (db|tx).select().from(table) with optional .where(...), .orderBy(...), .limit(n), .offset(n)
+ *   - (db|tx).insert(table).values({ ... } | [{ ... }]) with optional .returning()
+ *   - (db|tx).update(table).set({ ... }).where(...) with optional .returning()
+ *   - (db|tx).delete(table).where(...) with optional .returning()
+ *   - (db|tx).$count(table[, condition])
+ *   - Any of the above with a trailing .toSQL() call
  *
- * Unsupported patterns (e.g. .where(), .orderBy(), .join()) throw explicit
- * messages directing users to use db.execute(sql`...`).
+ * .where()/conditions accept eq/ne/gt/gte/lt/lte/like/ilike/inArray/notInArray/
+ * isNull/isNotNull/between combined with and/or/not, over literal values.
+ *
+ * update()/delete() require a .where() — unguarded whole-table mutations are
+ * rejected. Joins, groupBy/having, set operations (union/…), and column
+ * projections are not auto-translated; use db.execute(sql`...`) for those.
  */
 export function drizzleQueryToSql(source: string): string {
-	const query = trimTrailingSemicolon(stripLeadingComments(source))
+	const stripped = trimTrailingSemicolon(stripLeadingComments(source))
+	const query = stripped.replace(/\.toSQL\s*\(\s*\)\s*$/, '').trimEnd()
 	if (!query) {
 		throw new Error('Enter a Drizzle query to execute.')
 	}
@@ -201,29 +400,55 @@ export function drizzleQueryToSql(source: string): string {
 
 		const chain = simpleSelectMatch[2].trim()
 
-		if (/\.where\s*\(/i.test(chain)) {
+		const hardMethod = chain.match(
+			/\.(leftJoin|rightJoin|innerJoin|fullJoin|join|groupBy|having|unionAll|union|intersect|except)\s*\(/
+		)
+		if (hardMethod) {
 			throw new Error(
-				'Queries with .where() are not auto-translated. ' +
-				'Use db.execute(sql`...`) instead.'
-			)
-		}
-		if (/\.orderBy\s*\(/i.test(chain)) {
-			throw new Error(
-				'Queries with .orderBy() are not auto-translated. ' +
-				'Use db.execute(sql`...`) instead.'
+				`.${hardMethod[1]}() is not auto-translated. Use db.execute(sql\`...\`) ` +
+				'for joins, grouping, and set operations.'
 			)
 		}
 
-		const unsupportedChain = chain
+		let strippedChain = chain
+		let whereClause: string | undefined
+		let orderByClause: string | undefined
+
+		const whereCall = extractChainCall(chain, 'where')
+		if (whereCall) {
+			whereClause = parseConditionExpression(whereCall.inner.trim())
+			if (!whereClause) {
+				throw new Error(
+					'Unsupported .where() expression. Use eq/ne/gt/gte/lt/lte/like/ilike/' +
+					'inArray/notInArray/isNull/isNotNull/between combined with and/or/not, ' +
+					'or db.execute(sql`...`).'
+				)
+			}
+			strippedChain = strippedChain.replace(whereCall.full, '')
+		}
+
+		const orderCall = extractChainCall(chain, 'orderBy')
+		if (orderCall) {
+			const terms = parseOrderByTerms(orderCall.inner)
+			if (!terms) {
+				throw new Error(
+					'Unsupported .orderBy() expression. Use column references or ' +
+					'asc()/desc(), or db.execute(sql`...`).'
+				)
+			}
+			orderByClause = terms.join(', ')
+			strippedChain = strippedChain.replace(orderCall.full, '')
+		}
+
+		const unsupportedChain = strippedChain
 			.replace(/\.limit\s*\(\s*\d+\s*\)/g, '')
 			.replace(/\.offset\s*\(\s*\d+\s*\)/g, '')
 			.trim()
 
 		if (unsupportedChain) {
 			throw new Error(
-				'Unsupported Drizzle query. Currently supported: sql`...`, ' +
-				'(db|tx).execute(sql`...`), (db|tx).select().from(table) with ' +
-				'optional .limit(n) and .offset(n), without where/join clauses. ' +
+				'Unsupported Drizzle query. select().from(table) supports ' +
+				'.where(...), .orderBy(...), .limit(n), and .offset(n). ' +
 				'For more complex queries, use db.execute(sql`...`).'
 			)
 		}
@@ -231,43 +456,154 @@ export function drizzleQueryToSql(source: string): string {
 		const limitMatch = chain.match(/\.limit\s*\(\s*(\d+)\s*\)/)
 		const offsetMatch = chain.match(/\.offset\s*\(\s*(\d+)\s*\)/)
 		let sql = `SELECT * FROM ${tableName}`
+		if (whereClause) sql += ` WHERE ${whereClause}`
+		if (orderByClause) sql += ` ORDER BY ${orderByClause}`
 		if (limitMatch) sql += ` LIMIT ${limitMatch[1]}`
 		if (offsetMatch) sql += ` OFFSET ${offsetMatch[1]}`
 		return sql
 	}
 
-	const simpleUpdateMatch = query.match(
-		/^(?:await\s+)?(?:db|tx)\.update\s*\(\s*([^)]+?)\s*\)\s*\.set\s*\(\s*(\{[\s\S]*?\})\s*\)\s*\.where\s*\(\s*([\s\S]+?)\s*\)(?:\s*\.returning\s*\(\s*\))?$/
+	const insertHead = query.match(
+		/^(?:await\s+)?(?:db|tx)\.insert\s*\(\s*([^)]+?)\s*\)\s*\.values\s*\(/
 	)
-	if (simpleUpdateMatch) {
-		const tableName = normalizeTableExpression(simpleUpdateMatch[1])
+	if (insertHead) {
+		const tableName = normalizeTableExpression(insertHead[1])
 		if (!tableName) {
 			throw new Error(
-				'Unsupported Drizzle table expression. Use a simple table name ' +
-				'(e.g. users, schema.users). For quoted or multi-part names, ' +
-				'use db.execute(sql`...`).'
+				'Unsupported insert table expression. Use a simple table name, ' +
+				'or db.execute(sql`...`).'
 			)
 		}
-
-		const assignments = parseObjectAssignments(simpleUpdateMatch[2])
-		const where = parseWhereExpression(simpleUpdateMatch[3])
-
-		if (!assignments || !where) {
+		const open = query.indexOf('(', insertHead[0].length - 1)
+		const inner = extractBalancedParens(query, open)
+		if (inner === undefined) {
+			throw new Error('Malformed .values() call.')
+		}
+		const returning = parseTrailingReturning(query.slice(open + inner.length + 2))
+		const rows = parseValuesRows(inner.trim())
+		if (!rows) {
 			throw new Error(
-				'Unsupported Drizzle update expression. Supported shape: ' +
-				'db.update(table).set({ column: value }).where(eq(table.column, value)). ' +
-				'For complex updates, use db.execute(sql`...`).'
+				'Unsupported .values() payload. Use an object literal { column: value } ' +
+				'(or an array of them) with literal values. For expressions, use db.execute(sql`...`).'
 			)
 		}
+		const columnsSql = rows.columns.map(sqlIdentifier).join(', ')
+		const valuesSql = rows.tuples.map((tuple) => `(${tuple.join(', ')})`).join(', ')
+		let sql = `INSERT INTO ${sqlIdentifier(tableName)} (${columnsSql}) VALUES ${valuesSql}`
+		if (returning) sql += ' RETURNING *'
+		return sql
+	}
 
-		return `UPDATE ${sqlIdentifier(tableName)} SET ${assignments.join(', ')} WHERE ${where}`
+	const deleteHead = query.match(
+		/^(?:await\s+)?(?:db|tx)\.delete\s*\(\s*([^)]+?)\s*\)([\s\S]*)$/
+	)
+	if (deleteHead) {
+		const tableName = normalizeTableExpression(deleteHead[1])
+		if (!tableName) {
+			throw new Error(
+				'Unsupported delete table expression. Use a simple table name, ' +
+				'or db.execute(sql`...`).'
+			)
+		}
+		const rest = deleteHead[2].trim()
+		const whereCall = rest ? extractChainCall(rest, 'where') : undefined
+		if (!whereCall) {
+			throw new Error(
+				'db.delete(table) without .where() is rejected to avoid deleting every row. ' +
+				'Add .where(...), or use db.execute(sql`DELETE FROM ...`).'
+			)
+		}
+		const condition = parseConditionExpression(whereCall.inner.trim())
+		if (!condition) {
+			throw new Error(
+				'Unsupported .where() expression in delete. Use eq/ne/.../and/or/not over ' +
+				'literal values, or db.execute(sql`...`).'
+			)
+		}
+		const returning = parseTrailingReturning(rest.replace(whereCall.full, ''))
+		let sql = `DELETE FROM ${sqlIdentifier(tableName)} WHERE ${condition}`
+		if (returning) sql += ' RETURNING *'
+		return sql
+	}
+
+	const updateHead = query.match(
+		/^(?:await\s+)?(?:db|tx)\.update\s*\(\s*([^)]+?)\s*\)\s*\.set\s*\(/
+	)
+	if (updateHead) {
+		const tableName = normalizeTableExpression(updateHead[1])
+		if (!tableName) {
+			throw new Error(
+				'Unsupported update table expression. Use a simple table name, ' +
+				'or db.execute(sql`...`).'
+			)
+		}
+		const open = query.indexOf('(', updateHead[0].length - 1)
+		const setInner = extractBalancedParens(query, open)
+		if (setInner === undefined) {
+			throw new Error('Malformed .set() call.')
+		}
+		const assignments = parseObjectAssignments(setInner.trim())
+		if (!assignments) {
+			throw new Error(
+				'Unsupported .set() payload. Use { column: value } with literal values, ' +
+				'or db.execute(sql`...`).'
+			)
+		}
+		const rest = query.slice(open + setInner.length + 2).trim()
+		const whereCall = rest ? extractChainCall(rest, 'where') : undefined
+		if (!whereCall) {
+			throw new Error(
+				'db.update(table).set({...}) without .where() is rejected to avoid updating ' +
+				'every row. Add .where(...), or use db.execute(sql`...`).'
+			)
+		}
+		const condition = parseConditionExpression(whereCall.inner.trim())
+		if (!condition) {
+			throw new Error(
+				'Unsupported .where() expression in update. Use eq/ne/.../and/or/not over ' +
+				'literal values, or db.execute(sql`...`).'
+			)
+		}
+		const returning = parseTrailingReturning(rest.replace(whereCall.full, ''))
+		let sql = `UPDATE ${sqlIdentifier(tableName)} SET ${assignments.join(', ')} WHERE ${condition}`
+		if (returning) sql += ' RETURNING *'
+		return sql
+	}
+
+	const countCallMatch = query.match(/^(?:await\s+)?(?:db|tx)\.\$count\s*\(/)
+	if (countCallMatch) {
+		const parenStart = query.indexOf('(', countCallMatch[0].length - 1)
+		const inner = extractBalancedParens(query, parenStart)
+		if (inner === undefined) {
+			throw new Error('Malformed db.$count() call.')
+		}
+		const args = splitArgsRespectingDepth(inner)
+		const tableName = normalizeTableExpression(args[0] ?? '')
+		if (!tableName) {
+			throw new Error(
+				'Unsupported db.$count() table expression. Use a simple table name ' +
+				'(e.g. db.$count(users) or db.$count(users, eq(users.active, true))).'
+			)
+		}
+		let sql = `SELECT count(*) FROM ${tableName}`
+		if (args.length > 1) {
+			const condition = parseConditionExpression(args.slice(1).join(', '))
+			if (!condition) {
+				throw new Error(
+					'Unsupported db.$count() condition. Use eq/ne/.../and/or/not over ' +
+					'literal values, or db.execute(sql`...`).'
+				)
+			}
+			sql += ` WHERE ${condition}`
+		}
+		return sql
 	}
 
 	throw new Error(
-		'Unsupported Drizzle query. Currently supported: ' +
-		'sql`...`, (db|tx).execute(sql`...`), ' +
-		'(db|tx).select().from(table) with optional .limit(n) and .offset(n), ' +
-		'without where/orderBy/join clauses. ' +
-		'For more complex queries, use db.execute(sql`...`).'
+		'Unsupported Drizzle query. Supported: sql`...`, (db|tx).execute(sql`...`), ' +
+		'select().from(table) (+ .where/.orderBy/.limit/.offset), ' +
+		'insert(table).values({...}), update(table).set({...}).where(...), ' +
+		'delete(table).where(...), and $count(table). ' +
+		'Append .toSQL() to any of these. For everything else, use db.execute(sql`...`).'
 	)
 }

--- a/packages/studio/src/features/drizzle-runner/utils/lsp-patterns.ts
+++ b/packages/studio/src/features/drizzle-runner/utils/lsp-patterns.ts
@@ -13,7 +13,7 @@
  * Returns "db" for db., "tx" for tx., null otherwise.
  */
 export function getDbName(text: string): 'db' | 'tx' | null {
-	const match = text.match(/\b(db|tx)\.[\w]*$/)
+	const match = text.match(/\b(db|tx)\.[\w$]*$/)
 	if (!match) return null
 	if (match[1] === 'tx') return 'tx'
 	return 'db'
@@ -139,6 +139,10 @@ export function isInsideFromParens(text: string): boolean {
 
 export function isInsideJoinParens(text: string): boolean {
 	return /\.(left|right|inner|full)Join\(\s*[\w]*$/.test(text)
+}
+
+export function isInsideCountParens(text: string): boolean {
+	return /\b(?:db|tx)\.\$count\(\s*[\w]*$/.test(text)
 }
 
 export function isInsideWhereParens(text: string): boolean {

--- a/packages/studio/src/features/prisma-runner/prisma-runner.tsx
+++ b/packages/studio/src/features/prisma-runner/prisma-runner.tsx
@@ -166,42 +166,17 @@ export function PrismaRunner({ connectionId }: PrismaRunnerProps) {
 
 	return (
 		<div className='flex h-full w-full flex-col bg-background overflow-hidden text-sm'>
-			<div className='flex items-center h-10 border-b border-sidebar-border bg-sidebar shrink-0 px-2 justify-between'>
-				<div className='flex items-center gap-2'>
-					<span className='font-semibold text-sidebar-foreground px-2'>Prisma Runner</span>
-				</div>
-
-				<div className='flex items-center gap-1 mx-4'>
-					<Button
-						size='sm'
-						variant='default'
-						className={cn(
-							'h-7 px-3 gap-1.5 text-xs font-medium shadow-sm transition-all',
-							isRunning
-								? 'bg-muted text-muted-foreground cursor-wait'
-								: 'bg-emerald-600 hover:bg-emerald-700 text-white hover:scale-105 active:scale-95'
-						)}
-						onClick={function () {
-							handleExecute()
-						}}
-						disabled={isRunning}
-					>
-						{isRunning ? (
-							<Loader2 className='h-3 w-3 animate-spin' />
-						) : (
-							<Play className='h-3 w-3 fill-current' />
-						)}
-						<span>{isRunning ? 'Running...' : 'Run'}</span>
-					</Button>
-
-					<div className='w-px h-4 bg-border/50 mx-1' />
+			<div className='flex h-9 shrink-0 items-center justify-between gap-2 border-b border-sidebar-border bg-sidebar px-2'>
+				<div className='flex min-w-0 items-center gap-1'>
+					<span className='px-2 text-xs font-medium text-muted-foreground'>Prisma</span>
 
 					<Button
 						variant='ghost'
 						size='icon'
-						className='h-7 w-7 text-muted-foreground hover:text-foreground'
+						className='h-8 w-8 rounded-md text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.97]'
 						onClick={handlePrettify}
 						title='Format code (Shift+Alt+F)'
+						aria-label='Format code'
 					>
 						<Sparkles className='h-3.5 w-3.5' />
 					</Button>
@@ -210,13 +185,15 @@ export function PrismaRunner({ connectionId }: PrismaRunnerProps) {
 						variant='ghost'
 						size='icon'
 						className={cn(
-							'h-7 w-7 text-muted-foreground hover:text-foreground',
-							showJson && 'text-primary bg-primary/10'
+							'h-8 w-8 rounded-md text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.97]',
+							showJson && 'bg-sidebar-accent text-sidebar-foreground'
 						)}
 						onClick={function () {
 							setShowJson(!showJson)
 						}}
 						title='Toggle JSON view'
+						aria-label='Toggle JSON view'
+						aria-pressed={showJson}
 					>
 						<Braces className='h-3.5 w-3.5' />
 					</Button>
@@ -225,25 +202,48 @@ export function PrismaRunner({ connectionId }: PrismaRunnerProps) {
 						variant='ghost'
 						size='icon'
 						className={cn(
-							'h-7 w-7 text-muted-foreground hover:text-foreground',
-							(!result || result.rows.length === 0) && 'opacity-50 cursor-not-allowed'
+							'h-8 w-8 rounded-md text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.97]',
+							(!result || result.rows.length === 0) && 'cursor-not-allowed opacity-45'
 						)}
 						onClick={handleExport}
 						disabled={!result || result.rows.length === 0}
 						title='Export results as JSON'
+						aria-label='Export results as JSON'
 					>
 						<Download className='h-3.5 w-3.5' />
 					</Button>
 				</div>
 
-				<div className='flex items-center gap-1'>
+				<div className='flex shrink-0 items-center gap-1.5'>
+					<Button
+						size='sm'
+						variant='default'
+						className='h-7 gap-2 rounded-md px-3 text-xs font-semibold shadow-sm transition-[background-color,color,transform,box-shadow] duration-150 ease-out active:scale-[0.97] bg-sidebar-foreground text-sidebar hover:bg-sidebar-foreground/90'
+						onClick={function () {
+							handleExecute()
+						}}
+						disabled={isRunning}
+					>
+						{isRunning ? (
+							<Loader2 className='h-3.5 w-3.5 animate-spin' />
+						) : (
+							<Play className='h-3.5 w-3.5 fill-current' />
+						)}
+						<span>{isRunning ? 'Running…' : 'Run'}</span>
+					</Button>
+
 					<Button
 						variant='ghost'
 						size='sm'
-						className={cn('h-7 text-xs', isSidebarCollapsed && 'bg-sidebar-accent')}
+						className={cn(
+							'h-7 gap-1.5 rounded-md px-2 text-xs text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-sidebar-accent hover:text-sidebar-foreground active:scale-[0.97]',
+							isSidebarCollapsed && 'bg-sidebar-accent'
+						)}
 						onClick={function () {
 							setIsSidebarCollapsed(!isSidebarCollapsed)
 						}}
+						aria-expanded={!isSidebarCollapsed}
+						aria-label={isSidebarCollapsed ? 'Show schema sidebar' : 'Hide schema sidebar'}
 					>
 						{isSidebarCollapsed ? 'Show Schema' : 'Hide Schema'}
 					</Button>


### PR DESCRIPTION
## Summary

The Drizzle runner translates queries to SQL in the **frontend** (there is no Drizzle runtime), but the autocomplete was a near-complete Drizzle LSP — so it guided users to build queries the translator then rejected at run time. This PR aligns the two, expands the executable surface, and fixes the embedded Prisma toolbar.

## Translator (`drizzle-query.ts`)
- `db.$count(table[, condition])` and a trailing `.toSQL()` on any form
- `select()`: multi-condition `.where(and/or/not, inArray, between, isNull, …)` and `.orderBy(asc/desc/col)`, alongside `.limit/.offset`
- `insert(table).values({…} | [{…}])` with optional `.returning()`
- `delete(table).where(…)` and `update().set().where()` with `.returning()`
- **Whole-table guard:** unguarded `UPDATE`/`DELETE` (no `WHERE`) are rejected on purpose
- Precise, method-named errors for joins / groupBy / having / union (→ `db.execute(sql\`…\`)`)
- Quote-aware paren/arg parsing + a recursive condition parser

## Autocomplete (`code-editor.tsx`, `lsp-patterns.ts`)
- `$count` completion + `$`-aware `db.` member detection
- `select(table)` now inserts `).from(table)` so the next `.` drives chaining (instead of the broken `db.select(table)`)
- Removed the bogus `.where('col','=',x)` suggestions (neither valid Drizzle nor translatable)
- Non-translatable chain methods are labeled **"raw SQL only"** and sorted last, so autocomplete only *promotes* what executes

## Prisma runner UI — closes #178
The embedded `PrismaRunner` rendered its own toolbar with a centered button group and an off-palette emerald Run button. Restyled it to match the console's action bar: left-aligned tools, right-aligned monochrome Run.

## Related issues
- Closes #178 (Prisma toolbar)
- Addresses #176 (Drizzle `eq` LSP support) — residual dotless-chain papercut tracked separately
- Related to #162 (that issue is schema-level DDL conversion, a different scope — not closed here)

## Testing
145 tests pass across `drizzle-runner`, `prisma-runner`, and `sql-console` suites (up from 38 at the start). New coverage for every added capability and guard. `tsc --noEmit` clean on all edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/remco-stoeten/codesmith/dora/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784643551&installation_id=140085766&pr_number=179&repository=remco-stoeten%2Fdora&return_to=https%3A%2F%2Fgithub.com%2Fremco-stoeten%2Fdora%2Fpull%2F179&signature=7519059b5a5d636bb7e5ff42dabff14bc9795924d0d923f72e84f37871368ec5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->