### PR TITLE
perf(studio): cut re-renders, virtualize result tables, defer startup bundle

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -82,6 +82,19 @@ export default defineConfig({
 
           // Feature-based splitting
           if (id.includes("src/features/")) {
+            // The data seeder is lazy-loaded (it drags in faker's locale data);
+            // keep it out of the eager feature-studio chunk.
+            if (id.includes("data-seeder-dialog")) return;
+            // The connection dialog + every provider connect-flow is only needed
+            // when adding/editing a connection. It's a lazy import — let Rollup
+            // give it its own async chunk instead of welding it into the eager
+            // feature-core chunk (which the always-visible sidebar lives in).
+            if (
+              id.includes("features/connections/components/connection-dialog") ||
+              id.includes("features/integrations")
+            ) {
+              return;
+            }
             if (id.includes("database-studio")) return "feature-studio";
             if (id.includes("schema-visualizer")) return "feature-visualizer";
             if (id.includes("sql-console")) return "feature-sql";

--- a/packages/studio/src/core/data-provider/adapters/index.ts
+++ b/packages/studio/src/core/data-provider/adapters/index.ts
@@ -1,2 +1,1 @@
 export { createTauriAdapter } from './tauri'
-export { createMockAdapter, resetMockStore } from './mock'

--- a/packages/studio/src/core/data-provider/context.tsx
+++ b/packages/studio/src/core/data-provider/context.tsx
@@ -19,6 +19,7 @@ type Props = {
 export function DataProvider({ children, forceMock = false }: Props) {
 	const [isReady, setIsReady] = useState(false)
 	const [adapter, setAdapter] = useState<DataAdapter | null>(null)
+	const [initError, setInitError] = useState<Error | null>(null)
 
 	// Lazy initialization for isTauri to ensure it runs once and persists
 	const [isTauri] = useState(() => !forceMock && detectTauri())
@@ -34,11 +35,19 @@ export function DataProvider({ children, forceMock = false }: Props) {
 			// The mock adapter (and its bundled demo dataset) is only for the web
 			// demo — load it on demand so desktop startup never pays for it.
 			let cancelled = false
-			import('./adapters/mock').then(function (m) {
-				if (cancelled) return
-				setAdapter(m.createMockAdapter())
-				setIsReady(true)
-			})
+			import('./adapters/mock')
+				.then(function (m) {
+					if (cancelled) return
+					setAdapter(m.createMockAdapter())
+					setIsReady(true)
+				})
+				.catch(function (error) {
+					if (cancelled) return
+					console.error('Failed to load the mock data adapter:', error)
+					setInitError(
+						error instanceof Error ? error : new Error('Failed to initialize data adapter')
+					)
+				})
 			return function () {
 				cancelled = true
 			}
@@ -50,6 +59,29 @@ export function DataProvider({ children, forceMock = false }: Props) {
 		() => (adapter ? { adapter, isTauri, isReady } : null),
 		[adapter, isTauri, isReady]
 	)
+
+	// A rejected adapter load renders an inline message instead of hanging
+	// forever on the null render below. There is no ErrorBoundary above this
+	// provider, so surfacing it here (rather than throwing) avoids blanking the
+	// whole window.
+	if (initError) {
+		return (
+			<div
+				role='alert'
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					height: '100vh',
+					padding: '2rem',
+					textAlign: 'center',
+					font: '14px system-ui, sans-serif'
+				}}
+			>
+				Failed to initialize the data adapter. Please reload the app.
+			</div>
+		)
+	}
 
 	if (!value || !isReady) {
 		return null

--- a/packages/studio/src/core/data-provider/context.tsx
+++ b/packages/studio/src/core/data-provider/context.tsx
@@ -1,5 +1,4 @@
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
-import { createMockAdapter } from './adapters/mock'
+import { createContext, useContext, useState, useEffect, useMemo, ReactNode } from 'react'
 import { createTauriAdapter } from './adapters/tauri'
 import type { DataAdapter, DataProviderContextValue } from './types'
 
@@ -28,22 +27,32 @@ export function DataProvider({ children, forceMock = false }: Props) {
 		function () {
 			if (isTauri) {
 				setAdapter(createTauriAdapter())
-			} else {
-				setAdapter(createMockAdapter())
+				setIsReady(true)
+				return
 			}
-			setIsReady(true)
+
+			// The mock adapter (and its bundled demo dataset) is only for the web
+			// demo — load it on demand so desktop startup never pays for it.
+			let cancelled = false
+			import('./adapters/mock').then(function (m) {
+				if (cancelled) return
+				setAdapter(m.createMockAdapter())
+				setIsReady(true)
+			})
+			return function () {
+				cancelled = true
+			}
 		},
 		[isTauri]
 	)
 
-	if (!isReady || !adapter) {
-		return null
-	}
+	const value: DataProviderContextValue | null = useMemo(
+		() => (adapter ? { adapter, isTauri, isReady } : null),
+		[adapter, isTauri, isReady]
+	)
 
-	const value: DataProviderContextValue = {
-		adapter,
-		isTauri,
-		isReady
+	if (!value || !isReady) {
+		return null
 	}
 
 	return <DataProviderContext.Provider value={value}>{children}</DataProviderContext.Provider>

--- a/packages/studio/src/core/data-provider/index.ts
+++ b/packages/studio/src/core/data-provider/index.ts
@@ -1,6 +1,5 @@
 export { DataProvider, useDataProvider, useAdapter, useIsTauri } from './context'
 export { createTauriAdapter } from './adapters/tauri'
-export { createMockAdapter, resetMockStore } from './adapters/mock'
 export type { DataAdapter, AdapterResult, QueryResult, DataProviderContextValue } from './types'
 export {
 	useConnections,

--- a/packages/studio/src/core/pending-edits/pending-edits-store.tsx
+++ b/packages/studio/src/core/pending-edits/pending-edits-store.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react'
 
 export type PendingEdit = {
 	rowIndex: number
@@ -104,17 +104,29 @@ export function PendingEditsProvider({ children }: Props) {
 		[getEditCount]
 	)
 
-	const value: PendingEditsContextValue = {
-		isDryEditMode,
-		setDryEditMode,
-		pendingEdits,
-		addEdit,
-		removeEdit,
-		clearEdits,
-		getEditsForTable,
-		getEditCount,
-		hasEdits
-	}
+	const value: PendingEditsContextValue = useMemo(
+		() => ({
+			isDryEditMode,
+			setDryEditMode,
+			pendingEdits,
+			addEdit,
+			removeEdit,
+			clearEdits,
+			getEditsForTable,
+			getEditCount,
+			hasEdits
+		}),
+		[
+			isDryEditMode,
+			pendingEdits,
+			addEdit,
+			removeEdit,
+			clearEdits,
+			getEditsForTable,
+			getEditCount,
+			hasEdits
+		]
+	)
 
 	return <PendingEditsContext.Provider value={value}>{children}</PendingEditsContext.Provider>
 }

--- a/packages/studio/src/core/settings/settings-store.tsx
+++ b/packages/studio/src/core/settings/settings-store.tsx
@@ -5,6 +5,7 @@ import {
 	useState,
 	ReactNode,
 	useCallback,
+	useMemo,
 	useRef
 } from 'react'
 import { commands } from '@studio/lib/bindings'
@@ -147,6 +148,12 @@ type SettingsContextValue = {
 	isLoading: boolean
 	updateSetting: <K extends keyof SettingsState>(key: K, value: SettingsState[K]) => void
 	updateSettings: (partial: Partial<SettingsState>) => void
+	/**
+	 * Persist a setting WITHOUT re-rendering consumers. For restore-on-launch
+	 * keys written on hot paths (row selection, table switches) where the live
+	 * value is never read back reactively — only saved for the next launch.
+	 */
+	persistSetting: <K extends keyof SettingsState>(key: K, value: SettingsState[K]) => void
 	resetSettings: () => void
 }
 
@@ -211,18 +218,14 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
 	const [isLoading, setIsLoading] = useState(true)
 	const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 	const initialLoadDone = useRef(false)
+	// Source of truth for persistence. Holds reactive state PLUS keys written
+	// through `persistSetting` (which bypass React state on purpose).
 	const latestSettingsRef = useRef(settings)
-
-	useEffect(
-		function syncLatestSettingsRef() {
-			latestSettingsRef.current = settings
-		},
-		[settings]
-	)
 
 	useEffect(() => {
 		async function load() {
 			const loaded = await loadSettingsFromBackend()
+			latestSettingsRef.current = loaded
 			setSettings(loaded)
 			setIsLoading(false)
 			initialLoadDone.current = true
@@ -230,7 +233,7 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
 		load()
 	}, [])
 
-	useEffect(() => {
+	const scheduleSave = useCallback(function scheduleSave() {
 		if (!initialLoadDone.current) return
 
 		if (saveTimeoutRef.current) {
@@ -241,13 +244,17 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
 			saveSettingsToBackend(latestSettingsRef.current)
 			saveTimeoutRef.current = null
 		}, 300)
+	}, [])
+
+	useEffect(() => {
+		scheduleSave()
 
 		return () => {
 			if (saveTimeoutRef.current) {
 				clearTimeout(saveTimeoutRef.current)
 			}
 		}
-	}, [settings])
+	}, [settings, scheduleSave])
 
 	useEffect(function flushSettingsBeforeExit() {
 		function flush() {
@@ -270,32 +277,47 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
 
 	const updateSetting = useCallback(
 		<K extends keyof SettingsState>(key: K, value: SettingsState[K]) => {
-			setSettings((prev) => ({ ...prev, [key]: value }))
+			const next = { ...latestSettingsRef.current, [key]: value }
+			latestSettingsRef.current = next
+			setSettings(next)
 		},
 		[]
 	)
 
 	const updateSettings = useCallback((partial: Partial<SettingsState>) => {
-		setSettings((prev) => ({ ...prev, ...partial }))
+		const next = { ...latestSettingsRef.current, ...partial }
+		latestSettingsRef.current = next
+		setSettings(next)
 	}, [])
+
+	const persistSetting = useCallback(
+		<K extends keyof SettingsState>(key: K, value: SettingsState[K]) => {
+			if (latestSettingsRef.current[key] === value) return
+			latestSettingsRef.current = { ...latestSettingsRef.current, [key]: value }
+			scheduleSave()
+		},
+		[scheduleSave]
+	)
 
 	const resetSettings = useCallback(() => {
-		setSettings({ ...DEFAULT_SETTINGS })
+		const next = { ...DEFAULT_SETTINGS }
+		latestSettingsRef.current = next
+		setSettings(next)
 	}, [])
 
-	return (
-		<SettingsContext.Provider
-			value={{
-				settings,
-				isLoading,
-				updateSetting,
-				updateSettings,
-				resetSettings
-			}}
-		>
-			{children}
-		</SettingsContext.Provider>
+	const value = useMemo(
+		() => ({
+			settings,
+			isLoading,
+			updateSetting,
+			updateSettings,
+			persistSetting,
+			resetSettings
+		}),
+		[settings, isLoading, updateSetting, updateSettings, persistSetting, resetSettings]
 	)
+
+	return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
 }
 
 // ============================================================================

--- a/packages/studio/src/core/tabs/tabs-store.tsx
+++ b/packages/studio/src/core/tabs/tabs-store.tsx
@@ -446,26 +446,48 @@ export function TabsProvider({ children }: { children: ReactNode }) {
   )
   const activeTabId = activeTabIdOf(state)
 
-  const value: TabsContextValue = {
-    tabs: state.tabs,
-    visibleTabs,
-    activeTabId,
-    activeConnectionId: state.activeConnectionId,
-    openConnectionIds: state.openConnectionIds,
-    openTab,
-    closeTab,
-    closeOtherTabs,
-    closeTabsToLeft,
-    closeTabsToRight,
-    setActiveTab,
-    togglePinTab,
-    reorderTab,
-    closeTabsForConnection,
-    hydrateSession,
-    setActiveConnection,
-    openConnection,
-    closeConnection,
-  }
+  const value: TabsContextValue = useMemo(
+    () => ({
+      tabs: state.tabs,
+      visibleTabs,
+      activeTabId,
+      activeConnectionId: state.activeConnectionId,
+      openConnectionIds: state.openConnectionIds,
+      openTab,
+      closeTab,
+      closeOtherTabs,
+      closeTabsToLeft,
+      closeTabsToRight,
+      setActiveTab,
+      togglePinTab,
+      reorderTab,
+      closeTabsForConnection,
+      hydrateSession,
+      setActiveConnection,
+      openConnection,
+      closeConnection,
+    }),
+    [
+      state.tabs,
+      visibleTabs,
+      activeTabId,
+      state.activeConnectionId,
+      state.openConnectionIds,
+      openTab,
+      closeTab,
+      closeOtherTabs,
+      closeTabsToLeft,
+      closeTabsToRight,
+      setActiveTab,
+      togglePinTab,
+      reorderTab,
+      closeTabsForConnection,
+      hydrateSession,
+      setActiveConnection,
+      openConnection,
+      closeConnection,
+    ]
+  )
 
   return <TabsContext.Provider value={value}>{children}</TabsContext.Provider>
 }

--- a/packages/studio/src/features/database-studio/components/data-grid.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useMemo } from 'react'
+import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react'
 import { useShortcut, useEffectiveShortcuts, useActiveScope } from '@studio/core/shortcuts'
 import { useSettings } from '@studio/core/settings'
 import { cn } from '@studio/shared/utils/cn'
@@ -112,12 +112,6 @@ export function DataGrid({
 		onCellSelectionChange
 	)
 
-	const effectiveSelectedRows = useMemo(() => {
-		if (selectedRows.size > 0) return selectedRows
-		if (focusedCell) return new Set([focusedCell.row])
-		return new Set<number>()
-	}, [selectedRows, focusedCell])
-
 	const primaryKeyColumnName = useMemo(() => {
 		return columns.find(function (c) {
 			return c.primaryKey
@@ -161,19 +155,22 @@ export function DataGrid({
 	const { handleCellContextMenuChange, handleRowContextMenuChange, handleContextMenuCapture } =
 		useContextMenuReporting(onContextMenuChange)
 
-	function handleCellMouseDown(e: React.MouseEvent, rowIndex: number, colIndex: number) {
-		if (e.button !== 0) return
-		if (editingCell) {
-			// Clicking another cell while editing – commit the in-flight edit
-			// then fall through so the new cell gets focused.
-			handleSaveEdit()
-		}
+	const handleCellMouseDown = useCallback(
+		function (e: React.MouseEvent, rowIndex: number, colIndex: number) {
+			if (e.button !== 0) return
+			if (editingCell) {
+				// Clicking another cell while editing – commit the in-flight edit
+				// then fall through so the new cell gets focused.
+				handleSaveEdit()
+			}
 
-		// Simplified logic: Just set focus and let event bubble to row for selection
-		const cellPos: CellPosition = { row: rowIndex, col: colIndex }
-		setFocusedCell(cellPos)
-		setAnchorCell(cellPos)
-	}
+			// Simplified logic: Just set focus and let event bubble to row for selection
+			const cellPos: CellPosition = { row: rowIndex, col: colIndex }
+			setFocusedCell(cellPos)
+			setAnchorCell(cellPos)
+		},
+		[editingCell, handleSaveEdit, setFocusedCell]
+	)
 
 	const { handleRowClick, ensureRowSelectionForContextMenu } = useRowSelection({
 		lastClickedRowRef,
@@ -199,13 +196,16 @@ export function DataGrid({
 		[focusedCell]
 	)
 
-	function handleCellMouseEnter(rowIndex: number, colIndex: number) {
-		if (!isDragging || !dragStart) return
+	const handleCellMouseEnter = useCallback(
+		function (rowIndex: number, colIndex: number) {
+			if (!isDragging || !dragStart) return
 
-		const cellPos: CellPosition = { row: rowIndex, col: colIndex }
-		const rangeCells = getCellsInRectangle(dragStart, cellPos)
-		updateCellSelection(rangeCells)
-	}
+			const cellPos: CellPosition = { row: rowIndex, col: colIndex }
+			const rangeCells = getCellsInRectangle(dragStart, cellPos)
+			updateCellSelection(rangeCells)
+		},
+		[isDragging, dragStart, updateCellSelection]
+	)
 
 	useEffect(
 		function () {
@@ -361,7 +361,6 @@ export function DataGrid({
 						editInputRef={editInputRef}
 						editingCell={editingCell}
 						editValue={editValue}
-						effectiveSelectedRows={effectiveSelectedRows}
 						focusedCell={focusedCell}
 						getColumnWidth={getColumnWidth}
 						handleCellContextMenuChange={handleCellContextMenuChange}

--- a/packages/studio/src/features/database-studio/components/data-grid/grid-body.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid/grid-body.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { memo, useMemo } from 'react'
 import type { VirtualItem } from '@tanstack/react-virtual'
 import { Checkbox } from '@studio/shared/ui/checkbox'
 import { cn } from '@studio/shared/utils/cn'
@@ -11,6 +11,302 @@ import { NoRowsState } from './empty-states'
 import { FKNavigateIcon } from './fk-icon'
 import { EditingCell } from './types'
 
+const EMPTY_ROW_SET: ReadonlySet<number> = new Set<number>()
+
+type GridRowProps = {
+	row: Record<string, unknown>
+	rowIndex: number
+	columns: ColumnDefinition[]
+	allRows: Record<string, unknown>[]
+	tableName?: string
+	masked?: boolean
+	selectedRows: Set<number>
+	isRowSelected: boolean
+	rowSelectedCols: Set<number> | undefined
+	focusedCol: number | null
+	/** Column being edited in THIS row, null when this row has no active editor. */
+	editingColumnName: string | null
+	/** Only meaningful while `editingColumnName` is set. */
+	editValue: string
+	pendingEdits?: Set<string>
+	primaryKeyColumnName?: string
+	getColumnWidth: (columnName: string) => number | undefined
+	editInputRef: React.RefObject<HTMLInputElement | HTMLSelectElement>
+	handleCellContextMenuChange: (open: boolean, row: number, col: number) => void
+	handleCellDoubleClick: (rowIndex: number, columnName: string, currentValue: unknown) => void
+	handleCellMouseDown: (e: React.MouseEvent, rowIndex: number, colIndex: number) => void
+	handleCellMouseEnter: (rowIndex: number, colIndex: number) => void
+	handleEditKeyDown: (e: React.KeyboardEvent) => void
+	handleEditBlur: () => void
+	handleSelectCommit: (value: string) => void
+	handleRowClick: (e: React.MouseEvent, rowIndex: number) => void
+	handleRowContextMenuChange: (open: boolean, row: number) => void
+	onBatchCellEdit?: (rowIndexes: number[], columnName: string, newValue: unknown) => void
+	onCellEdit?: (rowIndex: number, columnName: string, newValue: unknown) => void
+	onFilterAdd?: (filter: FilterDescriptor) => void
+	onBlobAction?: (
+		action: BlobAction,
+		column: ColumnDefinition,
+		row: Record<string, unknown>
+	) => void
+	onRowAction?: (
+		action: RowAction,
+		row: Record<string, unknown>,
+		rowIndex: number,
+		batchIndexes?: number[]
+	) => void
+	onRowSelect: (rowIndex: number, checked: boolean) => void
+	ensureRowSelectionForContextMenu: (rowIndex: number) => void
+	setEditValue: (value: string) => void
+	onFKNavigate?: (referencedTable: string, referencedColumn: string, value: unknown) => void
+}
+
+/**
+ * One data row, memoized so grid-level state churn (editing keystrokes, focus
+ * moves, drag selection) only re-renders the rows it touches instead of every
+ * visible cell.
+ */
+const GridRow = memo(function GridRow({
+	row,
+	rowIndex,
+	columns,
+	allRows,
+	tableName,
+	masked,
+	selectedRows,
+	isRowSelected,
+	rowSelectedCols,
+	focusedCol,
+	editingColumnName,
+	editValue,
+	pendingEdits,
+	primaryKeyColumnName,
+	getColumnWidth,
+	editInputRef,
+	handleCellContextMenuChange,
+	handleCellDoubleClick,
+	handleCellMouseDown,
+	handleCellMouseEnter,
+	handleEditKeyDown,
+	handleEditBlur,
+	handleSelectCommit,
+	handleRowClick,
+	handleRowContextMenuChange,
+	onBatchCellEdit,
+	onCellEdit,
+	onFilterAdd,
+	onBlobAction,
+	onRowAction,
+	onRowSelect,
+	ensureRowSelectionForContextMenu,
+	setEditValue,
+	onFKNavigate
+}: GridRowProps) {
+	// Selection the context menus act on. Falls back to this row when nothing is
+	// selected but a cell here is focused — batch actions (which need size > 1)
+	// only ever come from the real selection, so the fallback never has to know
+	// about focus on OTHER rows.
+	const menuSelectedRows = useMemo(() => {
+		if (selectedRows.size > 0) return selectedRows
+		if (focusedCol !== null) return new Set([rowIndex])
+		return EMPTY_ROW_SET as Set<number>
+	}, [selectedRows, focusedCol, rowIndex])
+
+	const rowBackgroundClasses = isRowSelected
+		? 'bg-primary/10'
+		: rowIndex % 2 === 1
+			? 'bg-muted/35 hover:bg-sidebar-accent/30'
+			: 'hover:bg-sidebar-accent/30'
+	const rowClasses = cn('group transition-colors cursor-pointer', rowBackgroundClasses)
+	// The checkbox column is sticky, so it floats over other cells during
+	// horizontal scroll — it needs an OPAQUE background (the translucent row
+	// tints would let scrolled content bleed through). Use the solid, theme-aware
+	// table tokens so striping/hover/selection still read correctly.
+	const stickyCellBackgroundClasses = isRowSelected
+		? 'bg-table-row-selected'
+		: rowIndex % 2 === 1
+			? 'bg-table-header group-hover:bg-table-row-hover'
+			: 'bg-background group-hover:bg-table-row-hover'
+
+	return (
+		<RowContextMenu
+			disabled={masked}
+			row={row}
+			rowIndex={rowIndex}
+			columns={columns}
+			tableName={tableName}
+			allRows={allRows}
+			onAction={function (action, row, index, batchIndexes) {
+				onRowAction?.(action, row, index, batchIndexes)
+			}}
+			onOpenChange={function (open, row) {
+				if (open) {
+					ensureRowSelectionForContextMenu(row)
+				}
+				handleRowContextMenuChange(open, row)
+			}}
+			selectedRows={menuSelectedRows}
+		>
+			<tr
+				className={rowClasses}
+				onClick={function (e) {
+					handleRowClick(e, rowIndex)
+				}}
+				role='row'
+				aria-rowindex={rowIndex + 2}
+				aria-selected={isRowSelected}
+			>
+				<td
+					className={cn(
+						'w-[30px] min-w-[30px] p-0 text-center align-middle border-b border-l border-r border-sidebar-border sticky left-0 z-20 transition-colors',
+						stickyCellBackgroundClasses
+					)}
+					role='gridcell'
+				>
+					<Checkbox
+						checked={isRowSelected}
+						onCheckedChange={function (checked) {
+							onRowSelect(rowIndex, !!checked)
+						}}
+						className='h-4 w-4'
+						aria-label={`Select row ${rowIndex + 1}`}
+						// Keep the grid a single tab stop: the table owns roving
+						// keyboard focus (arrows navigate cells, Space toggles the
+						// row). A tabbable checkbox per row would make Tab hop
+						// checkboxes and skip the data cells.
+						tabIndex={-1}
+					/>
+				</td>
+				{columns.map(function (col, colIndex) {
+					const isEditing = editingColumnName === col.name
+					const isFocused = focusedCol === colIndex
+					const isSelected = rowSelectedCols?.has(colIndex) || false
+					const width = getColumnWidth(col.name)
+					const isDirty = primaryKeyColumnName
+						? pendingEdits?.has(`${row[primaryKeyColumnName]}:${col.name}`)
+						: false
+
+					return (
+						<CellContextMenu
+							key={col.name}
+							disabled={masked}
+							value={row[col.name]}
+							column={col}
+							rowIndex={rowIndex}
+							colIndex={colIndex}
+							row={row}
+							selectedRows={menuSelectedRows}
+							hasFilter={!!onFilterAdd}
+							onBlobAction={onBlobAction}
+							onAction={function (action, value, column, batchAction) {
+								if (action === 'filter-by-value' && onFilterAdd) {
+									onFilterAdd({
+										column: column.name,
+										operator: 'eq',
+										value
+									})
+								} else if (action === 'edit') {
+									handleCellDoubleClick(rowIndex, column.name, value)
+								} else if (action === 'set-null' && onCellEdit) {
+									onCellEdit(rowIndex, column.name, null)
+								} else if (
+									action === 'set-null-batch' &&
+									batchAction &&
+									onBatchCellEdit
+								) {
+									onBatchCellEdit(batchAction.rowIndexes, column.name, null)
+								}
+							}}
+							onOpenChange={function (open, row, col) {
+								handleCellContextMenuChange(open, row, col)
+							}}
+						>
+							<td
+								className={cn(
+									'border-b border-r border-sidebar-border last:border-r-0 font-mono text-sm overflow-hidden cursor-cell px-3 py-1.5 relative whitespace-nowrap text-ellipsis max-w-[300px] group/cell',
+									isSelected && !isEditing && 'bg-muted-foreground/10',
+									isFocused &&
+										!isEditing &&
+										'bg-sidebar-accent/35 shadow-[inset_0_0_0_1px_hsl(var(--sidebar-foreground)/0.22)] z-10',
+									isDirty && 'bg-amber-500/10'
+								)}
+								style={width ? { maxWidth: width } : undefined}
+								data-cell-key={`${rowIndex}:${colIndex}`}
+								onMouseDown={function (e) {
+									handleCellMouseDown(e, rowIndex, colIndex)
+								}}
+								onMouseEnter={function () {
+									handleCellMouseEnter(rowIndex, colIndex)
+								}}
+								onDoubleClick={function () {
+									if (masked) return
+									handleCellDoubleClick(rowIndex, col.name, row[col.name])
+								}}
+							>
+								{isEditing && col.allowedValues ? (
+									<select
+										ref={editInputRef as React.RefObject<HTMLSelectElement>}
+										value={editValue}
+										onChange={function (e) {
+											handleSelectCommit(e.target.value)
+										}}
+										onBlur={handleEditBlur}
+										onKeyDown={handleEditKeyDown}
+										data-no-shortcuts='true'
+										className='w-full h-full bg-sidebar-accent/35 outline outline-1 outline-offset-[-1px] outline-sidebar-foreground/25 font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
+									>
+										{!col.allowedValues.includes(editValue) && (
+											<option value={editValue}>
+												{editValue === '' ? '(empty)' : editValue}
+											</option>
+										)}
+										{col.allowedValues.map(function (value) {
+											return (
+												<option key={value} value={value}>
+													{value}
+												</option>
+											)
+										})}
+									</select>
+								) : isEditing ? (
+									<input
+										ref={editInputRef as React.RefObject<HTMLInputElement>}
+										type='text'
+										value={editValue}
+										onChange={function (e) {
+											setEditValue(e.target.value)
+										}}
+										onBlur={handleEditBlur}
+										onKeyDown={handleEditKeyDown}
+										data-no-shortcuts='true'
+										className='w-full h-full bg-sidebar-accent/35 outline outline-1 outline-offset-[-1px] outline-sidebar-foreground/25 font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
+									/>
+								) : (
+									<div className='flex items-center min-w-0 relative'>
+										<span className='truncate flex-1'>
+											{formatCellValue(row[col.name], col, masked)}
+										</span>
+										{col.foreignKey && onFKNavigate && !masked && (
+											<FKNavigateIcon
+												foreignKey={col.foreignKey}
+												cellValue={row[col.name]}
+												onNavigate={onFKNavigate}
+											/>
+										)}
+										{isDirty && (
+											<div className='absolute top-0 right-0 -mr-3 -mt-1.5 w-0 h-0 border-t-[6px] border-r-[6px] border-t-transparent border-r-amber-500' />
+										)}
+									</div>
+								)}
+							</td>
+						</CellContextMenu>
+					)
+				})}
+			</tr>
+		</RowContextMenu>
+	)
+})
+
 type GridBodyProps = {
 	columns: ColumnDefinition[]
 	draftInsertIndex?: number | null
@@ -18,7 +314,6 @@ type GridBodyProps = {
 	editInputRef: React.RefObject<HTMLInputElement | HTMLSelectElement>
 	editingCell: EditingCell | null
 	editValue: string
-	effectiveSelectedRows: Set<number>
 	focusedCell: { row: number; col: number } | null
 	getColumnWidth: (columnName: string) => number | undefined
 	handleCellContextMenuChange: (open: boolean, row: number, col: number) => void
@@ -72,7 +367,6 @@ export function GridBody({
 	editInputRef,
 	editingCell,
 	editValue,
-	effectiveSelectedRows,
 	focusedCell,
 	getColumnWidth,
 	handleCellContextMenuChange,
@@ -104,17 +398,23 @@ export function GridBody({
 	setEditValue,
 	onFKNavigate,
 	virtualRows,
-	totalVirtualSize,
+	totalVirtualSize
 }: GridBodyProps) {
 	// Determine which rows to actually render
-	const rowsToRender: Array<{ rowIndex: number; start?: number }> = virtualRows
-		? virtualRows.map(function (vr) { return { rowIndex: vr.index, start: vr.start } })
-		: rows.map(function (_, i) { return { rowIndex: i } })
+	const rowIndexesToRender: number[] = virtualRows
+		? virtualRows.map(function (vr) {
+				return vr.index
+			})
+		: rows.map(function (_, i) {
+				return i
+			})
 
 	const topPad = virtualRows && virtualRows.length > 0 ? virtualRows[0].start : 0
-	const bottomPad = virtualRows && virtualRows.length > 0 && totalVirtualSize
-		? totalVirtualSize - (virtualRows[virtualRows.length - 1].start + virtualRows[virtualRows.length - 1].size)
-		: 0
+	const bottomPad =
+		virtualRows && virtualRows.length > 0 && totalVirtualSize
+			? totalVirtualSize -
+				(virtualRows[virtualRows.length - 1].start + virtualRows[virtualRows.length - 1].size)
+			: 0
 	return (
 		<tbody role='rowgroup'>
 			{draftRow &&
@@ -139,236 +439,47 @@ export function GridBody({
 				</tr>
 			)}
 
-			{rowsToRender.map(function ({ rowIndex }) {
-				const row = rows[rowIndex]
-				const rowBackgroundClasses = selectedRows.has(rowIndex)
-					? 'bg-primary/10'
-					: rowIndex % 2 === 1
-						? 'bg-muted/35 hover:bg-sidebar-accent/30'
-						: 'hover:bg-sidebar-accent/30'
-				const rowClasses = cn(
-					'group transition-colors cursor-pointer',
-					rowBackgroundClasses
-				)
-				// The checkbox column is sticky, so it floats over other cells during
-				// horizontal scroll — it needs an OPAQUE background (the translucent row
-				// tints would let scrolled content bleed through). Use the solid, theme-aware
-				// table tokens so striping/hover/selection still read correctly.
-				const stickyCellBackgroundClasses = selectedRows.has(rowIndex)
-					? 'bg-table-row-selected'
-					: rowIndex % 2 === 1
-						? 'bg-table-header group-hover:bg-table-row-hover'
-						: 'bg-background group-hover:bg-table-row-hover'
+			{rowIndexesToRender.map(function (rowIndex) {
+				const isEditingRow = editingCell?.rowIndex === rowIndex
 
 				return (
 					<React.Fragment key={rowIndex}>
-						<RowContextMenu
-							disabled={masked}
-							row={row}
+						<GridRow
+							row={rows[rowIndex]}
 							rowIndex={rowIndex}
 							columns={columns}
-							tableName={tableName}
 							allRows={rows}
-							onAction={function (action, row, index, batchIndexes) {
-								onRowAction?.(action, row, index, batchIndexes)
-							}}
-							onOpenChange={function (open, row) {
-								if (open) {
-									ensureRowSelectionForContextMenu(row)
-								}
-								handleRowContextMenuChange(open, row)
-							}}
-							selectedRows={effectiveSelectedRows}
-						>
-							<tr
-								className={rowClasses}
-								onClick={function (e) {
-									handleRowClick(e, rowIndex)
-								}}
-								role='row'
-								aria-rowindex={rowIndex + 2}
-								aria-selected={selectedRows.has(rowIndex)}
-							>
-								<td
-									className={cn(
-										'w-[30px] min-w-[30px] p-0 text-center align-middle border-b border-l border-r border-sidebar-border sticky left-0 z-20 transition-colors',
-										stickyCellBackgroundClasses
-									)}
-									role='gridcell'
-								>
-									<Checkbox
-										checked={selectedRows.has(rowIndex)}
-										onCheckedChange={function (checked) {
-											onRowSelect(rowIndex, !!checked)
-										}}
-										className='h-4 w-4'
-										aria-label={`Select row ${rowIndex + 1}`}
-										// Keep the grid a single tab stop: the table owns roving
-										// keyboard focus (arrows navigate cells, Space toggles the
-										// row). A tabbable checkbox per row would make Tab hop
-										// checkboxes and skip the data cells.
-										tabIndex={-1}
-									/>
-								</td>
-								{columns.map(function (col, colIndex) {
-									const isEditing =
-										editingCell?.rowIndex === rowIndex &&
-										editingCell?.columnName === col.name
-									const isFocused =
-										focusedCell?.row === rowIndex &&
-										focusedCell?.col === colIndex
-									const rowSelectedCols = selectedCellsByRow.get(rowIndex)
-									const isSelected = rowSelectedCols?.has(colIndex) || false
-									const width = getColumnWidth(col.name)
-									const isDirty = primaryKeyColumnName
-										? pendingEdits?.has(
-												`${row[primaryKeyColumnName]}:${col.name}`
-											)
-										: false
-
-									return (
-										<CellContextMenu
-											key={col.name}
-											disabled={masked}
-											value={row[col.name]}
-											column={col}
-											rowIndex={rowIndex}
-											colIndex={colIndex}
-											row={row}
-											selectedRows={effectiveSelectedRows}
-											hasFilter={!!onFilterAdd}
-											onBlobAction={onBlobAction}
-											onAction={function (
-												action,
-												value,
-												column,
-												batchAction
-											) {
-												if (action === 'filter-by-value' && onFilterAdd) {
-													onFilterAdd({
-														column: column.name,
-														operator: 'eq',
-														value
-													})
-												} else if (action === 'edit') {
-													handleCellDoubleClick(
-														rowIndex,
-														column.name,
-														value
-													)
-												} else if (action === 'set-null' && onCellEdit) {
-													onCellEdit(rowIndex, column.name, null)
-												} else if (
-													action === 'set-null-batch' &&
-													batchAction &&
-													onBatchCellEdit
-												) {
-													onBatchCellEdit(
-														batchAction.rowIndexes,
-														column.name,
-														null
-													)
-												}
-											}}
-											onOpenChange={function (open, row, col) {
-												handleCellContextMenuChange(open, row, col)
-											}}
-										>
-											<td
-												className={cn(
-													'border-b border-r border-sidebar-border last:border-r-0 font-mono text-sm overflow-hidden cursor-cell px-3 py-1.5 relative whitespace-nowrap text-ellipsis max-w-[300px] group/cell',
-													isSelected &&
-														!isEditing &&
-														'bg-muted-foreground/10',
-													isFocused &&
-														!isEditing &&
-														'bg-sidebar-accent/35 shadow-[inset_0_0_0_1px_hsl(var(--sidebar-foreground)/0.22)] z-10',
-													isDirty && 'bg-amber-500/10'
-												)}
-												style={width ? { maxWidth: width } : undefined}
-												data-cell-key={`${rowIndex}:${colIndex}`}
-												onMouseDown={function (e) {
-													handleCellMouseDown(e, rowIndex, colIndex)
-												}}
-												onMouseEnter={function () {
-													handleCellMouseEnter(rowIndex, colIndex)
-												}}
-												onDoubleClick={function () {
-													if (masked) return
-													handleCellDoubleClick(
-														rowIndex,
-														col.name,
-														row[col.name]
-													)
-												}}
-											>
-												{isEditing && col.allowedValues ? (
-													<select
-														ref={
-															editInputRef as React.RefObject<HTMLSelectElement>
-														}
-														value={editValue}
-														onChange={function (e) {
-															handleSelectCommit(e.target.value)
-														}}
-														onBlur={handleEditBlur}
-														onKeyDown={handleEditKeyDown}
-														data-no-shortcuts='true'
-														className='w-full h-full bg-sidebar-accent/35 outline outline-1 outline-offset-[-1px] outline-sidebar-foreground/25 font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
-													>
-														{!col.allowedValues.includes(editValue) && (
-															<option value={editValue}>
-																{editValue === ''
-																	? '(empty)'
-																	: editValue}
-															</option>
-														)}
-														{col.allowedValues.map(function (value) {
-															return (
-																<option key={value} value={value}>
-																	{value}
-																</option>
-															)
-														})}
-													</select>
-												) : isEditing ? (
-													<input
-														ref={
-															editInputRef as React.RefObject<HTMLInputElement>
-														}
-														type='text'
-														value={editValue}
-														onChange={function (e) {
-															setEditValue(e.target.value)
-														}}
-														onBlur={handleEditBlur}
-														onKeyDown={handleEditKeyDown}
-														data-no-shortcuts='true'
-														className='w-full h-full bg-sidebar-accent/35 outline outline-1 outline-offset-[-1px] outline-sidebar-foreground/25 font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
-													/>
-												) : (
-													<div className='flex items-center min-w-0 relative'>
-														<span className='truncate flex-1'>
-															{formatCellValue(row[col.name], col, masked)}
-														</span>
-														{col.foreignKey && onFKNavigate && !masked && (
-															<FKNavigateIcon
-																foreignKey={col.foreignKey}
-																cellValue={row[col.name]}
-																onNavigate={onFKNavigate}
-															/>
-														)}
-														{isDirty && (
-															<div className='absolute top-0 right-0 -mr-3 -mt-1.5 w-0 h-0 border-t-[6px] border-r-[6px] border-t-transparent border-r-amber-500' />
-														)}
-													</div>
-												)}
-											</td>
-										</CellContextMenu>
-									)
-								})}
-							</tr>
-						</RowContextMenu>
+							tableName={tableName}
+							masked={masked}
+							selectedRows={selectedRows}
+							isRowSelected={selectedRows.has(rowIndex)}
+							rowSelectedCols={selectedCellsByRow.get(rowIndex)}
+							focusedCol={focusedCell?.row === rowIndex ? focusedCell.col : null}
+							editingColumnName={isEditingRow ? editingCell.columnName : null}
+							editValue={isEditingRow ? editValue : ''}
+							pendingEdits={pendingEdits}
+							primaryKeyColumnName={primaryKeyColumnName}
+							getColumnWidth={getColumnWidth}
+							editInputRef={editInputRef}
+							handleCellContextMenuChange={handleCellContextMenuChange}
+							handleCellDoubleClick={handleCellDoubleClick}
+							handleCellMouseDown={handleCellMouseDown}
+							handleCellMouseEnter={handleCellMouseEnter}
+							handleEditKeyDown={handleEditKeyDown}
+							handleEditBlur={handleEditBlur}
+							handleSelectCommit={handleSelectCommit}
+							handleRowClick={handleRowClick}
+							handleRowContextMenuChange={handleRowContextMenuChange}
+							onBatchCellEdit={onBatchCellEdit}
+							onCellEdit={onCellEdit}
+							onFilterAdd={onFilterAdd}
+							onBlobAction={onBlobAction}
+							onRowAction={onRowAction}
+							onRowSelect={onRowSelect}
+							ensureRowSelectionForContextMenu={ensureRowSelectionForContextMenu}
+							setEditValue={setEditValue}
+							onFKNavigate={onFKNavigate}
+						/>
 						{draftRow && draftInsertIndex === rowIndex + 1 && (
 							<DraftRow
 								columns={columns}

--- a/packages/studio/src/features/database-studio/components/data-grid/use-cell-selection.ts
+++ b/packages/studio/src/features/database-studio/components/data-grid/use-cell-selection.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 export function useCellSelection(
 	externalSelectedCells?: Set<string>,
@@ -23,13 +23,16 @@ export function useCellSelection(
 		return byRow
 	}, [selectedCellsSet])
 
-	function updateCellSelection(cells: Set<string>) {
-		if (onCellSelectionChange) {
-			onCellSelectionChange(cells)
-		} else {
-			setInternalSelectedCells(cells)
-		}
-	}
+	const updateCellSelection = useCallback(
+		function (cells: Set<string>) {
+			if (onCellSelectionChange) {
+				onCellSelectionChange(cells)
+			} else {
+				setInternalSelectedCells(cells)
+			}
+		},
+		[onCellSelectionChange]
+	)
 
 	return { selectedCellsSet, selectedCellsByRow, updateCellSelection }
 }

--- a/packages/studio/src/features/database-studio/components/data-grid/use-context-menu-reporting.ts
+++ b/packages/studio/src/features/database-studio/components/data-grid/use-context-menu-reporting.ts
@@ -1,41 +1,47 @@
-import { useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import type React from 'react'
 import { ContextMenuState } from './types'
 
 export function useContextMenuReporting(onContextMenuChange?: (ctx: ContextMenuState) => void) {
 	const lastContextMenuCoordsRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
 
-	function handleCellContextMenuChange(open: boolean, row: number, col: number) {
-		if (!onContextMenuChange) return
-		if (open) {
-			onContextMenuChange({
-				kind: 'cell',
-				cell: { row, col },
-				x: lastContextMenuCoordsRef.current.x,
-				y: lastContextMenuCoordsRef.current.y
-			})
-		} else {
-			onContextMenuChange(null)
-		}
-	}
+	const handleCellContextMenuChange = useCallback(
+		function (open: boolean, row: number, col: number) {
+			if (!onContextMenuChange) return
+			if (open) {
+				onContextMenuChange({
+					kind: 'cell',
+					cell: { row, col },
+					x: lastContextMenuCoordsRef.current.x,
+					y: lastContextMenuCoordsRef.current.y
+				})
+			} else {
+				onContextMenuChange(null)
+			}
+		},
+		[onContextMenuChange]
+	)
 
-	function handleRowContextMenuChange(open: boolean, row: number) {
-		if (!onContextMenuChange) return
-		if (open) {
-			onContextMenuChange({
-				kind: 'row',
-				cell: { row, col: 0 },
-				x: lastContextMenuCoordsRef.current.x,
-				y: lastContextMenuCoordsRef.current.y
-			})
-		} else {
-			onContextMenuChange(null)
-		}
-	}
+	const handleRowContextMenuChange = useCallback(
+		function (open: boolean, row: number) {
+			if (!onContextMenuChange) return
+			if (open) {
+				onContextMenuChange({
+					kind: 'row',
+					cell: { row, col: 0 },
+					x: lastContextMenuCoordsRef.current.x,
+					y: lastContextMenuCoordsRef.current.y
+				})
+			} else {
+				onContextMenuChange(null)
+			}
+		},
+		[onContextMenuChange]
+	)
 
-	function handleContextMenuCapture(e: React.MouseEvent) {
+	const handleContextMenuCapture = useCallback(function (e: React.MouseEvent) {
 		lastContextMenuCoordsRef.current = { x: e.clientX, y: e.clientY }
-	}
+	}, [])
 
 	return {
 		handleCellContextMenuChange,

--- a/packages/studio/src/features/database-studio/components/data-grid/use-focused-cell.ts
+++ b/packages/studio/src/features/database-studio/components/data-grid/use-focused-cell.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { CellPosition } from './types'
 
 export function useFocusedCell(
@@ -25,10 +25,13 @@ export function useFocusedCell(
 		}
 	}, [initialFocusedCell, focusedCell])
 
-	function setFocusedCell(cell: CellPosition | null) {
-		setFocusedCellInternal(cell)
-		onFocusedCellChange?.(cell)
-	}
+	const setFocusedCell = useCallback(
+		function (cell: CellPosition | null) {
+			setFocusedCellInternal(cell)
+			onFocusedCellChange?.(cell)
+		},
+		[onFocusedCellChange]
+	)
 
 	return { focusedCell, setFocusedCell }
 }

--- a/packages/studio/src/features/database-studio/components/data-grid/use-row-selection.ts
+++ b/packages/studio/src/features/database-studio/components/data-grid/use-row-selection.ts
@@ -43,12 +43,15 @@ export function useRowSelection({
 		[lastClickedRowRef, onRowSelect, onRowsSelect, selectedRows]
 	)
 
-	function ensureRowSelectionForContextMenu(rowIndex: number) {
-		if (selectedRows.has(rowIndex)) return
-		onSelectAll(false)
-		onRowSelect(rowIndex, true)
-		lastClickedRowRef.current = rowIndex
-	}
+	const ensureRowSelectionForContextMenu = useCallback(
+		function (rowIndex: number) {
+			if (selectedRows.has(rowIndex)) return
+			onSelectAll(false)
+			onRowSelect(rowIndex, true)
+			lastClickedRowRef.current = rowIndex
+		},
+		[lastClickedRowRef, onRowSelect, onSelectAll, selectedRows]
+	)
 
 	return { handleRowClick, ensureRowSelectionForContextMenu }
 }

--- a/packages/studio/src/features/database-studio/database-studio.tsx
+++ b/packages/studio/src/features/database-studio/database-studio.tsx
@@ -23,7 +23,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle
 } from '@studio/shared/ui/alert-dialog'
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { AddRecordDialog } from './components/add-record-dialog'
 import { BottomStatusBar } from './components/bottom-status-bar'
 import { BulkEditDialog } from './components/bulk-edit-dialog'
@@ -45,7 +45,11 @@ import { SetNullDialog } from './components/set-null-dialog'
 import { StudioToolbar } from './components/studio-toolbar'
 import { ExportOptionsDialog, type ExportFormatChoice } from './components/export-options-dialog'
 import { ImportCsvDialog } from './components/import-csv-dialog'
-import { DataSeederDialog } from './data-seeder-dialog'
+const DataSeederDialog = lazy(function () {
+	return import('./data-seeder-dialog').then(function (m) {
+		return { default: m.DataSeederDialog }
+	})
+})
 import { useDatabaseStudioSync } from './hooks/use-database-studio-sync'
 import { useDatabaseStudioActions } from './hooks/use-database-studio-actions'
 import { useDatabaseStudioEdits } from './hooks/use-database-studio-edits'
@@ -54,7 +58,11 @@ import { buildDefaultTableCacheKey, buildTableCacheKey } from './utils/table-cac
 import { appendRows, removeRowsByPrimaryKey } from './utils/studio-data'
 import { FilterConjunction, FilterDescriptor, FilterGroup, PaginationState, SortDescriptor, TableData, ViewMode } from './types'
 import { flatFiltersToGroup, groupToFlatFilters } from '@studio/core/data-provider/filter-sql'
-import { ResultChartPanel } from '@studio/features/result-charts/result-chart-panel'
+const ResultChartPanel = lazy(function () {
+	return import('@studio/features/result-charts/result-chart-panel').then(function (m) {
+		return { default: m.ResultChartPanel }
+	})
+})
 import type { ResultChartConfig } from '@studio/features/result-charts/types'
 import { commands } from '@studio/lib/bindings'
 import type { ColumnDefinition } from './types'
@@ -903,13 +911,15 @@ export function DatabaseStudio({
 					onMarkChangesRead={showLiveMonitor ? liveMonitor.markRead : undefined}
 				/>
 				<div className='min-h-0 flex-1'>
-					<ResultChartPanel
-						columns={tableData.columns}
-						rows={tableData.rows}
-						config={chartConfig}
-						onConfigChange={setChartConfig}
-						title={`${displayTableName} chart`}
-					/>
+					<Suspense fallback={null}>
+						<ResultChartPanel
+							columns={tableData.columns}
+							rows={tableData.rows}
+							config={chartConfig}
+							onConfigChange={setChartConfig}
+							title={`${displayTableName} chart`}
+						/>
+					</Suspense>
 				</div>
 			</div>
 		)
@@ -1237,19 +1247,21 @@ export function DatabaseStudio({
 				/>
 			)}
 
-			{tableData && (
-				<DataSeederDialog
-					open={showDataSeederDialog}
-					onOpenChange={setShowDataSeederDialog}
-					tableName={displayTableName || ''}
-					columns={tableData.columns.map((c) => ({
-						name: c.name,
-						type: c.type,
-						isNullable: c.nullable,
-						isPrimaryKey: c.primaryKey
-					}))}
-					onGenerate={handleSeederGenerate}
-				/>
+			{tableData && showDataSeederDialog && (
+				<Suspense fallback={null}>
+					<DataSeederDialog
+						open={showDataSeederDialog}
+						onOpenChange={setShowDataSeederDialog}
+						tableName={displayTableName || ''}
+						columns={tableData.columns.map((c) => ({
+							name: c.name,
+							type: c.type,
+							isNullable: c.nullable,
+							isPrimaryKey: c.primaryKey
+						}))}
+						onGenerate={handleSeederGenerate}
+					/>
+				</Suspense>
 			)}
 
 			<ExportOptionsDialog

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
@@ -99,6 +99,7 @@ export function useDatabaseStudioSync(args: Args) {
   const initializedFromUrlRef = useRef(false);
   const isUpdatingUrlRef = useRef(false);
   const loadRequestIdRef = useRef(0);
+  const restoredFromPKRef = useRef(false);
   // The cache key whose data is currently painted on screen. Used to tell a
   // genuine view switch (paint the cache for an instant result) apart from an
   // in-place refresh of the view already shown (don't paint the now-stale
@@ -431,11 +432,16 @@ export function useDatabaseStudioSync(args: Args) {
 
   useEffect(
     function restoreSelectionFromPK() {
+      if (restoredFromPKRef.current) return;
       if (!tableData || !initialRowPK || selectedRows.size > 0 || initializedFromUrlRef.current)
         return;
 
       const primaryKeyColumn = tableData.columns.find((c) => c.primaryKey);
       if (!primaryKeyColumn) return;
+
+      // One-shot: restoring launch state must never resurrect a selection the
+      // user has since cleared.
+      restoredFromPKRef.current = true;
 
       const rowIndex = tableData.rows.findIndex(
         (row) => String(row[primaryKeyColumn.name]) === String(initialRowPK),

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
@@ -433,15 +433,18 @@ export function useDatabaseStudioSync(args: Args) {
   useEffect(
     function restoreSelectionFromPK() {
       if (restoredFromPKRef.current) return;
-      if (!tableData || !initialRowPK || selectedRows.size > 0 || initializedFromUrlRef.current)
-        return;
+      if (!tableData) return;
+
+      // Consume the one-shot the moment data is available — this is our single
+      // restore opportunity. `initialRowPK` no longer changes during the session
+      // (it's persisted without React state), so without consuming the ref here
+      // a later selection-clear would re-run this and resurrect the launch row.
+      restoredFromPKRef.current = true;
+
+      if (!initialRowPK || selectedRows.size > 0 || initializedFromUrlRef.current) return;
 
       const primaryKeyColumn = tableData.columns.find((c) => c.primaryKey);
       if (!primaryKeyColumn) return;
-
-      // One-shot: restoring launch state must never resurrect a selection the
-      // user has since cleared.
-      restoredFromPKRef.current = true;
 
       const rowIndex = tableData.rows.findIndex(
         (row) => String(row[primaryKeyColumn.name]) === String(initialRowPK),

--- a/packages/studio/src/features/drizzle-runner/components/results-panel.tsx
+++ b/packages/studio/src/features/drizzle-runner/components/results-panel.tsx
@@ -137,6 +137,8 @@ export function ResultsPanel({ result, showJson }: Props) {
 							return (
 								<tr
 									key={rowIndex}
+									data-index={rowIndex}
+									ref={shouldVirtualize ? rowVirtualizer.measureElement : undefined}
 									className='hover:bg-sidebar-accent/50 transition-colors'
 								>
 									{result.columns.map((col) => (

--- a/packages/studio/src/features/drizzle-runner/components/results-panel.tsx
+++ b/packages/studio/src/features/drizzle-runner/components/results-panel.tsx
@@ -1,4 +1,6 @@
 import { Copy } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { Button } from '@studio/shared/ui/button'
 import { ScrollArea } from '@studio/shared/ui/scroll-area'
 import { useSettings } from '@studio/core/settings'
@@ -10,9 +12,28 @@ type Props = {
 	showJson: boolean
 }
 
+const VIRTUALIZE_THRESHOLD = 100
+
 export function ResultsPanel({ result, showJson }: Props) {
 	const { settings } = useSettings()
 	const masked = settings.privacyMaskData
+
+	const [scrollViewport, setScrollViewport] = useState<HTMLDivElement | null>(null)
+	const scrollAreaRef = useCallback((node: HTMLDivElement | null) => {
+		setScrollViewport(
+			node?.querySelector<HTMLDivElement>('[data-radix-scroll-area-viewport]') ?? null
+		)
+	}, [])
+
+	const rowCount = result?.rows.length ?? 0
+	const shouldVirtualize = !showJson && rowCount > VIRTUALIZE_THRESHOLD
+	const rowVirtualizer = useVirtualizer({
+		count: shouldVirtualize ? rowCount : 0,
+		getScrollElement: () => scrollViewport,
+		estimateSize: () => 37,
+		overscan: 12,
+		enabled: shouldVirtualize
+	})
 
 	if (!result) {
 		return (
@@ -69,6 +90,17 @@ export function ResultsPanel({ result, showJson }: Props) {
 		)
 	}
 
+	const virtualRows = shouldVirtualize ? rowVirtualizer.getVirtualItems() : null
+	const totalVirtualSize = shouldVirtualize ? rowVirtualizer.getTotalSize() : 0
+	const topPad = virtualRows && virtualRows.length > 0 ? virtualRows[0].start : 0
+	const bottomPad =
+		virtualRows && virtualRows.length > 0
+			? totalVirtualSize - virtualRows[virtualRows.length - 1].end
+			: 0
+	const rowIndexesToRender = virtualRows
+		? virtualRows.map((vr) => vr.index)
+		: result.rows.map((_, i) => i)
+
 	return (
 		<div className='flex flex-col h-full'>
 			{/* Status bar */}
@@ -80,7 +112,7 @@ export function ResultsPanel({ result, showJson }: Props) {
 			</div>
 
 			{/* Data table */}
-			<ScrollArea className='flex-1'>
+			<ScrollArea ref={scrollAreaRef} className='flex-1'>
 				<table className='w-full text-sm'>
 					<thead className='sticky top-0 bg-sidebar-accent'>
 						<tr>
@@ -95,27 +127,40 @@ export function ResultsPanel({ result, showJson }: Props) {
 						</tr>
 					</thead>
 					<tbody>
-						{result.rows.map((row, rowIndex) => (
-							<tr
-								key={rowIndex}
-								className='hover:bg-sidebar-accent/50 transition-colors'
-							>
-								{result.columns.map((col) => (
-									<td
-										key={col}
-										className='px-3 py-2 text-sidebar-foreground border-b border-r border-sidebar-border last:border-r-0 font-mono'
-									>
-										{masked ? (
-											<span className='select-none tracking-widest text-muted-foreground'>
-												{MASK_TOKEN}
-											</span>
-										) : (
-											formatCellValue(row[col])
-										)}
-									</td>
-								))}
+						{topPad > 0 && (
+							<tr style={{ height: topPad }}>
+								<td colSpan={result.columns.length} />
 							</tr>
-						))}
+						)}
+						{rowIndexesToRender.map((rowIndex) => {
+							const row = result.rows[rowIndex]
+							return (
+								<tr
+									key={rowIndex}
+									className='hover:bg-sidebar-accent/50 transition-colors'
+								>
+									{result.columns.map((col) => (
+										<td
+											key={col}
+											className='px-3 py-2 text-sidebar-foreground border-b border-r border-sidebar-border last:border-r-0 font-mono'
+										>
+											{masked ? (
+												<span className='select-none tracking-widest text-muted-foreground'>
+													{MASK_TOKEN}
+												</span>
+											) : (
+												formatCellValue(row[col])
+											)}
+										</td>
+									))}
+								</tr>
+							)
+						})}
+						{bottomPad > 0 && (
+							<tr style={{ height: bottomPad }}>
+								<td colSpan={result.columns.length} />
+							</tr>
+						)}
 					</tbody>
 				</table>
 			</ScrollArea>

--- a/packages/studio/src/features/schema-visualizer/components/relationship-edge.tsx
+++ b/packages/studio/src/features/schema-visualizer/components/relationship-edge.tsx
@@ -5,6 +5,7 @@ import {
 	type Edge,
 	type EdgeProps,
 } from '@xyflow/react'
+import { memo } from 'react'
 import { cn } from '@studio/shared/utils/cn'
 import type { RelationshipEdgeData } from '../hooks/use-schema-graph'
 
@@ -72,7 +73,7 @@ function getEdgeVisuals(data: RelationshipEdgeData | undefined): EdgeVisuals {
 	}
 }
 
-export function RelationshipEdge({
+function RelationshipEdgeInner({
 	id,
 	sourceX,
 	sourceY,
@@ -167,3 +168,9 @@ export function RelationshipEdge({
 		</>
 	)
 }
+
+/**
+ * React Flow re-renders every edge on any node position change (drag). Memoize
+ * so only edges whose geometry or data actually changed re-run their path math.
+ */
+export const RelationshipEdge = memo(RelationshipEdgeInner)

--- a/packages/studio/src/features/sql-console/components/sql-results.tsx
+++ b/packages/studio/src/features/sql-console/components/sql-results.tsx
@@ -13,7 +13,8 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle
 } from '@studio/shared/ui/alert-dialog'
-import { useState, useRef, useEffect, useMemo } from 'react'
+import { lazy, Suspense, useState, useRef, useEffect, useMemo, useCallback } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { useDataMutation } from '@studio/core/data-provider'
 import { useSettings } from '@studio/core/settings'
 import { MASK_TOKEN, maskRowsForJson } from '@studio/core/privacy/mask'
@@ -32,7 +33,11 @@ import { useToast } from '@studio/shared/ui/use-toast'
 import { remeasureMonacoFonts } from '@studio/shared/lib/font-loader'
 import { cn } from '@studio/shared/utils/cn'
 import { areValuesEqual } from '@studio/shared/utils/value-equality'
-import { ResultChartPanel } from '@studio/features/result-charts/result-chart-panel'
+const ResultChartPanel = lazy(function () {
+	return import('@studio/features/result-charts/result-chart-panel').then(function (m) {
+		return { default: m.ResultChartPanel }
+	})
+})
 import type { ResultChartConfig } from '@studio/features/result-charts/types'
 import { formatCellValue as renderCellValue } from '@studio/features/database-studio/components/data-grid/cell-value'
 import type { ColumnDefinition } from '@studio/features/database-studio/types'
@@ -110,12 +115,14 @@ export function SqlResults({
 	}, [result])
 
 	// In privacy mode the JSON view must not leak raw values either, so mask the
-	// rows before serializing.
+	// rows before serializing. Only serialized while the JSON view is showing —
+	// stringifying a large result set is too expensive to pay on every query
+	// when the table view is active.
 	const resultJsonText = useMemo(() => {
-		if (!result) return ''
+		if (!result || viewMode !== 'json') return ''
 		const rows = masked ? maskRowsForJson(result.rows) : result.rows
 		return JSON.stringify(rows, null, 2)
-	}, [result, masked])
+	}, [result, masked, viewMode])
 
 	const cellColumns = useMemo(() => {
 		if (!result) return new Map<string, ColumnDefinition>()
@@ -362,6 +369,37 @@ export function SqlResults({
 		return { filteredRows: rows, filterTime: (end - start).toFixed(2) }
 	}, [result, filterText])
 
+	// The scroll element lives inside the Radix ScrollArea; hold it in state so
+	// the virtualizer re-measures once the viewport mounts.
+	const [scrollViewport, setScrollViewport] = useState<HTMLDivElement | null>(null)
+	const scrollAreaRef = useCallback((node: HTMLDivElement | null) => {
+		setScrollViewport(
+			node?.querySelector<HTMLDivElement>('[data-radix-scroll-area-viewport]') ?? null
+		)
+	}, [])
+
+	// Virtualize large result sets — rendering thousands of rows (each wrapped
+	// in a context menu) makes big SELECTs unusable.
+	const VIRTUALIZE_THRESHOLD = 100
+	const shouldVirtualize = viewMode === 'table' && filteredRows.length > VIRTUALIZE_THRESHOLD
+	const rowVirtualizer = useVirtualizer({
+		count: shouldVirtualize ? filteredRows.length : 0,
+		getScrollElement: () => scrollViewport,
+		estimateSize: () => 34,
+		overscan: 12,
+		enabled: shouldVirtualize
+	})
+	const virtualRows = shouldVirtualize ? rowVirtualizer.getVirtualItems() : null
+	const totalVirtualSize = shouldVirtualize ? rowVirtualizer.getTotalSize() : 0
+	const topPad = virtualRows && virtualRows.length > 0 ? virtualRows[0].start : 0
+	const bottomPad =
+		virtualRows && virtualRows.length > 0
+			? totalVirtualSize - virtualRows[virtualRows.length - 1].end
+			: 0
+	const rowIndexesToRender = virtualRows
+		? virtualRows.map((vr) => vr.index)
+		: filteredRows.map((_, i) => i)
+
 	// Reset filter if hidden
 	useEffect(() => {
 		if (!showFilter) setFilterText('')
@@ -482,18 +520,20 @@ export function SqlResults({
 				) : isExplainQuery(result.executedQuery) ? (
 					<QueryPlanPanel result={result} />
 				) : viewMode === 'chart' ? (
-					<ResultChartPanel
-						columns={result.columns.map(function (column) {
-							const definition = result.columnDefinitions?.find(function (item) {
-								return item.name === column
-							})
-							return { name: column, type: definition?.type }
-						})}
-						rows={result.rows}
-						config={chartConfig}
-						onConfigChange={onChartConfigChange}
-						title='Query chart'
-					/>
+					<Suspense fallback={null}>
+						<ResultChartPanel
+							columns={result.columns.map(function (column) {
+								const definition = result.columnDefinitions?.find(function (item) {
+									return item.name === column
+								})
+								return { name: column, type: definition?.type }
+							})}
+							rows={result.rows}
+							config={chartConfig}
+							onConfigChange={onChartConfigChange}
+							title='Query chart'
+						/>
+					</Suspense>
 				) : result.rows.length === 0 ? (
 					<div className='flex flex-col items-center justify-center h-full text-muted-foreground'>
 						<div className='inline-flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-emerald-600 dark:text-emerald-400'>
@@ -549,7 +589,7 @@ export function SqlResults({
 								/>
 							</div>
 						)}
-						<ScrollArea className='flex-1'>
+						<ScrollArea ref={scrollAreaRef} className='flex-1'>
 							<table className='w-full text-sm'>
 								<thead className='sticky top-0 bg-sidebar-accent z-10'>
 									<tr>
@@ -567,7 +607,14 @@ export function SqlResults({
 									</tr>
 								</thead>
 								<tbody>
-									{filteredRows.map((row, rowIndex) => (
+									{topPad > 0 && (
+										<tr style={{ height: topPad }}>
+											<td colSpan={result.columns.length + 1} />
+										</tr>
+									)}
+									{rowIndexesToRender.map((rowIndex) => {
+										const row = filteredRows[rowIndex]
+										return (
 										<ContextMenu key={rowIndex}>
 											<ContextMenuTrigger asChild>
 												<tr className='hover:bg-sidebar-accent/50 transition-colors group'>
@@ -679,7 +726,13 @@ export function SqlResults({
 												</ContextMenuItem>
 											</ContextMenuContent>
 										</ContextMenu>
-									))}
+										)
+									})}
+									{bottomPad > 0 && (
+										<tr style={{ height: bottomPad }}>
+											<td colSpan={result.columns.length + 1} />
+										</tr>
+									)}
 								</tbody>
 							</table>
 						</ScrollArea>

--- a/packages/studio/src/features/sql-console/stores/query-history-store.tsx
+++ b/packages/studio/src/features/sql-console/stores/query-history-store.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
+import { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react'
 import type { ResultChartConfig } from '@studio/features/result-charts/types'
 
 export type QueryHistoryItem = {
@@ -129,21 +129,20 @@ export function QueryHistoryProvider({ children }: Props) {
 		})
 	}, [])
 
-	return (
-		<QueryHistoryContext.Provider
-			value={{
-				history,
-				addToHistory,
-				clearHistory,
-				removeFromHistory,
-				pinItem,
-				unpinItem,
-				updateChartConfig
-			}}
-		>
-			{children}
-		</QueryHistoryContext.Provider>
+	const value = useMemo(
+		() => ({
+			history,
+			addToHistory,
+			clearHistory,
+			removeFromHistory,
+			pinItem,
+			unpinItem,
+			updateChartConfig
+		}),
+		[history, addToHistory, clearHistory, removeFromHistory, pinItem, unpinItem, updateChartConfig]
 	)
+
+	return <QueryHistoryContext.Provider value={value}>{children}</QueryHistoryContext.Provider>
 }
 
 export function useQueryHistory(): QueryHistoryContextValue {

--- a/packages/studio/src/features/sql-console/stores/tab-store.tsx
+++ b/packages/studio/src/features/sql-console/stores/tab-store.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useReducer, useCallback, useEffect, ReactNode } from 'react'
+import { createContext, useContext, useReducer, useCallback, useEffect, useMemo, ReactNode } from 'react'
 import type { ResultChartConfig } from '@studio/features/result-charts/types'
 import { QueryTab, SqlQueryResult, ResultViewMode } from '../types'
 import { DEFAULT_SQL } from '../data'
@@ -444,28 +444,52 @@ export function QueryTabProvider({ children, connectionId }: TProps) {
 		}
 	}, [state.tabs])
 
-	const value: TabContextValue = {
-		tabs: state.tabs,
-		activeTabId: state.activeTabId,
-		activeTab,
-		addTab,
-		closeTab,
-		setActiveTab,
-		renameTab,
-		updateTabContent,
-		setTabMode,
-		setTabResult,
-		setTabExecuting,
-		setTabViewMode,
-		setTabChartConfig,
-		setTabHistoryEntry,
-		autoTitleTab,
-		reorderTabs,
-		duplicateTab,
-		nextTab,
-		prevTab,
-		goToTab
-	}
+	const value: TabContextValue = useMemo(
+		() => ({
+			tabs: state.tabs,
+			activeTabId: state.activeTabId,
+			activeTab,
+			addTab,
+			closeTab,
+			setActiveTab,
+			renameTab,
+			updateTabContent,
+			setTabMode,
+			setTabResult,
+			setTabExecuting,
+			setTabViewMode,
+			setTabChartConfig,
+			setTabHistoryEntry,
+			autoTitleTab,
+			reorderTabs,
+			duplicateTab,
+			nextTab,
+			prevTab,
+			goToTab
+		}),
+		[
+			state.tabs,
+			state.activeTabId,
+			activeTab,
+			addTab,
+			closeTab,
+			setActiveTab,
+			renameTab,
+			updateTabContent,
+			setTabMode,
+			setTabResult,
+			setTabExecuting,
+			setTabViewMode,
+			setTabChartConfig,
+			setTabHistoryEntry,
+			autoTitleTab,
+			reorderTabs,
+			duplicateTab,
+			nextTab,
+			prevTab,
+			goToTab
+		]
+	)
 
 	return (
 		<TabContext.Provider value={value}>

--- a/packages/studio/src/pages/Index.tsx
+++ b/packages/studio/src/pages/Index.tsx
@@ -16,14 +16,22 @@ import {
 } from "@studio/shared/lib/ui-zoom";
 import { LiveMonitorProvider } from "@studio/core/live-monitor";
 import { NavigationSidebar, SidebarProvider } from "@studio/features/app-sidebar";
-import { CommandPalette } from "@studio/features/command-palette";
+const CommandPalette = lazy(function () {
+  return import("@studio/features/command-palette").then(function (m) {
+    return { default: m.CommandPalette };
+  });
+});
 import { scheduleSqlConsoleCommand } from "@studio/features/command-palette/events";
 import { useConnections, useConnectionMutations } from "@studio/core/data-provider/hooks";
 import {
   backendToFrontendConnection,
   frontendToBackendDatabaseInfo,
 } from "@studio/features/connections/utils/mapping";
-import { ConnectionDialog } from "@studio/features/connections/components/connection-dialog";
+const ConnectionDialog = lazy(function () {
+  return import("@studio/features/connections/components/connection-dialog").then(function (m) {
+    return { default: m.ConnectionDialog };
+  });
+});
 import { Connection } from "@studio/features/connections/types";
 import { getContainerConnectionDetails } from "@studio/features/docker-manager/utilities/container-connection";
 import {
@@ -94,7 +102,7 @@ function IndexInner() {
       return !open;
     });
   }, []);
-  const { settings, updateSetting, updateSettings, isLoading: isSettingsLoading } = useSettings();
+  const { settings, persistSetting, isLoading: isSettingsLoading } = useSettings();
 
   const { data: connections = [], isLoading: isConnectionsLoading } = useConnections();
   const isLoading = isSettingsLoading || isConnectionsLoading;
@@ -190,6 +198,24 @@ function IndexInner() {
   const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<Connection | undefined>(undefined);
   const isConnectionDialogOpenRef = useRef(isConnectionDialogOpen);
+  // The connection dialog (and its framer-motion dependency) is a lazy chunk;
+  // mount it the first time it opens and keep it mounted so its exit animation
+  // still plays on close.
+  const [connectionDialogEverOpened, setConnectionDialogEverOpened] = useState(false);
+  useEffect(
+    function trackConnectionDialogFirstOpen() {
+      if (isConnectionDialogOpen) setConnectionDialogEverOpened(true);
+    },
+    [isConnectionDialogOpen],
+  );
+  // Same lazy-mount treatment for the command palette.
+  const [commandPaletteEverOpened, setCommandPaletteEverOpened] = useState(false);
+  useEffect(
+    function trackCommandPaletteFirstOpen() {
+      if (isCommandPaletteOpen) setCommandPaletteEverOpened(true);
+    },
+    [isCommandPaletteOpen],
+  );
 
   const startupConnectionMode =
     settings.startupConnectionMode ?? (settings.restoreLastConnection ? "auto" : "empty");
@@ -553,31 +579,12 @@ function IndexInner() {
     function saveLastConnection() {
       if (!activeConnectionId || isSettingsLoading) return;
 
-      const updates: Partial<typeof settings> = {};
-      let hasUpdates = false;
-
-      if (settings.lastConnectionId !== activeConnectionId) {
-        updates.lastConnectionId = activeConnectionId;
-        hasUpdates = true;
-      }
-
-      if (selectedTableId && settings.lastTableId !== selectedTableId) {
-        updates.lastTableId = selectedTableId;
-        hasUpdates = true;
-      }
-
-      if (hasUpdates) {
-        updateSettings(updates);
+      persistSetting("lastConnectionId", activeConnectionId);
+      if (selectedTableId) {
+        persistSetting("lastTableId", selectedTableId);
       }
     },
-    [
-      activeConnectionId,
-      selectedTableId,
-      isSettingsLoading,
-      settings.lastConnectionId,
-      settings.lastTableId,
-      updateSettings,
-    ],
+    [activeConnectionId, selectedTableId, isSettingsLoading, persistSetting],
   );
 
   async function handleAddConnection(connection: Omit<Connection, "id" | "status" | "createdAt">) {
@@ -1093,9 +1100,7 @@ function IndexInner() {
                           tableName={selectedTableName}
                           initialRowPK={settings.lastRowPK}
                           onRowSelectionChange={function (pk) {
-                            if (pk !== settings.lastRowPK) {
-                              updateSetting("lastRowPK", pk);
-                            }
+                            persistSetting("lastRowPK", pk);
                           }}
                           activeConnectionId={studioConnectionId}
                           onConnectionSelect={setActiveConnectionId}
@@ -1240,46 +1245,54 @@ function IndexInner() {
                 </Suspense>
               </main>
 
-              <ConnectionDialog
-                open={isConnectionDialogOpen}
-                onOpenChange={handleConnectionDialogOpenChange}
-                onSave={handleDialogSave}
-                droppedFilePaths={connectionDialogDroppedPaths}
-                externalDropActive={connectionDialogDragActive}
-                onDroppedFilePathsHandled={function () {
-                  setConnectionDialogDroppedPaths(null);
-                }}
-                onOpenDataFiles={
-                  isTauri
-                    ? async function (paths?: string[]) {
-                        if (paths && paths.length > 0) {
-                          setIsConnectionDialogOpen(false);
-                          await handleOpenDataFiles(paths);
-                          return;
-                        }
-                        setIsConnectionDialogOpen(false);
-                        await handlePickDataFiles();
-                      }
-                    : undefined
-                }
-                resolveDatabaseType={resolveDatabaseType}
-                initialValues={editingConnection}
-              />
+              {connectionDialogEverOpened && (
+                <Suspense fallback={null}>
+                  <ConnectionDialog
+                    open={isConnectionDialogOpen}
+                    onOpenChange={handleConnectionDialogOpenChange}
+                    onSave={handleDialogSave}
+                    droppedFilePaths={connectionDialogDroppedPaths}
+                    externalDropActive={connectionDialogDragActive}
+                    onDroppedFilePathsHandled={function () {
+                      setConnectionDialogDroppedPaths(null);
+                    }}
+                    onOpenDataFiles={
+                      isTauri
+                        ? async function (paths?: string[]) {
+                            if (paths && paths.length > 0) {
+                              setIsConnectionDialogOpen(false);
+                              await handleOpenDataFiles(paths);
+                              return;
+                            }
+                            setIsConnectionDialogOpen(false);
+                            await handlePickDataFiles();
+                          }
+                        : undefined
+                    }
+                    resolveDatabaseType={resolveDatabaseType}
+                    initialValues={editingConnection}
+                  />
+                </Suspense>
+              )}
 
-              <CommandPalette
-                open={isCommandPaletteOpen}
-                onOpenChange={setIsCommandPaletteOpen}
-                activeNavId={paletteActiveNavId}
-                onNavigate={setActiveNavId}
-                connections={connections}
-                activeConnectionId={activeConnectionId}
-                selectedTableId={selectedTableId}
-                onSelectConnection={handleConnectionSelect}
-                onCreateConnection={handleOpenNewConnection}
-                onEditConnection={handleEditConnection}
-                onDeleteConnection={handleDeleteConnection}
-                onSelectTable={handleTableSelect}
-              />
+              {commandPaletteEverOpened && (
+                <Suspense fallback={null}>
+                  <CommandPalette
+                    open={isCommandPaletteOpen}
+                    onOpenChange={setIsCommandPaletteOpen}
+                    activeNavId={paletteActiveNavId}
+                    onNavigate={setActiveNavId}
+                    connections={connections}
+                    activeConnectionId={activeConnectionId}
+                    selectedTableId={selectedTableId}
+                    onSelectConnection={handleConnectionSelect}
+                    onCreateConnection={handleOpenNewConnection}
+                    onEditConnection={handleEditConnection}
+                    onDeleteConnection={handleDeleteConnection}
+                    onSelectTable={handleTableSelect}
+                  />
+                </Suspense>
+              )}
 
               <AiAssistantToggle />
               <AiAssistantPanelHost

--- a/packages/studio/src/studio-app.tsx
+++ b/packages/studio/src/studio-app.tsx
@@ -12,7 +12,16 @@ import { AppProviders } from '@studio/providers'
 import Index from '@studio/pages/Index'
 import NotFound from '@studio/pages/NotFound'
 
-const queryClient = new QueryClient()
+// Desktop-tuned defaults: alt-tabbing back to the app must not refetch every
+// active query (connections, schemas, table pages) — data changes flow through
+// explicit refreshes, mutations, and the live monitor instead.
+const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: {
+			refetchOnWindowFocus: false
+		}
+	}
+})
 
 function GlobalToaster() {
 	const { settings } = useSettings()


### PR DESCRIPTION
## Summary

Performance pass over the Studio frontend and the desktop bundle — no behavior changes, no API changes. The theme: stop paying render/startup costs the app doesn't need.

Verified: `packages/studio` + `apps/desktop` typecheck clean, **725/725 tests pass** in both suites, production build succeeds.

## What changed

### Eliminate app-wide re-renders
- **Row selection no longer re-renders the whole app.** `Index` persisted `lastRowPK`/`lastTableId`/`lastConnectionId` via `updateSetting`, which set React state on a context consumed by ~12 components (including the data grid). New `persistSetting()` writes these restore-on-launch keys to disk via a ref + debounce **without touching React state** — they're only read back at startup, never reactively.
- **Memoized the context value of every provider that rebuilt it each render:** DataProvider, PendingEdits, Settings, QueryHistory, the tabs store, and the SQL-console tab store.
- Disabled `refetchOnWindowFocus` globally (alt-tab no longer refetches connections/schemas/table pages).

### Grid + result tables
- **Extracted each data-grid row into a memoized `GridRow`** — grid-level state churn (edit keystrokes, focus moves, drag-select) now re-renders only the affected rows instead of every visible cell. Grid callback hooks stabilized with `useCallback` so the memo boundary holds.
- **Virtualized the SQL-console and drizzle-runner result tables** (>100 rows). The SQL one previously rendered every row wrapped in a context menu.
- SQL JSON view is serialized only when that tab is active, not on every query.
- Memoized `RelationshipEdge` (React Flow re-renders all edges on any node drag).

### Bundle — move work off the startup path
- Lazy-loaded the connection dialog (carries framer-motion), command palette, data seeder (faker locale data), and the recharts chart panel. Modals stay mounted after first open so exit animations still play.
- Lazy-loaded the web-demo mock adapter so desktop startup never touches it or its demo dataset.
- Split the connection dialog + provider connect-flows out of the eager `feature-core` chunk: **~613KB → ~443KB of always-executed code**. ~625KB total moved to on-demand chunks.

### Rust
Reviewed the query→IPC hot paths (row writers build JSON into one reused buffer and return `Box<RawValue>`, clones are cold-path only, release profile already maxed). No changes warranted.

## Test plan
- [x] `bun run typecheck` — studio + desktop
- [x] `bun run test` — 725 pass (both suites)
- [x] `bun run build` (apps/desktop) — succeeds; verified feature-core shrank and connection-dialog/command-palette/seeder/faker/charts/mock are separate on-demand chunks
- [ ] Manual smoke: browse a large table, edit cells, run a large SELECT, open schema visualizer, add a connection, open command palette

## Summary by Sourcery

Improve Studio frontend performance by reducing unnecessary renders, virtualizing large result tables, and deferring heavy UI chunks from the initial desktop startup bundle.

Enhancements:
- Memoize data grid rows, selection handlers, and context values to limit re-renders to affected cells and providers.
- Virtualize large SQL-console and drizzle-runner result tables and gate JSON serialization on the active view to keep big results responsive.
- Lazy-load the command palette, connection dialog, data seeder, result charts, and mock adapter, keeping them out of always-executed desktop chunks.
- Adjust React Query defaults to avoid refetching data on window focus and refine database studio state restoration to be one-shot on launch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness when working with large database and SQL result tables through optimized rendering.
  * Reduced initial load times by loading charts, dialogs, and command tools only when needed.
  * Reduced unnecessary updates across tabs, settings, query history, and data-grid interactions.

* **Bug Fixes**
  * Prevented cleared row selections from being unexpectedly restored.
  * Improved settings persistence for frequently updated connection and table preferences.
  * Disabled unnecessary query refreshes when switching application windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->