### PR TITLE
chore(style): narrow the style rules to real violations and enforce them in CI

### DIFF
--- a/__tests__/apps/desktop/unit/tabs-store.test.tsx
+++ b/__tests__/apps/desktop/unit/tabs-store.test.tsx
@@ -3,9 +3,9 @@ import { renderHook, act } from '@testing-library/react'
 import React from 'react'
 import { TabsProvider, useTabs } from '@/core/tabs/tabs-store'
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <TabsProvider>{children}</TabsProvider>
-)
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <TabsProvider>{children}</TabsProvider>
+}
 
 describe('useTabs', () => {
   // Tabs persist to localStorage; clear it so each case starts isolated.

--- a/apps/marketing/src/app/(marketing)/docs/connect/[provider]/page.tsx
+++ b/apps/marketing/src/app/(marketing)/docs/connect/[provider]/page.tsx
@@ -5,7 +5,7 @@ import { GUIDES, getGuide, getGuidePath } from '@/core/config/guides'
 import { createMetadata } from '@/core/config/seo'
 import GuideDetailView from '@/views/guide-detail-view'
 
-type TPageProps = {
+type Props = {
     params: Promise<{ provider: string }>
 }
 
@@ -17,7 +17,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({
     params
-}: TPageProps): Promise<Metadata> {
+}: Props): Promise<Metadata> {
     const { provider } = await params
     const guide = getGuide(provider)
 
@@ -33,7 +33,7 @@ export async function generateMetadata({
     })
 }
 
-export default async function Page({ params }: TPageProps) {
+export default async function Page({ params }: Props) {
     const { provider } = await params
     const guide = getGuide(provider)
 

--- a/apps/marketing/src/app/(marketing)/features/[slug]/page.tsx
+++ b/apps/marketing/src/app/(marketing)/features/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { FEATURES, getFeature, getFeaturePath } from '@/core/config/features'
 import { createMetadata } from '@/core/config/seo'
 import FeatureDetailView from '@/views/feature-detail-view'
 
-type TPageProps = {
+type Props = {
     params: Promise<{ slug: string }>
 }
 
@@ -17,7 +17,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({
     params
-}: TPageProps): Promise<Metadata> {
+}: Props): Promise<Metadata> {
     const { slug } = await params
     const feature = getFeature(slug)
 
@@ -33,7 +33,7 @@ export async function generateMetadata({
     })
 }
 
-export default async function Page({ params }: TPageProps) {
+export default async function Page({ params }: Props) {
     const { slug } = await params
     const feature = getFeature(slug)
 

--- a/apps/marketing/src/app/(marketing)/layout.tsx
+++ b/apps/marketing/src/app/(marketing)/layout.tsx
@@ -3,11 +3,11 @@ import type { ReactNode } from 'react'
 import { DoraHeader } from '@/components/dora-header'
 import Footer from '@/components/footer'
 
-type TLayoutProps = {
+type Props = {
     children: ReactNode
 }
 
-export default function MarketingLayout({ children }: TLayoutProps) {
+export default function MarketingLayout({ children }: Props) {
     return (
         <>
             <DoraHeader />

--- a/apps/marketing/src/app/layout.tsx
+++ b/apps/marketing/src/app/layout.tsx
@@ -75,11 +75,11 @@ export const viewport: Viewport = {
     themeColor: siteConfig.themeColor
 }
 
-type TRootProps = {
+type Props = {
     children: ReactNode
 }
 
-export default function RootLayout({ children }: TRootProps) {
+export default function RootLayout({ children }: Props) {
     return (
         <html
             className={`${GeistSans.variable} ${GeistMono.variable} ${PixelFont.variable} ${InterFont.variable} ${JetBrainsMono.variable} dark`}

--- a/apps/marketing/src/components/feature-showcases/feature-showcase-shell.tsx
+++ b/apps/marketing/src/components/feature-showcases/feature-showcase-shell.tsx
@@ -14,7 +14,7 @@ import { usePrefersReducedMotion } from '@/shared/hooks/use-prefers-reduced-moti
 
 const FRAME_LINE = 'pointer-events-none absolute z-[2] bg-line-strong'
 
-type TFeatureShowcaseShellProps = {
+type Props = {
     slug: TFeatureSlug
     label: string
     children: ReactNode
@@ -24,7 +24,7 @@ export function FeatureShowcaseShell({
     slug,
     label,
     children
-}: TFeatureShowcaseShellProps) {
+}: Props) {
     const reducedMotion = usePrefersReducedMotion()
     const frame = useFrameDrawIn<HTMLDivElement>()
     const videoRef = useRef<HTMLVideoElement>(null)

--- a/apps/marketing/src/components/github-stats/commit-graph.tsx
+++ b/apps/marketing/src/components/github-stats/commit-graph.tsx
@@ -21,7 +21,7 @@ export interface CommitDataPoint {
     details?: CommitDetail[]
 }
 
-interface CommitGraphProps {
+interface Props {
     data: CommitDataPoint[]
     hoveredIndex: number | null
     onHoverChange: (
@@ -38,7 +38,7 @@ export function CommitGraph({
     onHoverChange,
     onClick,
     accentColor = ACCENT_COLOR
-}: CommitGraphProps) {
+}: Props) {
     const [animationProgress, setAnimationProgress] = useState(0)
     const [isInView, setIsInView] = useState(false)
     const [hasAnimated, setHasAnimated] = useState(false)

--- a/apps/marketing/src/components/github-stats/graph-tooltip.tsx
+++ b/apps/marketing/src/components/github-stats/graph-tooltip.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react'
 import type { CommitDataPoint } from './commit-graph'
 import { ACCENT_COLOR } from './constants'
 
-interface GraphTooltipProps {
+interface Props {
     data: CommitDataPoint | null
     position: { x: number; y: number } | null
     containerRef: React.RefObject<HTMLDivElement | null>
@@ -17,7 +17,7 @@ export function GraphTooltip({
     position,
     containerRef,
     accentColor = ACCENT_COLOR
-}: GraphTooltipProps) {
+}: Props) {
     const [mounted, setMounted] = useState(false)
 
     useEffect(() => {

--- a/apps/marketing/src/components/hero-app-demo-main.tsx
+++ b/apps/marketing/src/components/hero-app-demo-main.tsx
@@ -1030,7 +1030,7 @@ function TableWorkspace({ table }: { table: TDemoTable }) {
   );
 }
 
-type TMainProps = {
+type Props = {
   activeTable: string;
   openTables: string[];
   openConnectionIds: string[];
@@ -1052,7 +1052,7 @@ export function DemoMain({
   onSelectConnection,
   onCloseConnection,
   onAddConnection,
-}: TMainProps) {
+}: Props) {
   const table = findTable(activeTable);
 
   return (

--- a/apps/marketing/src/components/provider-info-popover.tsx
+++ b/apps/marketing/src/components/provider-info-popover.tsx
@@ -29,13 +29,13 @@ export type TProviderInfo = {
   blurb: string;
 };
 
-type TProps = {
+type Props = {
   info: TProviderInfo | null;
   anchor: HTMLElement | null;
   open: boolean;
 };
 
-export function ProviderInfoPopover({ info, anchor, open }: TProps) {
+export function ProviderInfoPopover({ info, anchor, open }: Props) {
   const reduced = usePrefersReducedMotion();
   const [mounted, setMounted] = useState(false);
 

--- a/apps/marketing/src/components/resources-page-shell.tsx
+++ b/apps/marketing/src/components/resources-page-shell.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 
 import { SectionFrame } from '@/components/section-frame'
 
-type TResourcesPageShellProps = {
+type Props = {
     eyebrow: string
     title: string
     lead: string
@@ -14,7 +14,7 @@ export function ResourcesPageShell({
     title,
     lead,
     children
-}: TResourcesPageShellProps) {
+}: Props) {
     return (
         <section className="relative">
             <SectionFrame />

--- a/packages/studio/src/features/app-sidebar/context.tsx
+++ b/packages/studio/src/features/app-sidebar/context.tsx
@@ -3,7 +3,7 @@ import type { SidebarContextValue, SidebarVariant } from './types'
 
 const SidebarContext = createContext<SidebarContextValue | null>(null)
 
-type SidebarProviderProps = {
+type Props = {
 	children: ReactNode
 	defaultVariant?: SidebarVariant
 	defaultActiveItemId?: string | null
@@ -13,7 +13,7 @@ export function SidebarProvider({
 	children,
 	defaultVariant = 'default',
 	defaultActiveItemId = null
-}: SidebarProviderProps) {
+}: Props) {
 	const [variant, setVariant] = useState<SidebarVariant>(defaultVariant)
 	const [activeItemId, setActiveItemId] = useState<string | null>(defaultActiveItemId)
 

--- a/packages/studio/src/features/database-studio/components/change-feed.tsx
+++ b/packages/studio/src/features/database-studio/components/change-feed.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@studio/shared/ui/toolt
 import { cn } from '@studio/shared/utils/cn'
 import type { ChangeEvent, ChangeType } from '@studio/core/live-monitor'
 
-type TProps = {
+type Props = {
 	events: ChangeEvent[]
 	unreadCount: number
 	onClear: () => void
@@ -47,7 +47,7 @@ function formatRelativeTime(ts: number): string {
 	return `${Math.floor(diff / 3600000)}h ago`
 }
 
-export function ChangeFeed({ events, unreadCount, onClear, onMarkRead }: TProps) {
+export function ChangeFeed({ events, unreadCount, onClear, onMarkRead }: Props) {
 	const scrollRef = useRef<HTMLDivElement>(null)
 
 	useEffect(

--- a/packages/studio/src/features/database-studio/components/live-monitor-popover.tsx
+++ b/packages/studio/src/features/database-studio/components/live-monitor-popover.tsx
@@ -8,7 +8,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@studio/shared/ui/toolt
 import { cn } from '@studio/shared/utils/cn'
 import type { LiveMonitorConfig, ChangeType } from '@studio/core/live-monitor'
 
-type TProps = {
+type Props = {
 	config: LiveMonitorConfig
 	onConfigChange: (config: LiveMonitorConfig) => void
 	isPolling: boolean
@@ -31,7 +31,7 @@ function formatInterval(ms: number): string {
 	return `${ms / 1000}s`
 }
 
-export function LiveMonitorPopover({ config, onConfigChange, isPolling }: TProps) {
+export function LiveMonitorPopover({ config, onConfigChange, isPolling }: Props) {
 	function handleToggleEnabled(enabled: boolean) {
 		onConfigChange({ ...config, enabled })
 	}

--- a/packages/studio/src/providers.tsx
+++ b/packages/studio/src/providers.tsx
@@ -7,7 +7,7 @@ import type { AnalyticsConfig } from '@studio/features/analytics'
 import { QueryHistoryProvider } from '@studio/features/sql-console/stores/query-history-store'
 import { TooltipProvider } from '@studio/shared/ui/tooltip'
 
-type AppProvidersProps = {
+type Props = {
 	/** Force the in-memory mock adapter (web demo). */
 	forceMock?: boolean
 	/** Analytics configuration for the host. */
@@ -26,7 +26,7 @@ type AppProvidersProps = {
  * `TooltipProvider` belongs here (not deep inside a page) so every tooltip in
  * the tree has a provider ancestor without each surface re-wrapping one.
  */
-export function AppProviders({ forceMock = false, analyticsConfig, children }: AppProvidersProps) {
+export function AppProviders({ forceMock = false, analyticsConfig, children }: Props) {
 	return (
 		<AnalyticsProvider config={analyticsConfig}>
 			<SettingsProvider>

--- a/packages/studio/src/shared/ui/number-input.tsx
+++ b/packages/studio/src/shared/ui/number-input.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { ChevronUp, ChevronDown } from 'lucide-react'
 import { cn } from '@studio/shared/utils/cn'
 
-type TProps = {
+type Props = {
 	value?: string | number
 	onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
 	min?: number
@@ -24,7 +24,7 @@ export function NumberInput({
 	placeholder,
 	disabled,
 	title
-}: TProps) {
+}: Props) {
 	const inputRef = React.useRef<HTMLInputElement>(null)
 
 	function handleIncrement() {

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"lint": "cd ../.. && oxlint -c packages/style/.oxlintrc.json . && bun run packages/style/tools/run-lint-style.ts",
+		"lint": "cd ../.. && oxlint -c packages/style/.oxlintrc.json . && bun run packages/style/tools/run-lint-style.ts --strict",
 		"lint:fix": "cd ../.. && oxlint --fix -c packages/style/.oxlintrc.json . && bun run packages/style/tools/run-lint-style-fix.ts",
 		"format": "cd ../.. && oxfmt --check -c packages/style/.oxfmtrc.json .",
 		"format:fix": "cd ../.. && oxfmt --write -c packages/style/.oxfmtrc.json . && bun run packages/style/tools/run-fix-imports.ts",

--- a/packages/style/tools/run-lint-style.ts
+++ b/packages/style/tools/run-lint-style.ts
@@ -1,15 +1,22 @@
-import { Project, SyntaxKind } from 'ts-morph'
+import { Node, Project, SyntaxKind } from 'ts-morph'
 
 /**
  * Read-only counterpart to `run-lint-style-fix.ts`.
  *
  * Reports the two project style rules oxlint does not cover:
- *   1. standalone functions must be `function` declarations, not arrows
- *      assigned to a `const`;
- *   2. a file's single non-exported type is named `Props`.
  *
- * Exits non-zero only with `--strict`, so CI can surface the count while the
- * existing backlog of violations is worked down. See issue #201.
+ *   1. `arrow-const` — a standalone function must be a `function` declaration.
+ *      Only module-scope arrows that are never passed as an argument count:
+ *      a nested or passed-along arrow is a callback, which the rule says
+ *      should stay an arrow.
+ *
+ *   2. `props-naming` — a component's props type is named `Props`. Only types
+ *      whose name already ends in `Props` are flagged; a file's single
+ *      non-exported type is not necessarily a props type (`LogLevel`,
+ *      `TableCacheEntry`, …) and renaming those would be wrong.
+ *
+ * Both rules are deliberately narrow so the gate can block in CI without
+ * false positives. See issue #201.
  */
 
 type Violation = {
@@ -17,6 +24,23 @@ type Violation = {
 	line: number
 	rule: 'arrow-const' | 'props-naming'
 	detail: string
+}
+
+function isPassedAsArgument(varDecl: Node): boolean {
+	const nameNode = varDecl.asKind(SyntaxKind.VariableDeclaration)?.getNameNode()
+	if (!nameNode || nameNode.getKind() !== SyntaxKind.Identifier) return false
+
+	for (const reference of nameNode.asKindOrThrow(SyntaxKind.Identifier).findReferencesAsNodes()) {
+		const parent = reference.getParent()
+		if (!parent) continue
+		if (parent.getKind() === SyntaxKind.CallExpression) {
+			const call = parent.asKindOrThrow(SyntaxKind.CallExpression)
+			if (call.getArguments().some(function (arg) { return arg === reference })) return true
+		}
+		if (parent.getKind() === SyntaxKind.JsxExpression) return true
+	}
+
+	return false
 }
 
 function collectViolations(): Violation[] {
@@ -49,11 +73,18 @@ function collectViolations(): Violation[] {
 			if (!varStmt || varStmt.getKind() !== SyntaxKind.VariableStatement) continue
 			if (varDeclList.getDeclarations().length !== 1) continue
 
+			// Nested arrows are closures over local state; converting them to
+			// declarations changes nothing the rule cares about.
+			if (varStmt.getParent()?.getKind() !== SyntaxKind.SourceFile) continue
+
+			// A named arrow that is handed to something else is a callback.
+			if (isPassedAsArgument(varDecl)) continue
+
 			violations.push({
 				file,
 				line: arrowFunction.getStartLineNumber(),
 				rule: 'arrow-const',
-				detail: `${varDecl.getName()} is an arrow assigned to a const; use a function declaration`
+				detail: `${varDecl.getName()} is a module-scope arrow assigned to a const; use a function declaration`
 			})
 		}
 
@@ -62,15 +93,19 @@ function collectViolations(): Violation[] {
 			...sourceFile.getTypeAliases().filter(function (t) { return !t.isExported() })
 		]
 
+		// Only a file whose *single* non-exported type is a props type must call
+		// it `Props`. With several types the rule asks for descriptive names
+		// instead, which `FooProps` / `BarProps` already are.
 		if (nonExported.length === 1) {
 			const decl = nonExported[0]
 			const name = decl.getName()
-			if (name !== 'Props') {
+
+			if (name !== 'Props' && name.endsWith('Props')) {
 				violations.push({
 					file,
 					line: decl.getStartLineNumber(),
 					rule: 'props-naming',
-					detail: `single non-exported type is named ${name}; rename to Props`
+					detail: `single non-exported props type is named ${name}; rename to Props`
 				})
 			}
 		}


### PR DESCRIPTION
Stacked on #211. Closes #201.

## The 138 number was wrong

My first pass reported 138 violations. Inspecting them showed most were false positives from a checker that applied both rules too broadly:

**props-naming (79 reported → 15 real).** It flagged *any* single non-exported type, so it wanted `LogLevel`, `TClassValue`, `TableCacheEntry` and `Config` in build scripts all renamed to `Props` — and `__EventObj__` in generated `bindings.ts`. Renaming those would have been vandalism. It also flagged files declaring several props types (`NoConnectionProps`, `ConnectionFailedProps`, …), where the rule actually asks for *descriptive* names, so those were already correct.

**arrow-const (61 reported → 1 real).** It flagged every `const x = () => {}`, including `onScroll`, `tick`, `update`, `onMove`, `onDown` — event handlers and rAF callbacks that get passed as arguments. The rule explicitly says callbacks should stay arrows, so converting those would have violated it.

## What changed

Both rules narrowed to fire only on genuine violations:
- `props-naming`: a file whose **single** non-exported type already ends in `Props` but isn't `Props`.
- `arrow-const`: **module-scope** arrows that are **never passed as an argument**.

That left 16 real violations, all fixed: 15 type renames via a ts-morph `.rename()` (updates references properly), plus the one `wrapper` component in `tabs-store.test.tsx`.

`--strict` is now on in the `lint` script, so CI enforces it.

## Verification
- `bun run lint` → exit 0 (oxlint: 0 errors / 126 warnings; run-lint-style: clean).
- **Gate proven to block:** reintroducing `TProps` in `number-input.tsx` gives exit 1; reverting gives exit 0.
- `tsc --noEmit` clean for `packages/studio` and `apps/desktop`.
- Vitest: 96 files / 763 tests green.
- `apps/marketing` `next build` compiles, 75/75 static pages generated (the renames touched marketing layouts and pages).

## Judgment call worth reviewing

I chose to make the checker precise rather than mass-rename 138 things to satisfy a naive rule. A narrow gate that actually blocks is worth more than a broad one that can never be turned on — but if you'd rather the rule stayed literal ("*any* single non-exported type must be named `Props`"), that's a different and much larger change, and worth saying so now.

## Summary by Sourcery

Tighten custom TypeScript style lint rules to only flag genuine arrow function and props naming violations and start enforcing them strictly in CI.

Enhancements:
- Refine the arrow-const rule to only require conversion of unused module-scope arrow functions assigned to consts into function declarations.
- Refine the props-naming rule to only flag single non-exported types that are clearly props types already ending in Props but not named Props.
- Rename various React component and layout props types across marketing and studio code to a consistent Props name.
- Change a test wrapper component in tabs-store tests from an arrow function to a function declaration for style compliance.

Build:
- Update the style package lint script to run run-lint-style.ts in strict mode so CI fails on style violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Improved style-lint accuracy by reducing false positives for callback arrows and props type naming.
  * Strict style checks now more reliably identify actionable issues.

* **Refactor**
  * Standardized internal component props type naming across marketing and Studio code without changing application behavior.

* **Tests**
  * Updated test setup syntax while preserving existing test coverage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->