### PR TITLE
fix(studio): pending-edit integrity — partial apply, undo-by-PK, reload guard

### DIFF
--- a/packages/studio/src/core/pending-edits/pending-edits-store.tsx
+++ b/packages/studio/src/core/pending-edits/pending-edits-store.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react'
 
 export type PendingEdit = {
-	rowIndex: number
 	primaryKeyColumn: string
 	primaryKeyValue: unknown
 	columnName: string
@@ -23,7 +22,7 @@ type PendingEditsContextValue = {
 
 const PendingEditsContext = createContext<PendingEditsContextValue | null>(null)
 
-function createEditKey(tableId: string, primaryKeyValue: unknown, columnName: string): string {
+export function createEditKey(tableId: string, primaryKeyValue: unknown, columnName: string): string {
 	return `${tableId}:${String(primaryKeyValue)}:${columnName}`
 }
 

--- a/packages/studio/src/features/database-studio/database-studio.tsx
+++ b/packages/studio/src/features/database-studio/database-studio.tsx
@@ -308,6 +308,7 @@ export function DatabaseStudio({
 		draftRow,
 		draftInsertIndex,
 		isApplyingEdits,
+		hasPendingEdits: Boolean(tableId) && hasEdits(tableId as string),
 		selectedRows,
 		selectedCells,
 		focusedCell,

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-edits.test.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-edits.test.ts
@@ -1,0 +1,143 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useDatabaseStudioEdits } from '@studio/features/database-studio/hooks/use-database-studio-edits'
+
+type Edit = {
+	primaryKeyColumn: string
+	primaryKeyValue: unknown
+	columnName: string
+	oldValue: unknown
+	newValue: unknown
+}
+
+const TABLE_ID = 'public.users'
+
+function makeEdit(id: number, column: string, oldValue: string, newValue: string): Edit {
+	return {
+		primaryKeyColumn: 'id',
+		primaryKeyValue: id,
+		columnName: column,
+		oldValue,
+		newValue
+	}
+}
+
+function setup(edits: Edit[], failFor: (payload: Record<string, unknown>) => boolean) {
+	const removed: string[] = []
+	const cleared: string[] = []
+	const failures: { title: string; error: unknown }[] = []
+	let tableData = {
+		columns: [{ name: 'id', primaryKey: true }, { name: 'name' }, { name: 'email' }],
+		rows: edits.map(function (edit) {
+			return { id: edit.primaryKeyValue, [edit.columnName]: edit.newValue }
+		})
+	}
+
+	const args = {
+		activeConnectionId: 'conn-1',
+		tableId: TABLE_ID,
+		tableRefName: 'public.users',
+		tableData,
+		currentCacheKey: 'cache-key',
+		isDryEditMode: true,
+		pendingEdits: new Map(),
+		getEditsForTable: function () { return edits },
+		hasEdits: function () { return edits.length > 0 },
+		addEdit: vi.fn(),
+		removeEdit: function (_tableId: string, key: string) { removed.push(key) },
+		clearEdits: function (tableId: string) { cleared.push(tableId) },
+		updateCell: {
+			mutate: vi.fn(),
+			mutateAsync: function (payload: Record<string, unknown>) {
+				if (failFor(payload)) return Promise.reject(new Error('constraint violation'))
+				return Promise.resolve({ affected_rows: 1 })
+			}
+		},
+		setTableData: function (updater: unknown) {
+			tableData = typeof updater === 'function' ? (updater as (p: unknown) => typeof tableData)(tableData) : (updater as typeof tableData)
+		},
+		setIsApplyingEdits: vi.fn(),
+		loadTableData: vi.fn(),
+		trackCellMutation: vi.fn(),
+		trackBatchCellMutation: vi.fn(),
+		notifyMissingPrimaryKey: vi.fn(),
+		notifyActionFailure: function (title: string, error: unknown) { failures.push({ title, error }) }
+	}
+
+	const { result } = renderHook(() => useDatabaseStudioEdits(args as never))
+	return { result, removed, cleared, failures, getTableData: function () { return tableData } }
+}
+
+describe('handleApplyPendingEdits partial failure', function () {
+	it('keeps only the failed edit pending', async function () {
+		const edits = [
+			makeEdit(1, 'name', 'a', 'A'),
+			makeEdit(2, 'name', 'b', 'B'),
+			makeEdit(3, 'name', 'c', 'C')
+		]
+		const ctx = setup(edits, function (payload) { return payload.primaryKeyValue === 2 })
+
+		await act(async function () {
+			await ctx.result.current.handleApplyPendingEdits()
+		})
+
+		expect(ctx.removed).toEqual([
+			`${TABLE_ID}:1:name`,
+			`${TABLE_ID}:3:name`
+		])
+		expect(ctx.removed).not.toContain(`${TABLE_ID}:2:name`)
+	})
+
+	it('does not clear the whole buffer on partial failure', async function () {
+		const edits = [makeEdit(1, 'name', 'a', 'A'), makeEdit(2, 'name', 'b', 'B')]
+		const ctx = setup(edits, function (payload) { return payload.primaryKeyValue === 2 })
+
+		await act(async function () {
+			await ctx.result.current.handleApplyPendingEdits()
+		})
+
+		expect(ctx.cleared).toEqual([])
+	})
+
+	it('names the failing row and column in the error', async function () {
+		const edits = [makeEdit(1, 'name', 'a', 'A'), makeEdit(2, 'email', 'b', 'B')]
+		const ctx = setup(edits, function (payload) { return payload.primaryKeyValue === 2 })
+
+		await act(async function () {
+			await ctx.result.current.handleApplyPendingEdits()
+		})
+
+		expect(ctx.failures).toHaveLength(1)
+		expect(ctx.failures[0].title).toBe('Failed to apply 1 of 2 change(s)')
+		expect(String(ctx.failures[0].error)).toContain('id=2')
+		expect(String(ctx.failures[0].error)).toContain('email')
+		expect(String(ctx.failures[0].error)).toContain('constraint violation')
+	})
+
+	it('reverts the failed cell on screen to its pre-edit value', async function () {
+		const edits = [makeEdit(1, 'name', 'a', 'A'), makeEdit(2, 'name', 'b', 'B')]
+		const ctx = setup(edits, function (payload) { return payload.primaryKeyValue === 2 })
+
+		await act(async function () {
+			await ctx.result.current.handleApplyPendingEdits()
+		})
+
+		const rows = ctx.getTableData().rows
+		expect(rows.find(function (r) { return r.id === 2 })?.name).toBe('b')
+		expect(rows.find(function (r) { return r.id === 1 })?.name).toBe('A')
+	})
+
+	it('clears the buffer in one go when all succeed', async function () {
+		const edits = [makeEdit(1, 'name', 'a', 'A'), makeEdit(2, 'name', 'b', 'B')]
+		const ctx = setup(edits, function () { return false })
+
+		await act(async function () {
+			await ctx.result.current.handleApplyPendingEdits()
+		})
+
+		expect(ctx.cleared).toEqual([TABLE_ID])
+		expect(ctx.removed).toEqual([])
+		expect(ctx.failures).toEqual([])
+	})
+})

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-edits.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-edits.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { areValuesEqual } from '@studio/shared/utils/value-equality'
+import { createEditKey } from '@studio/core/pending-edits/pending-edits-store'
 import { tableDataCache } from '@studio/core/table-cache'
 import { normalizeValueForInsert } from '../utils/studio-data'
 import type { TableData } from '../types'
@@ -10,7 +11,17 @@ type PendingEdit = {
 	columnName: string
 	oldValue: unknown
 	newValue: unknown
-	rowIndex: number
+}
+
+// Names the rows and columns that failed so the toast points at something the
+// user can act on, instead of a bare "failed to apply changes".
+function describeFailedEdits(failed: { edit: PendingEdit; reason: unknown }[]): string {
+	return failed
+		.map(function ({ edit, reason }) {
+			const message = reason instanceof Error ? reason.message : String(reason)
+			return `${edit.primaryKeyColumn}=${String(edit.primaryKeyValue)} · ${edit.columnName}: ${message}`
+		})
+		.join('\n')
 }
 
 type Args = {
@@ -105,7 +116,7 @@ export function useDatabaseStudioEdits(args: Args) {
 		}
 
 		if (isDryEditMode) {
-			const key = `${tableId}:${String(row[primaryKeyColumn.name])}:${columnName}`
+			const key = createEditKey(tableId, row[primaryKeyColumn.name], columnName)
 			const existingEdit = pendingEdits.get(key)
 			const oldValue = existingEdit ? existingEdit.oldValue : row[columnName]
 
@@ -121,7 +132,6 @@ export function useDatabaseStudioEdits(args: Args) {
 			}
 
 			addEdit(tableId, {
-				rowIndex,
 				primaryKeyColumn: primaryKeyColumn.name,
 				primaryKeyValue: row[primaryKeyColumn.name],
 				columnName,
@@ -218,16 +228,21 @@ export function useDatabaseStudioEdits(args: Args) {
 				const lastEdit = edits[edits.length - 1]
 				if (!lastEdit) return
 
-				const key = `${tableId}:${String(lastEdit.primaryKeyValue)}:${lastEdit.columnName}`
+				const key = createEditKey(tableId, lastEdit.primaryKeyValue, lastEdit.columnName)
 				removeEdit(tableId, key)
 				setTableData(function (prev) {
 					if (!prev) return prev
+					// Resolve by primary key, not a stored page position: after a
+					// sort, filter or page change that index points at a different row.
+					const index = prev.rows.findIndex(function (row) {
+						return row[lastEdit.primaryKeyColumn] === lastEdit.primaryKeyValue
+					})
+					if (index === -1) return prev
+
 					const newRows = [...prev.rows]
-					if (newRows[lastEdit.rowIndex]) {
-						newRows[lastEdit.rowIndex] = {
-							...newRows[lastEdit.rowIndex],
-							[lastEdit.columnName]: lastEdit.oldValue
-						}
+					newRows[index] = {
+						...newRows[index],
+						[lastEdit.columnName]: lastEdit.oldValue
 					}
 					return { ...prev, rows: newRows }
 				})
@@ -249,7 +264,7 @@ export function useDatabaseStudioEdits(args: Args) {
 
 		setIsApplyingEdits(true)
 		try {
-			await Promise.all(
+			const outcomes = await Promise.allSettled(
 				edits.map(function (edit) {
 					return updateCell.mutateAsync({
 						connectionId: activeConnectionId,
@@ -261,13 +276,35 @@ export function useDatabaseStudioEdits(args: Args) {
 					})
 				})
 			)
-			clearEdits(tableId)
+
+			const applied: PendingEdit[] = []
+			const failed: { edit: PendingEdit; reason: unknown }[] = []
+
+			outcomes.forEach(function (outcome, index) {
+				const edit = edits[index]
+				if (outcome.status === 'fulfilled') {
+					applied.push(edit)
+				} else {
+					failed.push({ edit, reason: outcome.reason })
+				}
+			})
+
+			// Drop only what actually landed, so a retry does not re-issue
+			// updates the database has already accepted.
+			if (failed.length === 0) {
+				clearEdits(tableId)
+			} else {
+				for (const edit of applied) {
+					removeEdit(tableId, createEditKey(tableId, edit.primaryKeyValue, edit.columnName))
+				}
+			}
+
 			// The edited values are already on screen from dry-edit mode, so
 			// patch the cached page instead of reloading (mirrors handleCellEdit).
 			const cached = tableDataCache.get(currentCacheKey)
 			if (cached) {
 				const patchedRows = cached.data.rows.map(function (cachedRow) {
-					const matching = edits.filter(function (edit) {
+					const matching = applied.filter(function (edit) {
 						return cachedRow[edit.primaryKeyColumn] === edit.primaryKeyValue
 					})
 					if (matching.length === 0) return cachedRow
@@ -281,6 +318,31 @@ export function useDatabaseStudioEdits(args: Args) {
 					...cached,
 					data: { ...cached.data, rows: patchedRows }
 				})
+			}
+
+			if (failed.length > 0) {
+				// Put the failed cells back to their pre-edit values on screen so
+				// the grid stops showing writes the database rejected.
+				setTableData(function (current) {
+					if (!current) return current
+					const rows = current.rows.map(function (row) {
+						const matching = failed.filter(function (entry) {
+							return row[entry.edit.primaryKeyColumn] === entry.edit.primaryKeyValue
+						})
+						if (matching.length === 0) return row
+						const reverted = { ...row }
+						for (const entry of matching) {
+							reverted[entry.edit.columnName] = entry.edit.oldValue
+						}
+						return reverted
+					})
+					return { ...current, rows }
+				})
+
+				notifyActionFailure(
+					`Failed to apply ${failed.length} of ${edits.length} change(s)`,
+					describeFailedEdits(failed)
+				)
 			}
 		} catch (error) {
 			notifyActionFailure('Failed to apply changes', error)

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
@@ -28,6 +28,7 @@ type Args = {
   draftRow: Record<string, unknown> | null;
   draftInsertIndex: number | null;
   isApplyingEdits: boolean;
+  hasPendingEdits: boolean;
   selectedRows: Set<number>;
   selectedCells: Set<string>;
   focusedCell: { row: number; col: number } | null;
@@ -66,6 +67,7 @@ export function useDatabaseStudioSync(args: Args) {
     draftRow,
     draftInsertIndex,
     isApplyingEdits,
+    hasPendingEdits,
     selectedRows,
     selectedCells,
     focusedCell,
@@ -280,11 +282,22 @@ export function useDatabaseStudioSync(args: Args) {
       const hasChangeForThisTable = liveMonitor.recentEvents.some(function (e) {
         return e.tableName === tableRefName || e.tableName === tableName;
       });
-      if (hasChangeForThisTable && !draftRow && !isApplyingEdits) {
+      // Reloading while dry edits are buffered would repaint database values
+      // over them, leaving the pending-changes count describing writes the user
+      // can no longer see.
+      if (hasChangeForThisTable && !draftRow && !isApplyingEdits && !hasPendingEdits) {
         loadTableData();
       }
     },
-    [liveMonitor.recentEvents, draftRow, isApplyingEdits, loadTableData, tableName, tableRefName],
+    [
+      liveMonitor.recentEvents,
+      draftRow,
+      isApplyingEdits,
+      hasPendingEdits,
+      loadTableData,
+      tableName,
+      tableRefName,
+    ],
   );
 
   useEffect(


### PR DESCRIPTION
Closes #198. Refs #195 (partially).

## #198 — partial apply left buffer, cache and screen disagreeing

`handleApplyPendingEdits` used `Promise.all`, so the first rejection reported *total* failure while the remaining updates kept running to completion. `clearEdits` was skipped entirely, so edits the database had already accepted stayed pending, and the cache still held pre-edit values. Re-clicking Apply re-issued the successful writes.

Now uses `Promise.allSettled` and:
- drops only the edits that actually landed (all-succeeded still clears in one bulk call, which is both cheaper and preserves the existing contract),
- patches the cache for succeeded edits only,
- reverts failed cells on screen to their pre-edit value, so the grid stops showing writes the database rejected,
- names the failing row and column: `Failed to apply 1 of 2 change(s)` → `id=2 · email: constraint violation`.

## #195 — two of the four parts

**`rowIndex` removed from `PendingEdit`.** It stored a position in the *loaded page*, so after a sort, filter or page change Ctrl+Z rewrote a different row's cell — a second data-corruption path. Undo now resolves the row by primary key and no-ops if the row isn't on the current page.

**Live-monitor reload is skipped while dry edits are buffered.** It was repainting database values over them while the pending-changes bar kept counting writes the user could no longer see.

## Verification
- 5 new tests for the partial-failure path, **verified to fail** against `Promise.all` (4 of 5 red) and pass after.
- Full suite: **97 files / 768 tests green** (was 96 / 763).
- `tsc --noEmit` clean for `packages/studio` and `apps/desktop`; `bun run lint` exit 0 with the new `--strict` gate.

## Still open on #195

Deliberately not in this PR, so it stays reviewable:
- re-applying the buffer as an overlay on freshly loaded rows (page/sort/filter changes still strand edits),
- the confirm-or-discard prompt on table switch and connection switch.

I did not run the app against a live database — these are code-level fixes with unit coverage, and the reload/undo behaviour deserves a hands-on check before #195 is closed.

## Summary by Sourcery

Handle partial failures and pending edits more safely in the database studio, and prevent live reloads from overwriting buffered edits.

New Features:
- Surface detailed error messages for failed pending edits, including the affected primary key and column.

Bug Fixes:
- Ensure only successfully applied pending edits are cleared so retries do not re-issue already accepted updates.
- Restore failed cells on screen to their original values when the database rejects an edit, keeping UI state consistent with persisted data.
- Resolve undo operations by primary key instead of row index so sorting, filtering, or paging does not corrupt data.
- Skip live-monitor driven table reloads while pending edits are buffered to avoid repainting over unsaved changes.

Enhancements:
- Use a shared edit key helper for pending edits to avoid ad hoc key construction and keep edit tracking consistent.

Tests:
- Add unit tests covering partial apply behaviour for pending edits, including buffer clearing, key removal, error messaging, and cell reversion.