### PR TITLE
chore(deps): upgrade @remcostoeten/analytics to 1.7.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -41,7 +41,7 @@
 		"@radix-ui/react-switch": "^1.2.5",
 		"@radix-ui/react-tabs": "^1.1.12",
 		"@radix-ui/react-tooltip": "^1.2.7",
-		"@remcostoeten/analytics": "^1.4.0",
+		"@remcostoeten/analytics": "^1.7.0",
 		"@remcostoeten/notifier": "^1.0.0",
 		"@remcostoeten/use-shortcut": "^2.3.0",
 		"@tanstack/react-query": "^5.83.0",

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -23,7 +23,7 @@
         "@dora/studio": "workspace:*",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.1",
-        "@remcostoeten/analytics": "^1.4.0",
+        "@remcostoeten/analytics": "^1.7.0",
         "@remcostoeten/use-shortcut": "^2.3.0",
         "@types/mdx": "^2.0.14",
         "framer-motion": "^12.29.0",

--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -103,7 +103,8 @@ export default function RootLayout({ children }: TRootProps) {
                     projectId={process.env.NEXT_PUBLIC_ANALYTICS_PROJECT_ID}
                     ingestUrl={process.env.NEXT_PUBLIC_ANALYTICS_INGEST_URL}
                     disabled={process.env.NODE_ENV !== 'production' || process.env.NEXT_PUBLIC_ANALYTICS_ENABLED === 'false'}
-                    // trackOutbound and trackErrors available after publishing v1.5.0
+                    trackOutbound
+                    trackErrors
                 />
             </body>
         </html>

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "apps/desktop": {
       "name": "@dora/desktop",
-      "version": "0.30.3",
+      "version": "0.35.1",
       "dependencies": {
         "@dora/studio": "workspace:*",
         "@faker-js/faker": "^10.2.0",
@@ -53,7 +53,7 @@
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@remcostoeten/analytics": "^1.4.0",
+        "@remcostoeten/analytics": "^1.7.0",
         "@remcostoeten/notifier": "^1.0.0",
         "@remcostoeten/use-shortcut": "^2.3.0",
         "@tanstack/react-query": "^5.83.0",
@@ -113,7 +113,7 @@
         "@dora/studio": "workspace:*",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.1",
-        "@remcostoeten/analytics": "^1.4.0",
+        "@remcostoeten/analytics": "^1.7.0",
         "@remcostoeten/use-shortcut": "^2.3.0",
         "@types/mdx": "^2.0.14",
         "framer-motion": "^12.29.0",
@@ -180,7 +180,7 @@
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@remcostoeten/analytics": "^1.4.0",
+        "@remcostoeten/analytics": "^1.7.0",
         "@remcostoeten/notifier": "^1.0.0",
         "@remcostoeten/use-shortcut": "^2.3.0",
         "@tanstack/react-query": "^5.83.0",
@@ -675,7 +675,7 @@
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
 
-    "@remcostoeten/analytics": ["@remcostoeten/analytics@1.4.0", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-TWsj+qxxW0S6TyvQYTKKgcEUopWaKGlzTCvI9Ayrm7amzgcJ272Rn7YK4Ci9e2FCea9DGn/Gw/JneEi2ELOtVQ=="],
+    "@remcostoeten/analytics": ["@remcostoeten/analytics@1.7.0", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-6zBomBUckjOk7osPfrFnX+8v8pmy/ygFZiJYxehAni/KdcHdJBMN8gg6t6MnQB3XSjr3GqKCzzosFgk7otkJjQ=="],
 
     "@remcostoeten/notifier": ["@remcostoeten/notifier@1.0.0", "", { "peerDependencies": { "motion": ">=12.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-s9xnwfH7Cz7lWnmOZwce6a8e7VCy1zoZTgVxoSYYuxJobN0Cg45ApCw3HSgzfYCzVNHQkSRHcMwp4ZdSdrzRfQ=="],
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -38,7 +38,7 @@
 		"@radix-ui/react-switch": "^1.2.5",
 		"@radix-ui/react-tabs": "^1.1.12",
 		"@radix-ui/react-tooltip": "^1.2.7",
-		"@remcostoeten/analytics": "^1.4.0",
+		"@remcostoeten/analytics": "^1.7.0",
 		"@remcostoeten/notifier": "^1.0.0",
 		"@remcostoeten/use-shortcut": "^2.3.0",
 		"@tanstack/react-query": "^5.83.0",


### PR DESCRIPTION
## Summary
- Bump `@remcostoeten/analytics` from `^1.4.0` to `^1.7.0` in `apps/marketing`, `apps/desktop`, and `packages/studio`.
- Enable the now-available `trackOutbound` and `trackErrors` opt-in observers on the marketing `<Analytics />` (a comment was waiting on a post-1.5.0 release).

1.7.0 brings the new ingestion features: offline queue with `/e/batch`, server-side tracking entry, client timestamps, and geo/timezone resolution.

## Test plan
- `bun install` — all workspaces resolve and link 1.7.0.
- `bun run typecheck` in `apps/marketing` — no new errors (45 pre-existing monaco/recharts errors in `packages/studio` are untouched by this change).

## Summary by Sourcery

Upgrade analytics dependency to v1.7.0 across apps and enable new tracking options in the marketing layout.

Enhancements:
- Enable outbound link and error tracking on the marketing Analytics component.

Build:
- Bump @remcostoeten/analytics from ^1.4.0 to ^1.7.0 in apps/marketing, apps/desktop, and packages/studio.
- Update bun.lock to reflect the new analytics version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added outbound link tracking and error tracking to improve analytics visibility.
* **Improvements**
  * Updated the analytics integration across desktop, marketing, and studio applications for enhanced tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->