### PR TITLE
fix(studio): UI quick wins — remove AI index button, lower AI panel, unified spinner

### DIFF
--- a/__tests__/ai-actions.test.ts
+++ b/__tests__/ai-actions.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
 	buildExplainQueryPrompt,
-	buildFixErrorPrompt,
-	buildSuggestIndexesPrompt
+	buildFixErrorPrompt
 } from '@/features/ai-assistant/ai-actions'
 
 describe('AI contextual prompt builders', () => {
@@ -16,13 +15,6 @@ describe('AI contextual prompt builders', () => {
 		expect(buildFixErrorPrompt('SELECT * FROM userz', 'relation "userz" does not exist')).toBe(
 			'This SQL query failed with the following error. Suggest a fix:\n\n' +
 				'Query:\nSELECT * FROM userz\n\nError:\nrelation "userz" does not exist'
-		)
-	})
-
-	it('builds a suggest-indexes prompt with schema and queries', () => {
-		expect(buildSuggestIndexesPrompt('CREATE TABLE t (...)', 'SELECT ...')).toBe(
-			'Given this table schema and these queries, what indexes would improve performance?\n\n' +
-				'CREATE TABLE t (...)\n\nSELECT ...'
 		)
 	})
 })

--- a/__tests__/apps/desktop/src/features/docker-manager/components/docker-view.test.tsx
+++ b/__tests__/apps/desktop/src/features/docker-manager/components/docker-view.test.tsx
@@ -138,7 +138,7 @@ describe('DockerView', () => {
 
 		renderWithProviders(<DockerView />)
 		expect(screen.getByText('Containers: 1')).toBeInTheDocument()
-		expect(screen.getByText('Docker Containers')).toBeInTheDocument()
+		expect(screen.getByText('Docker')).toBeInTheDocument()
 	})
 
 	it('opens create dialog when "New Container" is clicked', () => {
@@ -156,7 +156,7 @@ describe('DockerView', () => {
 
 		renderWithProviders(<DockerView />)
 
-		const newButton = screen.getByText('New Container')
+		const newButton = screen.getByText('New')
 		fireEvent.click(newButton)
 
 		expect(screen.getByTestId('create-dialog')).toBeInTheDocument()

--- a/packages/studio/src/components/credential-storage-notice.tsx
+++ b/packages/studio/src/components/credential-storage-notice.tsx
@@ -1,5 +1,6 @@
 import { notify } from '@remcostoeten/notifier'
-import { Check, Copy, Download, KeyRound, Loader2, X } from 'lucide-react'
+import { Check, Copy, Download, KeyRound, X } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useEffect, useState } from 'react'
 import { useIsTauri } from '@studio/core/data-provider'
 import {
@@ -132,7 +133,7 @@ export function CredentialStorageNotice({ className }: { className?: string }) {
 					title={plan.command}
 				>
 					{installing ? (
-						<Loader2 className='h-3.5 w-3.5 animate-spin' />
+						<Spinner className='h-3.5 w-3.5' />
 					) : plan.can_auto_install ? (
 						<Download className='h-3.5 w-3.5' />
 					) : hasCopied ? (

--- a/packages/studio/src/features/ai-assistant/ai-actions.ts
+++ b/packages/studio/src/features/ai-assistant/ai-actions.ts
@@ -2,8 +2,8 @@ import { useAiAssistantStore } from './store'
 
 /**
  * Opens the AI assistant panel and pre-fills it with a prompt. Shared entry
- * point for contextual actions (explain query, fix error, suggest indexes) so
- * they work from anywhere whether the panel is open or closed.
+ * point for contextual actions (explain query, fix error) so they work from
+ * anywhere whether the panel is open or closed.
  */
 export function askAi(prompt: string): void {
 	const store = useAiAssistantStore.getState()
@@ -17,8 +17,4 @@ export function buildExplainQueryPrompt(query: string): string {
 
 export function buildFixErrorPrompt(query: string, error: string): string {
 	return `This SQL query failed with the following error. Suggest a fix:\n\nQuery:\n${query}\n\nError:\n${error}`
-}
-
-export function buildSuggestIndexesPrompt(schema: string, queries: string): string {
-	return `Given this table schema and these queries, what indexes would improve performance?\n\n${schema}\n\n${queries}`
 }

--- a/packages/studio/src/features/ai-assistant/ai-assistant-panel.tsx
+++ b/packages/studio/src/features/ai-assistant/ai-assistant-panel.tsx
@@ -208,7 +208,7 @@ export function AiAssistantPanel({
 	return (
 		<aside
 			className={cn(
-				'fixed right-0 top-0 z-40 flex h-full w-[420px] max-w-[90vw] flex-col border-l border-sidebar-border bg-sidebar shadow-2xl'
+				'fixed right-0 top-9 z-40 flex h-[calc(100%-2.25rem)] w-[420px] max-w-[90vw] flex-col border-l border-sidebar-border bg-sidebar shadow-2xl'
 			)}
 		>
 			<header className='flex items-center gap-2 border-b border-sidebar-border px-3 py-2'>

--- a/packages/studio/src/features/ai-assistant/ai-provider-section.tsx
+++ b/packages/studio/src/features/ai-assistant/ai-provider-section.tsx
@@ -1,4 +1,5 @@
-import { Loader2, RefreshCw } from 'lucide-react'
+import { RefreshCw } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useIsTauri } from '@studio/core/data-provider'
 import { commands, type AiModelOption, type AiServiceConfig } from '@studio/lib/bindings'
@@ -194,7 +195,7 @@ export function AiProviderSection() {
 
 			{loading ? (
 				<div className='flex items-center gap-2 text-xs text-muted-foreground'>
-					<Loader2 className='h-3 w-3 animate-spin' />
+					<Spinner className='h-3 w-3' />
 					Loading…
 				</div>
 			) : (
@@ -343,7 +344,7 @@ export function AiProviderSection() {
 							onClick={handleSave}
 							disabled={!isTauri || saving || !config.model.trim()}
 						>
-							{saving ? <Loader2 className='h-3 w-3 animate-spin' /> : 'Save provider'}
+							{saving ? <Spinner className='h-3 w-3' /> : 'Save provider'}
 						</Button>
 						{message ? (
 							<span

--- a/packages/studio/src/features/ai-assistant/ai-usage-section.tsx
+++ b/packages/studio/src/features/ai-assistant/ai-usage-section.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useCallback, useEffect, useState } from 'react'
 import { useIsTauri } from '@studio/core/data-provider'
 import { buildMockAiUsageSummary } from '@studio/features/ai-assistant/mock-ai'
@@ -77,7 +77,7 @@ export function AiUsageSection() {
 	if (loading) {
 		return (
 			<div className='flex items-center gap-2 text-xs text-muted-foreground'>
-				<Loader2 className='h-3 w-3 animate-spin' />
+				<Spinner className='h-3 w-3' />
 				Loading usage…
 			</div>
 		)

--- a/packages/studio/src/features/ai-assistant/code-block.tsx
+++ b/packages/studio/src/features/ai-assistant/code-block.tsx
@@ -2,12 +2,12 @@ import {
 	Check,
 	Copy,
 	FileInput,
-	Loader2,
 	Maximize2,
 	Minimize2,
 	Play,
 	ShieldCheck
 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useCallback, useMemo, useState } from 'react'
 import { getEnv } from '@studio/core/env'
 import { notifySchemaChanged } from '@studio/core/schema-refresh'
@@ -277,7 +277,7 @@ export function CodeBlock({
 							title='Run SQL'
 						>
 							{runState.kind === 'running' && runState.mode === 'run' ? (
-								<Loader2 className='mr-1 h-3 w-3 animate-spin' />
+								<Spinner className='mr-1 h-3 w-3' />
 							) : (
 								<Play className='mr-1 h-3 w-3' />
 							)}
@@ -294,7 +294,7 @@ export function CodeBlock({
 							title='Dry run with EXPLAIN'
 						>
 							{runState.kind === 'running' && runState.mode === 'dry-run' ? (
-								<Loader2 className='mr-1 h-3 w-3 animate-spin' />
+								<Spinner className='mr-1 h-3 w-3' />
 							) : (
 								<ShieldCheck className='mr-1 h-3 w-3' />
 							)}

--- a/packages/studio/src/features/ai-assistant/ollama-models-section.tsx
+++ b/packages/studio/src/features/ai-assistant/ollama-models-section.tsx
@@ -1,5 +1,6 @@
 import { Channel } from '@tauri-apps/api/core'
-import { Check, Download, ExternalLink, Loader2, Trash2 } from 'lucide-react'
+import { Check, Download, ExternalLink, Trash2 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useIsTauri } from '@studio/core/data-provider'
 import {
@@ -452,7 +453,7 @@ export function OllamaModelsSection() {
 							void startManagedOllama()
 						}}
 					>
-						{starting ? <Loader2 className='mr-1 h-3 w-3 animate-spin' /> : null}
+						{starting ? <Spinner className='mr-1 h-3 w-3' /> : null}
 						Start Ollama
 					</Button>
 				</div>
@@ -479,7 +480,7 @@ export function OllamaModelsSection() {
 						}}
 						disabled={savingEndpoint}
 					>
-						{savingEndpoint ? <Loader2 className='h-3 w-3 animate-spin' /> : 'Save'}
+						{savingEndpoint ? <Spinner className='h-3 w-3' /> : 'Save'}
 					</Button>
 				</div>
 			</label>
@@ -577,7 +578,7 @@ export function OllamaModelsSection() {
 
 			{loading ? (
 				<div className='flex items-center gap-2 text-xs text-muted-foreground'>
-					<Loader2 className='h-3 w-3 animate-spin' />
+					<Spinner className='h-3 w-3' />
 					Loading models…
 				</div>
 			) : (

--- a/packages/studio/src/features/connections/components/connection-dialog.tsx
+++ b/packages/studio/src/features/connections/components/connection-dialog.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import {
-	Loader2,
 	CheckCircle2,
 	XCircle,
 	DatabaseZap,
@@ -10,6 +9,7 @@ import {
 	X,
 	Monitor
 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { commands, DatabaseInfo } from '@studio/lib/bindings'
 import { useIsTauri } from '@studio/core/data-provider'
 import { isDesktopOnlyError } from '@studio/core/platform/runtime'
@@ -911,7 +911,7 @@ export function ConnectionDialog({
 								>
 									{isSaving ? (
 										<>
-											<Loader2 className='h-3.5 w-3.5 animate-spin' />
+											<Spinner className='h-3.5 w-3.5' />
 											Saving...
 										</>
 									) : (
@@ -958,7 +958,7 @@ function TestConnectionButton({
 		idle: <span className='whitespace-nowrap'>Test Connection</span>,
 		testing: (
 			<>
-				<Loader2 className='h-3.5 w-3.5 animate-spin' />
+				<Spinner className='h-3.5 w-3.5' />
 				<span className='whitespace-nowrap'>Testing…</span>
 			</>
 		),

--- a/packages/studio/src/features/database-studio/components/add-column-dialog.tsx
+++ b/packages/studio/src/features/database-studio/components/add-column-dialog.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState } from 'react'
 import { Button } from '@studio/shared/ui/button'
 import { Checkbox } from '@studio/shared/ui/checkbox'
@@ -107,7 +107,7 @@ export function AddColumnDialog({ open, onOpenChange, tableName, onSubmit, isLoa
 						form='add-column-form'
 						disabled={isLoading || !formData.name.trim()}
 					>
-						{isLoading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+						{isLoading && <Spinner className='mr-2 h-4 w-4' />}
 						Add Column
 					</Button>
 				</>

--- a/packages/studio/src/features/database-studio/components/add-record-dialog.tsx
+++ b/packages/studio/src/features/database-studio/components/add-record-dialog.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState, useEffect } from 'react'
 import { Button } from '@studio/shared/ui/button'
 import type { ColumnDefinition } from '../types'
@@ -118,7 +118,7 @@ export function AddRecordDialog({
 					<Button type='submit' disabled={isLoading} form='add-record-form'>
 						{isLoading ? (
 							<>
-								<Loader2 className='mr-2 h-4 w-4 animate-spin' />
+								<Spinner className='mr-2 h-4 w-4' />
 								Saving...
 							</>
 						) : mode === 'edit' ? (

--- a/packages/studio/src/features/database-studio/components/bulk-edit-dialog.tsx
+++ b/packages/studio/src/features/database-studio/components/bulk-edit-dialog.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState } from 'react'
 import { Button } from '@studio/shared/ui/button'
 import {
@@ -146,7 +146,7 @@ export function BulkEditDialog({
 							Cancel
 						</Button>
 						<Button type='submit' disabled={!selectedColumn || isLoading}>
-							{isLoading && <Loader2 className='h-4 w-4 mr-2 animate-spin' />}
+							{isLoading && <Spinner className='h-4 w-4 mr-2' />}
 							Update {selectedCount} Row{selectedCount !== 1 ? 's' : ''}
 						</Button>
 					</DialogFooter>

--- a/packages/studio/src/features/database-studio/components/database-studio-empty-states.tsx
+++ b/packages/studio/src/features/database-studio/components/database-studio-empty-states.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@studio/shared/ui/button'
-import { Database, Loader2, PlugZap, Plus, Settings, Table2 } from 'lucide-react'
+import { Database, PlugZap, Plus, Settings, Table2 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 
 type NoConnectionProps = {
 	onAddConnection?: () => void
@@ -39,7 +40,7 @@ type ConnectionLoadingProps = {
 export function DatabaseStudioConnectionLoading({ connectionName }: ConnectionLoadingProps) {
 	return (
 		<div className='flex flex-1 flex-col items-center justify-center p-6 text-center'>
-			<Loader2 className='h-8 w-8 animate-spin text-muted-foreground/70 mb-4' />
+			<Spinner className='h-8 w-8 text-muted-foreground/70 mb-4' />
 			<h2 className='text-lg font-semibold text-foreground mb-1 tracking-tight'>
 				Connecting…
 			</h2>

--- a/packages/studio/src/features/database-studio/components/drop-column-dialog.tsx
+++ b/packages/studio/src/features/database-studio/components/drop-column-dialog.tsx
@@ -1,4 +1,5 @@
-import { AlertTriangle, Loader2 } from 'lucide-react'
+import { AlertTriangle } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useEffect, useState } from 'react'
 import { Button } from '@studio/shared/ui/button'
 import { Input } from '@studio/shared/ui/input'
@@ -76,7 +77,7 @@ export function DropColumnDialog({
 						disabled={isLoading || !isConfirmed}
 						form='drop-column-form'
 					>
-						{isLoading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+						{isLoading && <Spinner className='mr-2 h-4 w-4' />}
 						Drop Column
 					</Button>
 				</>

--- a/packages/studio/src/features/database-studio/components/drop-table-dialog.tsx
+++ b/packages/studio/src/features/database-studio/components/drop-table-dialog.tsx
@@ -1,4 +1,5 @@
-import { AlertTriangle, Loader2 } from 'lucide-react'
+import { AlertTriangle } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState, useEffect } from 'react'
 import { Button } from '@studio/shared/ui/button'
 import { Input } from '@studio/shared/ui/input'
@@ -68,7 +69,7 @@ export function DropTableDialog({ open, onOpenChange, tableName, onConfirm, isLo
 						disabled={isLoading || !isConfirmed}
 						form='drop-table-form'
 					>
-						{isLoading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+						{isLoading && <Spinner className='mr-2 h-4 w-4' />}
 						Drop Table
 					</Button>
 				</>

--- a/packages/studio/src/features/database-studio/components/import-files-into-duckdb-button.tsx
+++ b/packages/studio/src/features/database-studio/components/import-files-into-duckdb-button.tsx
@@ -18,7 +18,8 @@ import {
 import { DesktopOnlyButton } from '@studio/core/platform'
 import { useToast } from '@studio/shared/ui/use-toast'
 import { cn } from '@studio/shared/utils/cn'
-import { FileUp, Loader2 } from 'lucide-react'
+import { FileUp } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useImportFilesIntoDuckdb } from '../hooks/use-import-files-into-duckdb'
 import {
 	detectImportNameCollisions,
@@ -124,7 +125,7 @@ export function ImportFilesIntoDuckDbButton({
 				}}
 			>
 				{importFiles.isPending ? (
-					<Loader2 className='h-3.5 w-3.5 animate-spin' aria-hidden />
+					<Spinner className='h-3.5 w-3.5' />
 				) : (
 					<FileUp className='h-3.5 w-3.5' aria-hidden />
 				)}

--- a/packages/studio/src/features/database-studio/components/pending-changes-bar.tsx
+++ b/packages/studio/src/features/database-studio/components/pending-changes-bar.tsx
@@ -1,4 +1,5 @@
-import { Loader2, Check, X, Edit3 } from 'lucide-react'
+import { Check, X, Edit3 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { Button } from '@studio/shared/ui/button'
 import { cn } from '@studio/shared/utils/cn'
 
@@ -42,7 +43,7 @@ export function PendingChangesBar({ editCount, isApplying, onApply, onCancel, cl
 				</Button>
 				<Button size='sm' onClick={onApply} disabled={isApplying} className='gap-1.5'>
 					{isApplying ? (
-						<Loader2 className='h-4 w-4 animate-spin' />
+						<Spinner className='h-4 w-4' />
 					) : (
 						<Check className='h-4 w-4' />
 					)}

--- a/packages/studio/src/features/database-studio/components/save-as-duckdb-button.tsx
+++ b/packages/studio/src/features/database-studio/components/save-as-duckdb-button.tsx
@@ -19,7 +19,8 @@ import { DesktopOnlyButton } from '@studio/core/platform'
 import { mapSaveDataFileSessionError } from '@studio/features/connections/local-file-errors'
 import { useToast } from '@studio/shared/ui/use-toast'
 import { cn } from '@studio/shared/utils/cn'
-import { Database, Loader2 } from 'lucide-react'
+import { Database } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useSaveDataFileSession } from '../hooks/use-save-data-file-session'
 import {
 	basename,
@@ -139,7 +140,7 @@ export function SaveAsDuckDbButton({
 				}}
 			>
 				{isBusy ? (
-					<Loader2 className='h-3 w-3 animate-spin' aria-hidden />
+					<Spinner className='h-3 w-3' />
 				) : (
 					<Database className='h-3 w-3' aria-hidden />
 				)}

--- a/packages/studio/src/features/database-studio/components/set-null-dialog.tsx
+++ b/packages/studio/src/features/database-studio/components/set-null-dialog.tsx
@@ -1,4 +1,5 @@
-import { Loader2, AlertTriangle } from 'lucide-react'
+import { AlertTriangle } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState } from 'react'
 import { Button } from '@studio/shared/ui/button'
 import { Label } from '@studio/shared/ui/label'
@@ -68,7 +69,7 @@ export function SetNullDialog({
 						disabled={!selectedColumn || isLoading || nullableColumns.length === 0}
 						form='set-null-form'
 					>
-						{isLoading && <Loader2 className='h-4 w-4 mr-2 animate-spin' />}
+						{isLoading && <Spinner className='h-4 w-4 mr-2' />}
 						Set to NULL
 					</Button>
 				</>

--- a/packages/studio/src/features/database-studio/components/studio-toolbar.tsx
+++ b/packages/studio/src/features/database-studio/components/studio-toolbar.tsx
@@ -11,8 +11,7 @@ import {
 	RefreshCw,
 	Sparkles,
 	Copy,
-	Upload,
-	Gauge
+	Upload
 } from 'lucide-react'
 import { useState, useEffect, type ComponentProps } from 'react'
 import { Button } from '@studio/shared/ui/button'
@@ -84,7 +83,6 @@ type Props = {
 	onSeed?: () => void
 	onCopySchema?: () => void
 	onCopyDrizzleSchema?: () => void
-	onSuggestIndexes?: () => void
 	liveMonitorConfig?: LiveMonitorConfig
 	onLiveMonitorConfigChange?: (config: LiveMonitorConfig) => void
 	isLiveMonitorPolling?: boolean
@@ -116,7 +114,6 @@ export function StudioToolbar({
 	onSeed,
 	onCopySchema,
 	onCopyDrizzleSchema,
-	onSuggestIndexes,
 	liveMonitorConfig,
 	onLiveMonitorConfigChange,
 	isLiveMonitorPolling,
@@ -275,18 +272,6 @@ export function StudioToolbar({
 							tooltip='Seed Data — generate mock data using AI'
 						>
 							<Sparkles className='h-3.5 w-3.5 text-blue-400' />
-						</TooltipButton>
-					)}
-
-					{onSuggestIndexes && (
-						<TooltipButton
-							variant='ghost'
-							size='icon'
-							className='h-7 w-7'
-							onClick={onSuggestIndexes}
-							tooltip='Suggest indexes for this table using AI'
-						>
-							<Gauge className='h-3.5 w-3.5 text-blue-400' />
 						</TooltipButton>
 					)}
 

--- a/packages/studio/src/features/database-studio/data-seeder-dialog.tsx
+++ b/packages/studio/src/features/database-studio/data-seeder-dialog.tsx
@@ -12,7 +12,8 @@ import { Button } from '@studio/shared/ui/button'
 import { Input } from '@studio/shared/ui/input'
 import { Label } from '@studio/shared/ui/label'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@studio/shared/ui/table'
-import { Loader2, Sparkles } from 'lucide-react'
+import { Sparkles } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useToast } from '@studio/shared/ui/use-toast'
 
 type Props = {
@@ -126,7 +127,7 @@ export function DataSeederDialog({ open, onOpenChange, tableName, columns, onGen
 						Cancel
 					</Button>
 					<Button onClick={handleGenerate} disabled={isGenerating}>
-						{isGenerating && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+						{isGenerating && <Spinner className='mr-2 h-4 w-4' />}
 						Generate {rowCount} Rows
 					</Button>
 				</DialogFooter>

--- a/packages/studio/src/features/database-studio/database-studio.tsx
+++ b/packages/studio/src/features/database-studio/database-studio.tsx
@@ -10,7 +10,6 @@ import { useUndo } from '@studio/core/undo'
 import { getTableRefParts } from '@studio/shared/utils/table-ref'
 import { getSourceCaps } from '@studio/features/connections/source-caps'
 import { isUiActionVisible } from '@studio/features/connections/ui-actions'
-import { askAi, buildSuggestIndexesPrompt } from '@studio/features/ai-assistant/ai-actions'
 import { DataFileSessionChrome } from './components/data-file-session-chrome'
 import { ImportFilesIntoDuckDbButton } from './components/import-files-into-duckdb-button'
 import {
@@ -734,29 +733,6 @@ export function DatabaseStudio({
 		[hasActiveFilters, runExport]
 	)
 
-	const handleSuggestIndexes = useCallback(
-		function () {
-			if (!tableData) return
-			const columnLines = tableData.columns
-				.map(function (col) {
-					const flags: string[] = [col.type]
-					if (col.primaryKey) flags.push('PRIMARY KEY')
-					if (!col.nullable) flags.push('NOT NULL')
-					if (col.foreignKey) {
-						flags.push(
-							`REFERENCES ${col.foreignKey.referencedTable}(${col.foreignKey.referencedColumn})`
-						)
-					}
-					return `  ${col.name} ${flags.join(' ')}`
-				})
-				.join('\n')
-			const schema = `CREATE TABLE ${displayTableName} (\n${columnLines}\n);`
-			const queries =
-				'No recent query samples available; base suggestions on the schema and common access patterns.'
-			askAi(buildSuggestIndexesPrompt(schema, queries))
-		},
-		[tableData, displayTableName]
-	)
 
 	// No connection selected
 	if (!activeConnectionId) {
@@ -871,7 +847,6 @@ export function DatabaseStudio({
 					onDryEditModeChange={canEditRows ? setDryEditMode : undefined}
 					onCopySchema={handleCopySchema}
 					onCopyDrizzleSchema={handleCopyDrizzleSchema}
-					onSuggestIndexes={handleSuggestIndexes}
 					liveMonitorConfig={showLiveMonitor ? liveMonitor.config : undefined}
 					onLiveMonitorConfigChange={showLiveMonitor ? liveMonitor.setConfig : undefined}
 					isLiveMonitorPolling={showLiveMonitor ? liveMonitor.isPolling : false}
@@ -922,7 +897,6 @@ export function DatabaseStudio({
 				onDryEditModeChange={canEditRows ? setDryEditMode : undefined}
 				onCopySchema={handleCopySchema}
 				onCopyDrizzleSchema={handleCopyDrizzleSchema}
-				onSuggestIndexes={handleSuggestIndexes}
 				liveMonitorConfig={showLiveMonitor ? liveMonitor.config : undefined}
 				onLiveMonitorConfigChange={showLiveMonitor ? liveMonitor.setConfig : undefined}
 				isLiveMonitorPolling={showLiveMonitor ? liveMonitor.isPolling : false}

--- a/packages/studio/src/features/docker-manager/components/create-container-dialog.tsx
+++ b/packages/studio/src/features/docker-manager/components/create-container-dialog.tsx
@@ -1,4 +1,5 @@
-import { RefreshCw, Loader2, Eye, EyeOff, ChevronDown, ChevronRight } from "lucide-react";
+import { RefreshCw, Eye, EyeOff, ChevronDown, ChevronRight } from "lucide-react";
+import { Spinner } from "@studio/shared/ui/spinner";
 import { useState, useEffect, useRef } from "react";
 import { Button } from "@studio/shared/ui/button";
 import {
@@ -525,7 +526,7 @@ export function CreateContainerDialog({
             <Button type="submit" disabled={isSubmitting || Boolean(nameError)}>
               {isSubmitting ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Spinner className="mr-2 h-4 w-4" />
                   Creating...
                 </>
               ) : (

--- a/packages/studio/src/features/docker-manager/components/remove-container-dialog.tsx
+++ b/packages/studio/src/features/docker-manager/components/remove-container-dialog.tsx
@@ -1,4 +1,5 @@
-import { AlertTriangle, Loader2 } from 'lucide-react'
+import { AlertTriangle } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState } from 'react'
 import { Button } from '@studio/shared/ui/button'
 import { Checkbox } from '@studio/shared/ui/checkbox'
@@ -84,7 +85,7 @@ export function RemoveContainerDialog({
 					<Button variant='destructive' onClick={handleConfirm} disabled={isRemoving}>
 						{isRemoving ? (
 							<>
-								<Loader2 className='mr-2 h-4 w-4 animate-spin' />
+								<Spinner className='mr-2 h-4 w-4' />
 								Removing...
 							</>
 						) : (

--- a/packages/studio/src/features/docker-manager/components/seed-view.tsx
+++ b/packages/studio/src/features/docker-manager/components/seed-view.tsx
@@ -1,4 +1,5 @@
-import { Upload, FileCode, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react'
+import { Upload, FileCode, CheckCircle2, AlertCircle } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState, useRef } from 'react'
 import { useToast } from '@studio/shared/ui/use-toast'
 import { Button } from '@studio/shared/ui/button'
@@ -217,7 +218,7 @@ export function SeedView({ container }: Props) {
 					disabled={!file || seedMutation.isPending}
 					className='w-full'
 				>
-					{seedMutation.isPending && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+					{seedMutation.isPending && <Spinner className='mr-2 h-4 w-4' />}
 					{seedMutation.isPending ? 'Seeding...' : 'Run Seed Script'}
 				</Button>
 			</div>

--- a/packages/studio/src/features/drizzle-runner/drizzle-runner.tsx
+++ b/packages/studio/src/features/drizzle-runner/drizzle-runner.tsx
@@ -1,4 +1,5 @@
-import { Play, Sparkles, Download, Loader2, Braces } from 'lucide-react'
+import { Play, Sparkles, Download, Braces } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState, useCallback, useEffect, useMemo } from 'react'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import { useAdapter, useIsTauri } from '@studio/core/data-provider'
@@ -144,7 +145,7 @@ export function DrizzleRunner({ connectionId }: Props) {
 						disabled={isExecuting}
 					>
 						{isExecuting ? (
-							<Loader2 className='h-3 w-3 animate-spin' />
+							<Spinner className='h-3 w-3' />
 						) : (
 							<Play className='h-3 w-3 fill-current' />
 						)}

--- a/packages/studio/src/features/integrations/cloudflare/cloudflare-connect-flow.tsx
+++ b/packages/studio/src/features/integrations/cloudflare/cloudflare-connect-flow.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft, Check, Copy, ExternalLink, Loader2, LogOut, PlugZap, RefreshCw, Search } from 'lucide-react'
+import { ArrowLeft, Check, Copy, ExternalLink, LogOut, PlugZap, RefreshCw, Search } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { open } from '@tauri-apps/plugin-shell'
 import type { CloudflareAccount, CloudflareD1Database } from '@studio/lib/bindings'
 import { Button } from '@studio/shared/ui/button'
@@ -336,7 +337,7 @@ function CloudflareConnectFlowInner({ onComplete }: Props) {
 							className='shrink-0 gap-2'
 						>
 							{isAuthorizing ? (
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 							) : (
 								<PlugZap className='h-3.5 w-3.5' />
 							)}
@@ -369,7 +370,7 @@ function CloudflareConnectFlowInner({ onComplete }: Props) {
 					<div className='max-h-[min(18rem,36vh)] space-y-2 overflow-y-auto pr-1'>
 						{accountsLoading ? (
 							<div className='flex items-center gap-2 py-3 text-sm text-muted-foreground'>
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 								Loading accounts
 							</div>
 						) : null}
@@ -450,7 +451,7 @@ function CloudflareConnectFlowInner({ onComplete }: Props) {
 					<div className='max-h-[min(18rem,36vh)] space-y-2 overflow-y-auto pr-1'>
 						{isLoading ? (
 							<div className='flex items-center gap-2 py-3 text-sm text-muted-foreground'>
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 								Loading databases
 							</div>
 						) : null}

--- a/packages/studio/src/features/integrations/neon/neon-connect-flow.tsx
+++ b/packages/studio/src/features/integrations/neon/neon-connect-flow.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Check, Copy, ExternalLink, GitBranch, Loader2, LogOut, PlugZap, RefreshCw, Search } from 'lucide-react'
+import { Check, Copy, ExternalLink, GitBranch, LogOut, PlugZap, RefreshCw, Search } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { open } from '@tauri-apps/plugin-shell'
 import type { NeonAccount, NeonDatabase } from '@studio/lib/bindings'
 import { Button } from '@studio/shared/ui/button'
@@ -361,7 +362,7 @@ function NeonConnectFlowInner({ onComplete }: Props) {
 							className='shrink-0 gap-2'
 						>
 							{isAuthorizing ? (
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 							) : (
 								<PlugZap className='h-3.5 w-3.5' />
 							)}
@@ -404,7 +405,7 @@ function NeonConnectFlowInner({ onComplete }: Props) {
 					<div className='max-h-[min(18rem,36vh)] space-y-2 overflow-y-auto pr-1'>
 						{isLoading ? (
 							<div className='flex items-center gap-2 py-3 text-sm text-muted-foreground'>
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 								Loading databases
 							</div>
 						) : null}
@@ -462,7 +463,7 @@ function NeonConnectFlowInner({ onComplete }: Props) {
 								<GitBranch className='h-3.5 w-3.5' />
 								<span>Branch</span>
 								{branchesLoading ? (
-									<Loader2 className='h-3 w-3 animate-spin' />
+									<Spinner className='h-3 w-3' />
 								) : null}
 							</div>
 							<div className='flex flex-wrap gap-2'>
@@ -507,7 +508,7 @@ function NeonConnectFlowInner({ onComplete }: Props) {
 								className='gap-2'
 							>
 								{isBuilding ? (
-									<Loader2 className='h-3.5 w-3.5 animate-spin' />
+									<Spinner className='h-3.5 w-3.5' />
 								) : (
 									<PlugZap className='h-3.5 w-3.5' />
 								)}

--- a/packages/studio/src/features/integrations/planetscale/planetscale-connect-flow.tsx
+++ b/packages/studio/src/features/integrations/planetscale/planetscale-connect-flow.tsx
@@ -5,12 +5,12 @@ import {
 	Copy,
 	ExternalLink,
 	GitBranch,
-	Loader2,
 	LogOut,
 	PlugZap,
 	RefreshCw,
 	Search
 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { open } from '@tauri-apps/plugin-shell'
 import type {
 	PlanetscaleBranch,
@@ -391,7 +391,7 @@ function PlanetscaleConnectFlowInner({ onComplete }: Props) {
 							className='shrink-0 gap-2'
 						>
 							{isAuthorizing ? (
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 							) : (
 								<PlugZap className='h-3.5 w-3.5' />
 							)}
@@ -425,7 +425,7 @@ function PlanetscaleConnectFlowInner({ onComplete }: Props) {
 						<div className='max-h-[min(14rem,28vh)] space-y-2 overflow-y-auto pr-1'>
 							{isLoadingBranches ? (
 								<div className='flex items-center gap-2 py-3 text-sm text-muted-foreground'>
-									<Loader2 className='h-3.5 w-3.5 animate-spin' />
+									<Spinner className='h-3.5 w-3.5' />
 									Loading branches
 								</div>
 							) : null}
@@ -482,7 +482,7 @@ function PlanetscaleConnectFlowInner({ onComplete }: Props) {
 								className='gap-2'
 							>
 								{isBuilding ? (
-									<Loader2 className='h-3.5 w-3.5 animate-spin' />
+									<Spinner className='h-3.5 w-3.5' />
 								) : (
 									<PlugZap className='h-3.5 w-3.5' />
 								)}
@@ -523,7 +523,7 @@ function PlanetscaleConnectFlowInner({ onComplete }: Props) {
 					<div className='max-h-[min(18rem,36vh)] space-y-2 overflow-y-auto pr-1'>
 						{isLoading ? (
 							<div className='flex items-center gap-2 py-3 text-sm text-muted-foreground'>
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 								Loading databases
 							</div>
 						) : null}

--- a/packages/studio/src/features/integrations/supabase/supabase-connect-flow.tsx
+++ b/packages/studio/src/features/integrations/supabase/supabase-connect-flow.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { Check, ExternalLink, Loader2, LogOut, PlugZap, RefreshCw, Search } from "lucide-react";
+import { Check, ExternalLink, LogOut, PlugZap, RefreshCw, Search } from "lucide-react";
+import { Spinner } from "@studio/shared/ui/spinner";
 import { open } from "@tauri-apps/plugin-shell";
 import type { SupabaseOrganization, SupabaseProject } from "@studio/lib/bindings";
 import { Button } from "@studio/shared/ui/button";
@@ -270,7 +271,7 @@ function SupabaseConnectFlowInner({ onComplete }: Props) {
             className="w-full gap-2"
           >
             {isOauthConnecting ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              <Spinner className="h-3.5 w-3.5" />
             ) : (
               <PlugZap className="h-3.5 w-3.5" />
             )}
@@ -322,7 +323,7 @@ function SupabaseConnectFlowInner({ onComplete }: Props) {
                   className="shrink-0 gap-2"
                 >
                   {isAuthorizing ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    <Spinner className="h-3.5 w-3.5" />
                   ) : (
                     <PlugZap className="h-3.5 w-3.5" />
                   )}
@@ -377,7 +378,7 @@ function SupabaseConnectFlowInner({ onComplete }: Props) {
           <div className="max-h-44 space-y-2 overflow-y-auto pr-1">
             {isLoading ? (
               <div className="flex items-center gap-2 py-3 text-sm text-muted-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Spinner className="h-3.5 w-3.5" />
                 Loading projects
               </div>
             ) : null}
@@ -477,7 +478,7 @@ function SupabaseConnectFlowInner({ onComplete }: Props) {
                 className="self-start gap-2"
               >
                 {isBuilding ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <Spinner className="h-3.5 w-3.5" />
                 ) : (
                   <PlugZap className="h-3.5 w-3.5" />
                 )}

--- a/packages/studio/src/features/integrations/turso/turso-connect-flow.tsx
+++ b/packages/studio/src/features/integrations/turso/turso-connect-flow.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Check, Copy, ExternalLink, Loader2, LogOut, PlugZap, RefreshCw, Search, Terminal } from "lucide-react";
+import { Check, Copy, ExternalLink, LogOut, PlugZap, RefreshCw, Search, Terminal } from "lucide-react";
+import { Spinner } from "@studio/shared/ui/spinner";
 import { open } from "@tauri-apps/plugin-shell";
 import type { TursoDatabase, TursoOrganization } from "@studio/lib/bindings";
 import { Button } from "@studio/shared/ui/button";
@@ -363,7 +364,7 @@ function TursoConnectFlowInner({ onComplete }: Props) {
                     className="w-full gap-2"
                   >
                     {isMinting ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      <Spinner className="h-3.5 w-3.5" />
                     ) : (
                       <Terminal className="h-3.5 w-3.5" />
                     )}
@@ -382,7 +383,7 @@ function TursoConnectFlowInner({ onComplete }: Props) {
                     className="w-full gap-2"
                   >
                     {isLoggingIn ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      <Spinner className="h-3.5 w-3.5" />
                     ) : (
                       <Terminal className="h-3.5 w-3.5" />
                     )}
@@ -433,7 +434,7 @@ function TursoConnectFlowInner({ onComplete }: Props) {
                   className="w-full gap-2 border-border/70"
                 >
                   {isInstallingCli ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    <Spinner className="h-3.5 w-3.5" />
                   ) : (
                     <Terminal className="h-3.5 w-3.5" />
                   )}
@@ -475,7 +476,7 @@ function TursoConnectFlowInner({ onComplete }: Props) {
                     className="inline-flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground disabled:opacity-60"
                   >
                     {isReprobingCli ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
+                      <Spinner className="h-3 w-3" />
                     ) : (
                       <RefreshCw className="h-3 w-3" />
                     )}
@@ -532,7 +533,7 @@ function TursoConnectFlowInner({ onComplete }: Props) {
               className="shrink-0 gap-2"
             >
               {isAuthorizing ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Spinner className="h-3.5 w-3.5" />
               ) : (
                 <PlugZap className="h-3.5 w-3.5" />
               )}
@@ -560,7 +561,7 @@ function TursoConnectFlowInner({ onComplete }: Props) {
           <div className="max-h-44 space-y-2 overflow-y-auto pr-1">
             {isLoading ? (
               <div className="flex items-center gap-2 py-3 text-sm text-muted-foreground">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Spinner className="h-3.5 w-3.5" />
                 Loading databases
               </div>
             ) : null}
@@ -609,7 +610,7 @@ function TursoConnectFlowInner({ onComplete }: Props) {
               className="self-start gap-2"
             >
               {isBuilding ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Spinner className="h-3.5 w-3.5" />
               ) : (
                 <PlugZap className="h-3.5 w-3.5" />
               )}

--- a/packages/studio/src/features/integrations/vercel/vercel-connect-flow.tsx
+++ b/packages/studio/src/features/integrations/vercel/vercel-connect-flow.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Check, Copy, ExternalLink, Loader2, LogOut, PlugZap, RefreshCw, Search } from 'lucide-react'
+import { Check, Copy, ExternalLink, LogOut, PlugZap, RefreshCw, Search } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { open } from '@tauri-apps/plugin-shell'
 import type { VercelAccount, VercelStore } from '@studio/lib/bindings'
 import { Button } from '@studio/shared/ui/button'
@@ -328,7 +329,7 @@ function VercelConnectFlowInner({ onComplete }: Props) {
 							className='shrink-0 gap-2'
 						>
 							{isAuthorizing ? (
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 							) : (
 								<PlugZap className='h-3.5 w-3.5' />
 							)}
@@ -371,7 +372,7 @@ function VercelConnectFlowInner({ onComplete }: Props) {
 					<div className='max-h-[min(18rem,36vh)] space-y-2 overflow-y-auto pr-1'>
 						{isLoading ? (
 							<div className='flex items-center gap-2 py-3 text-sm text-muted-foreground'>
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 								Loading stores
 							</div>
 						) : null}
@@ -468,7 +469,7 @@ function VercelConnectFlowInner({ onComplete }: Props) {
 								className='gap-2'
 							>
 								{isBuilding ? (
-									<Loader2 className='h-3.5 w-3.5 animate-spin' />
+									<Spinner className='h-3.5 w-3.5' />
 								) : (
 									<PlugZap className='h-3.5 w-3.5' />
 								)}

--- a/packages/studio/src/features/integrations/xata/xata-connect-flow.tsx
+++ b/packages/studio/src/features/integrations/xata/xata-connect-flow.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Check, Copy, ExternalLink, Loader2, LogOut, PlugZap, RefreshCw, Search } from 'lucide-react'
+import { Check, Copy, ExternalLink, LogOut, PlugZap, RefreshCw, Search } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { open } from '@tauri-apps/plugin-shell'
 import type { XataAccount, XataDatabase } from '@studio/lib/bindings'
 import { Button } from '@studio/shared/ui/button'
@@ -335,7 +336,7 @@ function XataConnectFlowInner({ onComplete }: Props) {
 							className='shrink-0 gap-2'
 						>
 							{isAuthorizing ? (
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 							) : (
 								<PlugZap className='h-3.5 w-3.5' />
 							)}
@@ -378,7 +379,7 @@ function XataConnectFlowInner({ onComplete }: Props) {
 					<div className='max-h-[min(18rem,36vh)] space-y-2 overflow-y-auto pr-1'>
 						{isLoading ? (
 							<div className='flex items-center gap-2 py-3 text-sm text-muted-foreground'>
-								<Loader2 className='h-3.5 w-3.5 animate-spin' />
+								<Spinner className='h-3.5 w-3.5' />
 								Loading databases
 							</div>
 						) : null}
@@ -446,7 +447,7 @@ function XataConnectFlowInner({ onComplete }: Props) {
 								className='gap-2'
 							>
 								{isBuilding ? (
-									<Loader2 className='h-3.5 w-3.5 animate-spin' />
+									<Spinner className='h-3.5 w-3.5' />
 								) : (
 									<PlugZap className='h-3.5 w-3.5' />
 								)}

--- a/packages/studio/src/features/orm-cockpit/components/migration-status-view.tsx
+++ b/packages/studio/src/features/orm-cockpit/components/migration-status-view.tsx
@@ -4,7 +4,8 @@
  * concern (`drizzle-kit migrate`); this just shows the gap.
  */
 
-import { CheckCircle2, Clock, Info, Loader2 } from 'lucide-react'
+import { CheckCircle2, Clock, Info } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { cn } from '@studio/shared/utils/cn'
 import { EmptyState } from '@studio/shared/ui/empty-state'
 import type { MigrationStatusState } from '@studio/features/orm-cockpit/components/use-migration-status'
@@ -13,7 +14,7 @@ export function MigrationStatusView({ state }: { state: MigrationStatusState }) 
 	if (state.loading && !state.status) {
 		return (
 			<div className='flex h-full items-center justify-center gap-2 text-muted-foreground'>
-				<Loader2 className='h-5 w-5 animate-spin' />
+				<Spinner className='h-5 w-5' />
 				<span className='text-sm'>Reading migrations…</span>
 			</div>
 		)

--- a/packages/studio/src/features/orm-cockpit/components/orm-cockpit-panel.tsx
+++ b/packages/studio/src/features/orm-cockpit/components/orm-cockpit-panel.tsx
@@ -10,7 +10,6 @@
 import { useEffect, useState } from 'react'
 import {
 	FolderGit2,
-	Loader2,
 	RefreshCw,
 	Database,
 	ChevronDown,
@@ -21,6 +20,7 @@ import {
 	Eye,
 	EyeOff,
 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import { Button } from '@studio/shared/ui/button'
 import { EmptyState } from '@studio/shared/ui/empty-state'
@@ -208,7 +208,7 @@ export function OrmCockpitPanel({
 		if (busy && !cockpit.diff) {
 			return (
 				<div className='flex h-full flex-col items-center justify-center gap-3 text-muted-foreground'>
-					<Loader2 className='h-6 w-6 animate-spin' />
+					<Spinner className='h-6 w-6' />
 					<span className='text-sm'>
 						{cockpit.phase === 'linking'
 							? 'Detecting project…'

--- a/packages/studio/src/features/prisma-runner/prisma-runner.tsx
+++ b/packages/studio/src/features/prisma-runner/prisma-runner.tsx
@@ -1,4 +1,5 @@
-import { Play, Sparkles, Download, Loader2, Braces, X, FileCode2 } from 'lucide-react'
+import { Play, Sparkles, Download, Braces, X, FileCode2 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState, useCallback, useEffect, useMemo } from 'react'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import { useAdapter, useConnections } from '@studio/core/data-provider'
@@ -235,7 +236,7 @@ export function PrismaRunner({ connectionId }: PrismaRunnerProps) {
 						disabled={isRunning}
 					>
 						{isRunning ? (
-							<Loader2 className='h-3.5 w-3.5 animate-spin' />
+							<Spinner className='h-3.5 w-3.5' />
 						) : (
 							<Play className='h-3.5 w-3.5 fill-current' />
 						)}

--- a/packages/studio/src/features/sidebar/components/ai-keys-section.tsx
+++ b/packages/studio/src/features/sidebar/components/ai-keys-section.tsx
@@ -1,4 +1,5 @@
-import { Check, Loader2, Plus, RefreshCw, Trash2, X, Zap } from 'lucide-react'
+import { Check, Plus, RefreshCw, Trash2, X, Zap } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useIsTauri } from '@studio/core/data-provider'
 import { buildMockProviderModels } from '@studio/features/ai-assistant/mock-ai'
@@ -474,7 +475,7 @@ export function AiKeysSection() {
 							}
 						>
 							{settingsTest.testing ? (
-								<Loader2 className='mr-1 h-3 w-3 animate-spin' />
+								<Spinner className='mr-1 h-3 w-3' />
 							) : (
 								<Zap className='mr-1 h-3 w-3' />
 							)}
@@ -506,7 +507,7 @@ export function AiKeysSection() {
 
 				{loading && (
 					<div className='flex items-center gap-2 text-xs text-muted-foreground'>
-						<Loader2 className='h-3 w-3 animate-spin' /> Loading…
+						<Spinner className='h-3 w-3' /> Loading…
 					</div>
 				)}
 
@@ -568,7 +569,7 @@ export function AiKeysSection() {
 								title='Test key with the model and prompt above'
 							>
 								{test?.testing ? (
-									<Loader2 className='h-3 w-3 animate-spin' />
+									<Spinner className='h-3 w-3' />
 								) : (
 									<Zap className='h-3 w-3' />
 								)}
@@ -637,7 +638,7 @@ export function AiKeysSection() {
 								}}
 								disabled={testNew.testing || !apiKey.trim() || !resolvedTestModel}
 							>
-								{testNew.testing ? <Loader2 className='h-3 w-3 animate-spin' /> : 'Test'}
+								{testNew.testing ? <Spinner className='h-3 w-3' /> : 'Test'}
 							</Button>
 							<Button
 								variant='default'

--- a/packages/studio/src/features/sidebar/components/rename-table-dialog.tsx
+++ b/packages/studio/src/features/sidebar/components/rename-table-dialog.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState, useEffect } from 'react'
 import { Button } from '@studio/shared/ui/button'
 import {
@@ -91,7 +91,7 @@ export function RenameTableDialog({
 							Cancel
 						</Button>
 						<Button type='submit' disabled={isLoading || !isValid}>
-							{isLoading && <Loader2 className='mr-2 h-4 w-4 animate-spin' />}
+							{isLoading && <Spinner className='mr-2 h-4 w-4' />}
 							Rename
 						</Button>
 					</DialogFooter>

--- a/packages/studio/src/features/sidebar/components/table-info-dialog.tsx
+++ b/packages/studio/src/features/sidebar/components/table-info-dialog.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useState, useEffect } from 'react'
 import { useAdapter } from '@studio/core/data-provider'
 import { useIsTauri } from '@studio/core/data-provider/context'
@@ -188,7 +188,7 @@ export function TableInfoDialog({
 					<div className='py-2 pr-4'>
 					{isLoading && (
 						<div className='flex items-center justify-center py-8'>
-							<Loader2 className='h-6 w-6 animate-spin text-muted-foreground' />
+							<Spinner className='h-6 w-6 text-muted-foreground' />
 						</div>
 					)}
 

--- a/packages/studio/src/features/sql-console/components/ai-cmd-k.tsx
+++ b/packages/studio/src/features/sql-console/components/ai-cmd-k.tsx
@@ -1,5 +1,6 @@
 import { Channel } from '@tauri-apps/api/core'
-import { Loader2, Sparkles, X } from 'lucide-react'
+import { Sparkles, X } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { commands } from '@studio/lib/bindings'
 import type { AiStreamEvent } from '@studio/lib/bindings'
@@ -264,7 +265,7 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 					</span>
 					<div className='ml-auto flex items-center gap-1'>
 						{isGenerating && (
-							<Loader2 className='h-3.5 w-3.5 animate-spin text-muted-foreground' />
+							<Spinner className='h-3.5 w-3.5 text-muted-foreground' />
 						)}
 						<Button
 							variant='ghost'

--- a/packages/studio/src/features/sql-console/components/query-tab-bar.tsx
+++ b/packages/studio/src/features/sql-console/components/query-tab-bar.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
-import { Plus, X, Loader2, ChevronLeft, ChevronRight, Copy } from 'lucide-react'
+import { Plus, X, ChevronLeft, ChevronRight, Copy } from 'lucide-react'
+import { Spinner } from '@studio/shared/ui/spinner'
 import { useQueryTabs } from '../stores/tab-store'
 import { cn } from '@studio/shared/utils/cn'
 import {
@@ -133,7 +134,7 @@ export function QueryTabBar() {
 
 									{/* Executing spinner */}
 									{tab.isExecuting && (
-										<Loader2 className='h-3 w-3 shrink-0 animate-spin text-emerald-400' />
+										<Spinner className='h-3 w-3 shrink-0 text-emerald-400' />
 									)}
 
 									{/* Dirty dot */}

--- a/packages/studio/src/shared/ui/spinner.tsx
+++ b/packages/studio/src/shared/ui/spinner.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@studio/shared/utils/cn'
+
+type Props = {
+	className?: string
+}
+
+/**
+ * App-wide loading spinner. A clean two-tone ring with a rotating accent arc.
+ * Size and spacing come from `className` (e.g. `h-4 w-4 mr-2`); defaults to `h-4 w-4`.
+ * Colour follows `currentColor`, so set text colour on the element or a parent.
+ */
+export function Spinner({ className }: Props) {
+	return (
+		<svg
+			role='status'
+			aria-label='Loading'
+			viewBox='0 0 24 24'
+			fill='none'
+			xmlns='http://www.w3.org/2000/svg'
+			className={cn('h-4 w-4 animate-spin text-current', className)}
+		>
+			<circle
+				cx='12'
+				cy='12'
+				r='9'
+				stroke='currentColor'
+				strokeWidth='2.5'
+				className='opacity-20'
+			/>
+			<path
+				d='M21 12a9 9 0 0 0-9-9'
+				stroke='currentColor'
+				strokeWidth='2.5'
+				strokeLinecap='round'
+			/>
+		</svg>
+	)
+}


### PR DESCRIPTION
Three low-risk UI fixes, done on a clean worktree off \`master\`.

## Changes
- **Closes #177** — Remove the *"Suggest Index via AI"* toolbar button and its full wiring (`studio-toolbar.tsx`, `database-studio.tsx`), plus the now-dead `Gauge` import and `buildSuggestIndexesPrompt` helper.
- **Closes #164** — Lower the AI panel so it sits **below** the top window-control bar: `top-0 h-full` → `top-9 h-[calc(100%-2.25rem)]` (top bars are `h-8`/`h-9`).
- **Closes #158** — New shared `Spinner` component (`shared/ui/spinner.tsx`, a clean two-tone rotating ring) and migration of **65 unconditional `Loader2` loading spinners across 36 files** to it for a consistent loading variant. `RefreshCw` refresh-spin icons and the `status-badge` icon reference are intentionally left as-is.

## Verification
- `tsc --noEmit` on `packages/studio` passes (exit 0).
- No empty/duplicate `lucide-react` imports; every `<Spinner>` site imports it; no leftover `Loader2 … animate-spin` literals.

## ⚠️ Heads-up
`master` had no centralized spinner, but the in-progress `feat/duckdb-helper-process` branch introduces its own `shared/ui/spinner.tsx` (a 12-blade variant). **These will conflict** — pick one canonical spinner when merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/remco-stoeten/codesmith/dora/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784747309&installation_id=140085766&pr_number=181&repository=remco-stoeten%2Fdora&return_to=https%3A%2F%2Fgithub.com%2Fremco-stoeten%2Fdora%2Fpull%2F181&signature=dbf71fcd0c420b3d37be290d4e1704f1b04a304b6949cd885e90189d96951926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->