### PR TITLE
fix: audit batch — SQL tab data loss, dark failing test, dead CI gates

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -25,7 +25,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -18,7 +18,7 @@ jobs:
       AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
       AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           fetch-depth: 0
           ref: master

--- a/.github/workflows/brew.yml
+++ b/.github/workflows/brew.yml
@@ -23,7 +23,7 @@ jobs:
       HOMEBREW_TAP_REPO: remcostoeten/homebrew-dora
       HOMEBREW_SSH_PRIVATE_KEY: ${{ secrets.HOMEBREW_SSH_PRIVATE_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
       - name: Setup bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
                   echo "Using PostgreSQL tools from: ${PG_BIN_DIR}"
                   export PATH="${PG_BIN_DIR}:$PATH"
                   which initdb
-                  cargo test --lib
+                  cargo test
               env:
                   DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
 

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -20,7 +20,7 @@ jobs:
   flatpak:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
       - name: Resolve release metadata
         id: meta

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
       - name: Resolve release metadata
         id: meta

--- a/README.md
+++ b/README.md
@@ -201,8 +201,14 @@ bun run desktop:build:mac                # dmg
 **Tests**
 
 ```bash
-bun test
+bun run test          # full Vitest suite (via turbo)
+bun run test:watch    # watch mode
+bun run test:coverage # with coverage
 ```
+
+> [!NOTE]
+> Use `bun run test`, not a bare `bun test` — the latter invokes Bun's own
+> runner, which picks up Vitest and Playwright specs it cannot execute.
 
 > [!NOTE]
 > The desktop app uses Vite as its dev server (`http://localhost:1420`). Hot-reload works for the TypeScript frontend; Rust changes require a full rebuild.

--- a/apps/desktop/src-tauri/tests/credentials_tests.rs
+++ b/apps/desktop/src-tauri/tests/credentials_tests.rs
@@ -41,7 +41,9 @@ fn postgres_with_percent_encoded_password() {
 
     let (sanitized, pw) = extract_sensitive_data(dbi).expect("ok");
 
-    assert_eq!(pw.as_deref(), Some("p%404ss"));
+    // The keyring stores the real secret, so the percent-encoded form in the URL
+    // is decoded on extraction; `Url::set_password` re-encodes on reinsertion.
+    assert_eq!(pw.as_deref(), Some("p@4ss"));
 
     match sanitized {
         DatabaseInfo::Postgres {

--- a/apps/desktop/src-tauri/tests/duckdb_ipc_tests.rs
+++ b/apps/desktop/src-tauri/tests/duckdb_ipc_tests.rs
@@ -2,6 +2,11 @@
 //! `duckdb_helper` binary and drives it through the `IpcDuckDbConn` client,
 //! exercising open, a transactional batch, a raw query, and a streaming
 //! `execute_query`.
+//!
+//! Gated on `duckdb-engine` to match the `duckdb_helper` binary's
+//! `required-features`: without it the helper is never built, so the spawn
+//! below would fail on a path that only exists in a stale target dir.
+#![cfg(feature = "duckdb-engine")]
 
 use app_lib::database::duckdb_ipc::client;
 use app_lib::database::parser::ParsedStatement;

--- a/packages/studio/src/features/sql-console/stores/tab-store.test.tsx
+++ b/packages/studio/src/features/sql-console/stores/tab-store.test.tsx
@@ -1,0 +1,94 @@
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { QueryTabProvider, useQueryTabs } from '@studio/features/sql-console/stores/tab-store'
+
+function storageKey(connectionId: string): string {
+	return `dora-query-tabs-${connectionId}`
+}
+
+function seed(connectionId: string, sql: string): void {
+	localStorage.setItem(
+		storageKey(connectionId),
+		JSON.stringify({
+			tabs: [{ id: `tab-${connectionId}`, title: 'Query 1', mode: 'sql', sqlContent: sql, drizzleContent: '', result: null, isExecuting: false, isDirty: false, viewMode: 'table', chartConfig: null, historyEntryId: null, connectionId, createdAt: 0, lastExecutedAt: null }],
+			activeTabId: `tab-${connectionId}`
+		})
+	)
+}
+
+function ActiveQuery() {
+	const { activeTab } = useQueryTabs()
+	return <span data-testid="query">{activeTab?.sqlContent ?? ''}</span>
+}
+
+function readStoredQuery(connectionId: string): string | undefined {
+	const raw = localStorage.getItem(storageKey(connectionId))
+	if (!raw) return undefined
+	return JSON.parse(raw).tabs[0]?.sqlContent
+}
+
+describe('QueryTabProvider connection switching', function () {
+	beforeEach(() => {
+		localStorage.clear()
+	})
+
+	it('does not overwrite the incoming connection\'s saved tabs', function () {
+		seed('a', 'SELECT 1 FROM a')
+		seed('b', 'SELECT 2 FROM b')
+
+		const { rerender } = render(
+			<QueryTabProvider connectionId="a">
+				<ActiveQuery />
+			</QueryTabProvider>
+		)
+
+		rerender(
+			<QueryTabProvider connectionId="b">
+				<ActiveQuery />
+			</QueryTabProvider>
+		)
+
+		expect(readStoredQuery('b')).toBe('SELECT 2 FROM b')
+		expect(readStoredQuery('a')).toBe('SELECT 1 FROM a')
+	})
+
+	it('loads the incoming connection\'s tabs into state', function () {
+		seed('a', 'SELECT 1 FROM a')
+		seed('b', 'SELECT 2 FROM b')
+
+		const { rerender, getByTestId } = render(
+			<QueryTabProvider connectionId="a">
+				<ActiveQuery />
+			</QueryTabProvider>
+		)
+		expect(getByTestId('query').textContent).toBe('SELECT 1 FROM a')
+
+		rerender(
+			<QueryTabProvider connectionId="b">
+				<ActiveQuery />
+			</QueryTabProvider>
+		)
+		expect(getByTestId('query').textContent).toBe('SELECT 2 FROM b')
+	})
+
+	it('round-trips A to B and back without losing either side', function () {
+		seed('a', 'SELECT 1 FROM a')
+		seed('b', 'SELECT 2 FROM b')
+
+		const tree = function (connectionId: string) {
+			return (
+				<QueryTabProvider connectionId={connectionId}>
+					<ActiveQuery />
+				</QueryTabProvider>
+			)
+		}
+
+		const { rerender } = render(tree('a'))
+		rerender(tree('b'))
+		rerender(tree('a'))
+
+		expect(readStoredQuery('a')).toBe('SELECT 1 FROM a')
+		expect(readStoredQuery('b')).toBe('SELECT 2 FROM b')
+	})
+})

--- a/packages/studio/src/features/sql-console/stores/tab-store.tsx
+++ b/packages/studio/src/features/sql-console/stores/tab-store.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useReducer, useCallback, useEffect, useMemo, ReactNode } from 'react'
+import { createContext, useContext, useReducer, useCallback, useEffect, useMemo, useRef, ReactNode } from 'react'
 import type { ResultChartConfig } from '@studio/features/result-charts/types'
 import { QueryTab, SqlQueryResult, ResultViewMode } from '../types'
 import { DEFAULT_SQL } from '../data'
@@ -349,8 +349,15 @@ export function QueryTabProvider({ children, connectionId }: TProps) {
 
 	const [state, dispatch] = useReducer(tabReducer, undefined, initialState)
 
+	// The connection whose tabs are actually in `state`. Effects run in
+	// declaration order, so on a connectionId change the persist effect below
+	// would otherwise write the outgoing connection's tabs under the incoming
+	// connection's key, destroying its saved queries before the load effect runs.
+	const loadedConnectionIdRef = useRef(connectionId)
+
 	// Persist whenever state changes
 	useEffect(function () {
+		if (loadedConnectionIdRef.current !== connectionId) return
 		saveTabsToStorage(connectionId, state)
 	}, [state, connectionId])
 
@@ -363,6 +370,7 @@ export function QueryTabProvider({ children, connectionId }: TProps) {
 			const defaultTab = createDefaultTab(connectionId)
 			dispatch({ type: 'LOAD_TABS', tabs: [defaultTab], activeTabId: defaultTab.id })
 		}
+		loadedConnectionIdRef.current = connectionId
 	}, [connectionId])
 
 	const activeTab = state.tabs.find(function (t) { return t.id === state.activeTabId }) || state.tabs[0]

--- a/packages/studio/src/shared/utils/table-ref.test.ts
+++ b/packages/studio/src/shared/utils/table-ref.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { getTableSqlIdentifier } from '@studio/shared/utils/table-ref'
+import {
+	buildDropColumnSql,
+	getColumnSqlIdentifier,
+	getTableRefParts,
+	getTableSqlIdentifier
+} from '@studio/shared/utils/table-ref'
 
 describe('getTableSqlIdentifier', function () {
 	it('keeps schema qualification for postgres by default', function () {
@@ -34,5 +39,57 @@ describe('getTableSqlIdentifier', function () {
 
 	it('keeps simple identifiers quoted', function () {
 		expect(getTableSqlIdentifier('users')).toBe('"users"')
+	})
+
+	it('doubles embedded double quotes', function () {
+		expect(getTableSqlIdentifier({ name: 'we"ird' }, 'postgres')).toBe('"we""ird"')
+	})
+
+	it('doubles embedded backticks for mysql', function () {
+		expect(getTableSqlIdentifier({ name: 'we`ird' }, 'mysql')).toBe('`we``ird`')
+	})
+
+	it('round-trips a pre-quoted mysql reference', function () {
+		expect(getTableSqlIdentifier('`db`.`tbl`', 'mysql')).toBe('`db`.`tbl`')
+	})
+
+	it('splits on the separator outside quotes, not the first dot', function () {
+		expect(getTableRefParts('"weird.schema"."Table Name"')).toEqual({
+			schemaName: '"weird.schema"',
+			tableName: '"Table Name"'
+		})
+	})
+
+	it('treats an unquoted dotted name as schema-qualified', function () {
+		expect(getTableRefParts('public.user')).toEqual({
+			schemaName: 'public',
+			tableName: 'user'
+		})
+	})
+
+	it('drops the schema part for sqlite even when quoted', function () {
+		expect(getTableSqlIdentifier('"weird.schema"."Table Name"', 'sqlite')).toBe('"Table Name"')
+	})
+})
+
+describe('getColumnSqlIdentifier', function () {
+	it('doubles embedded double quotes', function () {
+		expect(getColumnSqlIdentifier('a"b')).toBe('"a""b"')
+	})
+
+	it('doubles embedded backticks for mysql', function () {
+		expect(getColumnSqlIdentifier('a`b', 'mysql')).toBe('`a``b`')
+	})
+
+	it('passes through an already-quoted column', function () {
+		expect(getColumnSqlIdentifier('"a b"')).toBe('"a b"')
+	})
+})
+
+describe('buildDropColumnSql', function () {
+	it('quotes both parts of a dotted quoted table and an awkward column', function () {
+		expect(buildDropColumnSql('"weird.schema"."Table Name"', 'a"b', 'postgres')).toBe(
+			'ALTER TABLE "weird.schema"."Table Name" DROP COLUMN "a""b"'
+		)
 	})
 })

--- a/packages/studio/src/shared/utils/table-ref.ts
+++ b/packages/studio/src/shared/utils/table-ref.ts
@@ -29,8 +29,53 @@ function dialectUsesSchemas(dialect?: TableDialect): boolean {
 	)
 }
 
+// Index of the schema/table separator, skipping over quoted spans so a dot
+// inside `"weird.schema"` is not mistaken for the separator. Doubled quotes
+// ("" / ``) are escapes and do not close the span.
+function findSeparatorIndex(value: string): number {
+	let index = 0
+
+	while (index < value.length) {
+		const char = value[index]
+
+		if (char === '"' || char === '`') {
+			index++
+			while (index < value.length) {
+				if (value[index] === char) {
+					if (value[index + 1] === char) {
+						index += 2
+						continue
+					}
+					index++
+					break
+				}
+				index++
+			}
+			continue
+		}
+
+		if (char === '.') return index
+		index++
+	}
+
+	return -1
+}
+
+// Quotes an identifier, doubling any embedded quote characters. An already
+// quoted identifier is returned unchanged so callers can pass through
+// user-supplied quoting.
+function quoteIdentifier(value: string, quote: '"' | '`'): string {
+	const trimmed = value.trim()
+
+	if (trimmed.length >= 2 && trimmed.startsWith(quote) && trimmed.endsWith(quote)) {
+		return trimmed
+	}
+
+	return `${quote}${trimmed.split(quote).join(quote + quote)}${quote}`
+}
+
 export function getTableRefParts(value: string): TableRefParts {
-	const separatorIndex = value.indexOf('.')
+	const separatorIndex = findSeparatorIndex(value)
 	if (separatorIndex === -1) {
 		return {
 			schemaName: null,
@@ -66,20 +111,20 @@ export function getTableSqlIdentifier(
 
 	if (dialect === 'mysql' || dialect === 'mariadb') {
 		if (parts.schemaName) {
-			return `\`${parts.schemaName}\`.\`${parts.tableName}\``
+			return `${quoteIdentifier(parts.schemaName, '`')}.${quoteIdentifier(parts.tableName, '`')}`
 		}
 
-		return `\`${parts.tableName}\``
+		return quoteIdentifier(parts.tableName, '`')
 	}
 
 	if (
 		parts.schemaName &&
 		(dialect === undefined || dialectUsesSchemas(dialect))
 	) {
-		return `"${parts.schemaName}"."${parts.tableName}"`
+		return `${quoteIdentifier(parts.schemaName, '"')}.${quoteIdentifier(parts.tableName, '"')}`
 	}
 
-	return `"${parts.tableName}"`
+	return quoteIdentifier(parts.tableName, '"')
 }
 
 // Quotes a bare column name for the given dialect. MySQL/MariaDB use backticks,
@@ -87,18 +132,11 @@ export function getTableSqlIdentifier(
 // already-quoted identifier (starts with the dialect's quote char) is returned
 // unchanged so callers can pass through user-supplied quoting.
 export function getColumnSqlIdentifier(column: string, dialect?: TableDialect): string {
-	const trimmed = column.trim()
 	if (dialect === 'mysql' || dialect === 'mariadb') {
-		if (trimmed.startsWith('`') && trimmed.endsWith('`')) {
-			return trimmed
-		}
-		return `\`${trimmed}\``
+		return quoteIdentifier(column, '`')
 	}
 
-	if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
-		return trimmed
-	}
-	return `"${trimmed}"`
+	return quoteIdentifier(column, '"')
 }
 
 // Builds the `ALTER TABLE ... DROP COLUMN` statement for the given dialect.

--- a/packages/style/tools/run-lint-style.ts
+++ b/packages/style/tools/run-lint-style.ts
@@ -1,1 +1,115 @@
-console.warn('run-lint-style: skipped (non-blocking in CI).')
+import { Project, SyntaxKind } from 'ts-morph'
+
+/**
+ * Read-only counterpart to `run-lint-style-fix.ts`.
+ *
+ * Reports the two project style rules oxlint does not cover:
+ *   1. standalone functions must be `function` declarations, not arrows
+ *      assigned to a `const`;
+ *   2. a file's single non-exported type is named `Props`.
+ *
+ * Exits non-zero only with `--strict`, so CI can surface the count while the
+ * existing backlog of violations is worked down. See issue #201.
+ */
+
+type Violation = {
+	file: string
+	line: number
+	rule: 'arrow-const' | 'props-naming'
+	detail: string
+}
+
+function collectViolations(): Violation[] {
+	const project = new Project()
+	project.addSourceFilesAtPaths([
+		'**/*.{ts,tsx}',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!**/build/**',
+		'!**/.next/**',
+		'!**/.turbo/**',
+		'!**/out/**',
+		'!**/*.d.ts',
+		'!packages/style/tools/**'
+	])
+
+	const violations: Violation[] = []
+
+	for (const sourceFile of project.getSourceFiles()) {
+		const file = sourceFile.getFilePath()
+
+		for (const arrowFunction of sourceFile.getDescendantsOfKind(SyntaxKind.ArrowFunction)) {
+			const varDecl = arrowFunction.getParent()
+			if (varDecl.getKind() !== SyntaxKind.VariableDeclaration) continue
+
+			const varDeclList = varDecl.getParent()
+			if (!varDeclList || varDeclList.getKind() !== SyntaxKind.VariableDeclarationList) continue
+
+			const varStmt = varDeclList.getParent()
+			if (!varStmt || varStmt.getKind() !== SyntaxKind.VariableStatement) continue
+			if (varDeclList.getDeclarations().length !== 1) continue
+
+			violations.push({
+				file,
+				line: arrowFunction.getStartLineNumber(),
+				rule: 'arrow-const',
+				detail: `${varDecl.getName()} is an arrow assigned to a const; use a function declaration`
+			})
+		}
+
+		const nonExported = [
+			...sourceFile.getInterfaces().filter(function (i) { return !i.isExported() }),
+			...sourceFile.getTypeAliases().filter(function (t) { return !t.isExported() })
+		]
+
+		if (nonExported.length === 1) {
+			const decl = nonExported[0]
+			const name = decl.getName()
+			if (name !== 'Props') {
+				violations.push({
+					file,
+					line: decl.getStartLineNumber(),
+					rule: 'props-naming',
+					detail: `single non-exported type is named ${name}; rename to Props`
+				})
+			}
+		}
+	}
+
+	return violations
+}
+
+function main(): void {
+	const strict = process.argv.includes('--strict')
+	const violations = collectViolations()
+
+	if (violations.length === 0) {
+		console.log('run-lint-style: clean')
+		return
+	}
+
+	const byRule = new Map<string, number>()
+	for (const violation of violations) {
+		byRule.set(violation.rule, (byRule.get(violation.rule) ?? 0) + 1)
+	}
+
+	if (strict) {
+		for (const violation of violations) {
+			console.error(`${violation.file}:${violation.line}  [${violation.rule}] ${violation.detail}`)
+		}
+	}
+
+	const summary = [...byRule.entries()]
+		.map(function ([rule, count]) { return `${rule}: ${count}` })
+		.join(', ')
+
+	console.error(`run-lint-style: ${violations.length} violation(s) (${summary})`)
+
+	if (strict) {
+		process.exit(1)
+	}
+
+	console.error('run-lint-style: non-blocking (see issue #201); run with --strict to fail')
+}
+
+main()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,7 +28,11 @@ export default defineConfig({
 		globals: true,
 		environment: 'happy-dom',
 		setupFiles: ['./__tests__/vitest.setup.ts'],
-		include: ['__tests__/**/*.test.{ts,tsx}'],
+		include: [
+			'__tests__/**/*.test.{ts,tsx}',
+			'packages/*/src/**/*.test.{ts,tsx}',
+			'apps/*/src/**/*.test.{ts,tsx}'
+		],
 		exclude: ['**/node_modules/**', '**/dist/**'],
 		coverage: {
 			provider: 'v8',


### PR DESCRIPTION
Fixes the confirmed-severe findings from the #190–#210 audit.

## Data loss
- **#194** — switching connections *deterministically* overwrote the target connection's saved SQL tabs. Effects run in declaration order, so the persist effect fired on the `connectionId` change while state still held the outgoing connection's tabs. Gated on a ref only the load effect advances. Regression test verified to fail without the fix.

## A test that had never run
- **#204 / #205** — the vitest glob only matched `__tests__/**`, so five colocated test files under `packages/studio/src` never ran. One had been failing in the dark: `getTableRefParts` split on the first dot with no quote awareness, corrupting identifiers fed to `ALTER TABLE … DROP COLUMN`. Fixed with a quote-aware split plus a shared quoting helper that doubles embedded quotes, and the glob widened in the same commit so master never goes red.

## Dead CI gates
- **#206** — `cargo test --lib` skipped 39 tests across 10 integration targets. Enabling them surfaced a genuine wrong assertion in `credentials_tests.rs` (it expected the password to stay percent-encoded; `url_password` deliberately decodes so the keyring holds the real secret). All 10 targets now pass.
- **#201** — `run-lint-style.ts` was a one-line `console.warn`. Now a real check; reports 138 existing violations so it stays non-blocking until they're burned down (see issue comment).
- **#203** — pinned the five floating `actions/checkout@v4` refs, all in workflows holding signing secrets.
- **#200** — README documented `bun test`, which fails on a clean checkout.

## Verification
- Vitest: **96 files / 763 tests green** (was 90 / 725).
- `cargo test --tests`: all 10 integration targets pass. The 2 remaining lib failures are `pgtemp` needing a local `initdb`, which CI provides on PATH.
- `tsc --noEmit` clean for both `packages/studio` and `apps/desktop`.
- Formatting left untouched: `oxfmt` already fails on these files on master and is not a CI gate, so reformatting would add unrelated churn.

Closes #194, closes #200, closes #203, closes #204, closes #205, closes #206. Refs #201.

## Summary by Sourcery

Address data loss when switching SQL connections, fix previously unrun table reference tests, and tighten CI/style tooling and documentation.

Bug Fixes:
- Prevent SQL tab state from one connection overwriting another connection’s saved tabs when switching connections.
- Correct table reference parsing and identifier quoting so dotted and quoted names are handled safely in generated SQL.
- Fix an incorrect expectation in the desktop credentials integration test for percent-encoded PostgreSQL passwords.

Enhancements:
- Implement a non-blocking style lint tool that reports project-specific arrow-function and Props naming violations with optional strict failure mode.

Build:
- Clarify README test instructions to use `bun run` scripts instead of a bare `bun test`.
- Widen Vitest includes to run colocated tests under package and app src directories.

CI:
- Run full `cargo test` instead of `cargo test --lib` in CI to cover integration tests.
- Pin all `actions/checkout` usages in publishing/signing workflows to a specific commit SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL console tab persistence when switching between database connections.
  * Improved quoting and parsing for table and column names containing dots, quotes, or special characters.
  * Corrected handling of percent-encoded database passwords.

* **Testing**
  * Expanded automated coverage for connection switching and SQL identifier handling.
  * CI now runs the complete Rust test suite.

* **Documentation**
  * Clarified available test commands and coverage options in the README.

* **Chores**
  * Improved workflow reliability by pinning action versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->