### PR TITLE
fix(rust): connection hygiene — redact secrets, connect timeouts, monitor deregistration, sane MySQL pooling

### DIFF
--- a/apps/desktop/src-tauri/src/database/commands/connections.rs
+++ b/apps/desktop/src-tauri/src/database/commands/connections.rs
@@ -142,6 +142,7 @@ pub async fn disconnect_from_database(
     connection_id: Uuid,
     state: State<'_, AppState>,
     live_monitor: State<'_, crate::database::LiveMonitorManager>,
+    monitor: State<'_, crate::database::ConnectionMonitor>,
 ) -> Result<(), Error> {
     live_monitor.stop_monitors_for_connection(connection_id);
 
@@ -149,7 +150,7 @@ pub async fn disconnect_from_database(
         connections: &state.connections,
         storage: &state.storage,
     };
-    svc.disconnect_from_database(connection_id).await
+    svc.disconnect_from_database(&monitor, connection_id).await
 }
 
 #[tauri::command]
@@ -167,12 +168,13 @@ pub async fn get_connections(state: State<'_, AppState>) -> Result<Vec<Connectio
 pub async fn remove_connection(
     connection_id: Uuid,
     state: State<'_, AppState>,
+    monitor: State<'_, crate::database::ConnectionMonitor>,
 ) -> Result<(), Error> {
     let svc = ConnectionService {
         connections: &state.connections,
         storage: &state.storage,
     };
-    svc.remove_connection(connection_id).await
+    svc.remove_connection(&monitor, connection_id).await
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/database/connection_monitor.rs
+++ b/apps/desktop/src-tauri/src/database/connection_monitor.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use tauri::{Emitter, EventTarget, Manager};
 use tokio::sync::RwLock;
@@ -8,17 +8,45 @@ use crate::{database::postgres::connect::ConnectionCheck, AppState};
 
 type ConnectionId = Uuid;
 
+/// One monitored handle per connection id. Replacing an entry aborts the old
+/// handle so a stale check can never evict a freshly reconnected connection.
+fn upsert(
+    connections: &mut HashMap<ConnectionId, ConnectionCheck>,
+    connection_id: ConnectionId,
+    conn_check: ConnectionCheck,
+) {
+    if let Some(old) = connections.insert(connection_id, conn_check) {
+        old.abort();
+    }
+}
+
+/// Removes and returns the ids whose connection task has finished, i.e. the
+/// server closed the connection.
+fn take_finished(connections: &mut HashMap<ConnectionId, ConnectionCheck>) -> Vec<ConnectionId> {
+    let finished: Vec<ConnectionId> = connections
+        .iter()
+        .filter(|(_, conn_check)| conn_check.inner().is_finished())
+        .map(|(connection_id, _)| *connection_id)
+        .collect();
+
+    for connection_id in &finished {
+        connections.remove(connection_id);
+    }
+
+    finished
+}
+
 #[derive(Clone)]
 pub struct ConnectionMonitor {
     app: tauri::AppHandle,
-    connections: Arc<RwLock<Vec<(ConnectionId, ConnectionCheck)>>>,
+    connections: Arc<RwLock<HashMap<ConnectionId, ConnectionCheck>>>,
 }
 
 impl ConnectionMonitor {
     pub fn new(app: tauri::AppHandle) -> Self {
         let monitor = Self {
             app,
-            connections: Arc::new(RwLock::new(Vec::new())),
+            connections: Arc::new(RwLock::new(HashMap::new())),
         };
 
         let polling_monitor = monitor.clone();
@@ -29,10 +57,20 @@ impl ConnectionMonitor {
 
     pub async fn add_connection(&self, connection_id: Uuid, conn_check: ConnectionCheck) {
         log::info!("Adding connection {connection_id} to ConnectionMonitor");
-        self.connections
-            .write()
-            .await
-            .push((connection_id, conn_check));
+        upsert(
+            &mut *self.connections.write().await,
+            connection_id,
+            conn_check,
+        );
+    }
+
+    /// Deregisters a connection on explicit disconnect/delete so its finishing
+    /// task is not mistaken for a server-side drop.
+    pub async fn remove_connection(&self, connection_id: Uuid) {
+        if let Some(conn_check) = self.connections.write().await.remove(&connection_id) {
+            log::info!("Removing connection {connection_id} from ConnectionMonitor");
+            conn_check.abort();
+        }
     }
 
     fn persist_disconnect(&self, connection_id: Uuid) {
@@ -61,7 +99,13 @@ impl ConnectionMonitor {
             } => *libsql_conn = None,
             crate::database::types::Database::MySQL {
                 pool: mysql_pool, ..
-            } => *mysql_pool = None,
+            } => {
+                if let Some(old_pool) = mysql_pool.take() {
+                    crate::database::services::connection::spawn_mysql_pool_disconnect(
+                        (*old_pool).clone(),
+                    );
+                }
+            }
             crate::database::types::Database::D1 {
                 connection: d1_conn,
                 ..
@@ -88,41 +132,61 @@ impl ConnectionMonitor {
         }
     }
 
-    async fn get_dropped_connections(
-        &self,
-        mut dropped_conns: Vec<ConnectionId>,
-    ) -> Vec<ConnectionId> {
-        let connections = self.connections.read().await;
-
-        for (connection_id, conn_check) in &*connections {
-            if conn_check.inner().is_finished() {
-                dropped_conns.push(*connection_id);
-            }
-        }
-
-        dropped_conns
-    }
-
     async fn poll(self) {
-        let mut dropped_conns = Vec::new();
-
         loop {
-            dropped_conns = self.get_dropped_connections(dropped_conns).await;
+            let dropped_conns = take_finished(&mut *self.connections.write().await);
 
-            if !dropped_conns.is_empty() {
-                for connection_id in &dropped_conns {
-                    self.notify_disconnect(*connection_id);
-                }
-
-                self.connections
-                    .write()
-                    .await
-                    .retain(|(id, _)| !dropped_conns.contains(id));
-
-                dropped_conns.clear();
+            for connection_id in dropped_conns {
+                self.notify_disconnect(connection_id);
             }
 
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finished_check() -> ConnectionCheck {
+        let check = tauri::async_runtime::spawn(async {});
+        while !check.inner().is_finished() {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        check
+    }
+
+    fn pending_check() -> ConnectionCheck {
+        tauri::async_runtime::spawn(async {
+            tokio::time::sleep(Duration::from_secs(300)).await;
+        })
+    }
+
+    #[test]
+    fn fresh_handle_survives_replacing_a_stale_one() {
+        let connection_id = Uuid::new_v4();
+        let mut connections = HashMap::new();
+
+        upsert(&mut connections, connection_id, finished_check());
+        upsert(&mut connections, connection_id, pending_check());
+
+        assert_eq!(connections.len(), 1);
+        assert!(take_finished(&mut connections).is_empty());
+        assert!(connections.contains_key(&connection_id));
+    }
+
+    #[test]
+    fn finished_handles_are_reported_and_removed() {
+        let finished_id = Uuid::new_v4();
+        let pending_id = Uuid::new_v4();
+        let mut connections = HashMap::new();
+
+        upsert(&mut connections, finished_id, finished_check());
+        upsert(&mut connections, pending_id, pending_check());
+
+        assert_eq!(take_finished(&mut connections), vec![finished_id]);
+        assert!(!connections.contains_key(&finished_id));
+        assert!(connections.contains_key(&pending_id));
     }
 }

--- a/apps/desktop/src-tauri/src/database/d1/mod.rs
+++ b/apps/desktop/src-tauri/src/database/d1/mod.rs
@@ -47,7 +47,7 @@ pub struct D1Http {
 impl D1Http {
     pub fn new(account_id: String, database_id: String, token: String) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: crate::http::query_client(),
             account_id,
             database_id,
             token,

--- a/apps/desktop/src-tauri/src/database/postgres/connect.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/connect.rs
@@ -89,6 +89,10 @@ pub async fn connect(
 ) -> Result<(Client, ConnectionCheck), Error> {
     use tokio_postgres::config::SslMode;
 
+    let mut config = config.clone();
+    config.connect_timeout(crate::http::CONNECT_TIMEOUT);
+    let config = &config;
+
     let client = match config.get_ssl_mode() {
         SslMode::Require if verify_tls => {
             let certificate_store = certificates.read().await?;

--- a/apps/desktop/src-tauri/src/database/posthog/mod.rs
+++ b/apps/desktop/src-tauri/src/database/posthog/mod.rs
@@ -43,7 +43,7 @@ pub struct PosthogHttp {
 impl PosthogHttp {
     pub fn new(region: &str, project_id: String, api_key: String) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: crate::http::query_client(),
             api_base: region_api_base(region).to_string(),
             project_id,
             api_key,

--- a/apps/desktop/src-tauri/src/database/services/connection.rs
+++ b/apps/desktop/src-tauri/src/database/services/connection.rs
@@ -23,6 +23,36 @@ use crate::{
     storage::Storage,
 };
 
+/// A GUI client issues few concurrent queries; mysql_async's default
+/// constraints (min 10 / max 100) would hold ten idle server sessions per
+/// saved connection. Min 0 means an idle Dora holds nothing.
+const MYSQL_POOL_MIN: usize = 0;
+const MYSQL_POOL_MAX: usize = 4;
+
+fn mysql_opts_with_pool_constraints(
+    mysql_url: &url::Url,
+    max_connections: usize,
+) -> Result<mysql_async::Opts, Error> {
+    let opts = mysql_async::Opts::from_url(mysql_url.as_str())
+        .map_err(|e| Error::Any(anyhow::anyhow!("Invalid MySQL URL: {}", e)))?;
+    let constraints = mysql_async::PoolConstraints::new(MYSQL_POOL_MIN, max_connections)
+        .expect("MYSQL_POOL_MIN <= max_connections");
+    Ok(mysql_async::OptsBuilder::from_opts(opts)
+        .pool_opts(mysql_async::PoolOpts::default().with_constraints(constraints))
+        .into())
+}
+
+/// `Pool::disconnect()` is mysql_async's deterministic teardown; plain `Drop`
+/// only closes server sessions best-effort. Sync call sites can't await it, so
+/// spawn the close.
+pub(crate) fn spawn_mysql_pool_disconnect(pool: mysql_async::Pool) {
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = pool.disconnect().await {
+            log::warn!("MySQL pool disconnect failed: {e}");
+        }
+    });
+}
+
 fn connect_result(connected: bool) -> DatabaseConnectResult {
     DatabaseConnectResult {
         connected,
@@ -175,7 +205,9 @@ impl<'a> ConnectionService<'a> {
                         *tunnel = None;
                     }
                     Database::MySQL { pool, tunnel, .. } => {
-                        *pool = None;
+                        if let Some(old_pool) = pool.take() {
+                            spawn_mysql_pool_disconnect((*old_pool).clone());
+                        }
                         *tunnel = None;
                     }
                     Database::SQLite {
@@ -477,7 +509,10 @@ impl<'a> ConnectionService<'a> {
 
                 let mut config: tokio_postgres::Config =
                     cleaned_string.parse().with_context(|| {
-                        format!("Failed to parse connection string: {}", cleaned_string)
+                        format!(
+                            "Failed to parse connection string: {}",
+                            crate::utils::redact_connection_string(&cleaned_string)
+                        )
                     })?;
                 if disable_channel_binding {
                     config.channel_binding(tokio_postgres::config::ChannelBinding::Disable);
@@ -557,7 +592,7 @@ impl<'a> ConnectionService<'a> {
                 let mut mysql_url = url::Url::parse(connection_string).with_context(|| {
                     format!(
                         "Failed to parse MySQL connection string: {}",
-                        connection_string
+                        crate::utils::redact_connection_string(connection_string)
                     )
                 })?;
 
@@ -593,12 +628,14 @@ impl<'a> ConnectionService<'a> {
                     }
                 }
 
-                let mysql_opts = mysql_async::Opts::from_url(&mysql_url.to_string())
-                    .map_err(|e| Error::Any(anyhow::anyhow!("Invalid MySQL URL: {}", e)))?;
+                let mysql_opts = mysql_opts_with_pool_constraints(&mysql_url, MYSQL_POOL_MAX)?;
                 let mysql_pool = mysql_async::Pool::new(mysql_opts);
 
-                match mysql_pool.get_conn().await {
-                    Ok(mut conn) => {
+                let conn_attempt =
+                    tokio::time::timeout(crate::http::CONNECT_TIMEOUT, mysql_pool.get_conn()).await;
+
+                match conn_attempt {
+                    Ok(Ok(mut conn)) => {
                         conn.ping().await?;
 
                         // Detect the real engine (MySQL vs MariaDB). The
@@ -634,8 +671,20 @@ impl<'a> ConnectionService<'a> {
 
                         Ok(connect_result(true))
                     }
-                    Err(e) => {
+                    Ok(Err(e)) => {
                         log::error!("Failed to connect to MySQL: {}", e);
+                        spawn_mysql_pool_disconnect(mysql_pool);
+                        *tunnel = None;
+                        *pool = None;
+                        connection.connected = false;
+                        Ok(connect_result(false))
+                    }
+                    Err(_) => {
+                        log::error!(
+                            "MySQL connection timed out after {:?}",
+                            crate::http::CONNECT_TIMEOUT
+                        );
+                        spawn_mysql_pool_disconnect(mysql_pool);
                         *tunnel = None;
                         *pool = None;
                         connection.connected = false;
@@ -1071,8 +1120,14 @@ impl<'a> ConnectionService<'a> {
         Ok(result)
     }
 
-    #[instrument(skip(self), fields(connection_id = %connection_id))]
-    pub async fn disconnect_from_database(&self, connection_id: Uuid) -> Result<(), Error> {
+    #[instrument(skip(self, monitor), fields(connection_id = %connection_id))]
+    pub async fn disconnect_from_database(
+        &self,
+        monitor: &ConnectionMonitor,
+        connection_id: Uuid,
+    ) -> Result<(), Error> {
+        monitor.remove_connection(connection_id).await;
+
         let mut connection_entry = self
             .connections
             .get_mut(&connection_id)
@@ -1085,7 +1140,9 @@ impl<'a> ConnectionService<'a> {
                 *tunnel = None;
             }
             Database::MySQL { pool, tunnel, .. } => {
-                *pool = None;
+                if let Some(old_pool) = pool.take() {
+                    spawn_mysql_pool_disconnect((*old_pool).clone());
+                }
                 *tunnel = None;
             }
             Database::SQLite {
@@ -1127,7 +1184,13 @@ impl<'a> ConnectionService<'a> {
         Ok(stored_connections)
     }
 
-    pub async fn remove_connection(&self, connection_id: Uuid) -> Result<(), Error> {
+    pub async fn remove_connection(
+        &self,
+        monitor: &ConnectionMonitor,
+        connection_id: Uuid,
+    ) -> Result<(), Error> {
+        monitor.remove_connection(connection_id).await;
+
         if let Err(e) = credentials::delete_password(&connection_id) {
             log::debug!(
                 "Could not delete password from keyring (may not exist): {}",
@@ -1136,7 +1199,13 @@ impl<'a> ConnectionService<'a> {
         }
 
         self.storage.remove_connection(&connection_id)?;
-        self.connections.remove(&connection_id);
+        if let Some((_, mut removed)) = self.connections.remove(&connection_id) {
+            if let Database::MySQL { pool, .. } = &mut removed.database {
+                if let Some(old_pool) = pool.take() {
+                    spawn_mysql_pool_disconnect((*old_pool).clone());
+                }
+            }
+        }
 
         Ok(())
     }
@@ -1292,7 +1361,10 @@ impl ConnectionService<'_> {
 
                 let mut config: tokio_postgres::Config =
                     cleaned_string.parse().with_context(|| {
-                        format!("Failed to parse connection string: {}", cleaned_string)
+                        format!(
+                            "Failed to parse connection string: {}",
+                            crate::utils::redact_connection_string(&cleaned_string)
+                        )
                     })?;
                 if disable_channel_binding {
                     config.channel_binding(tokio_postgres::config::ChannelBinding::Disable);
@@ -1412,7 +1484,7 @@ impl ConnectionService<'_> {
                 let mut mysql_url = url::Url::parse(&connection_string).with_context(|| {
                     format!(
                         "Failed to parse MySQL connection string: {}",
-                        connection_string
+                        crate::utils::redact_connection_string(&connection_string)
                     )
                 })?;
 
@@ -1455,16 +1527,29 @@ impl ConnectionService<'_> {
                     })?;
                 }
 
-                let mysql_opts = mysql_async::Opts::from_url(&mysql_url.to_string())
-                    .map_err(|e| Error::Any(anyhow::anyhow!("Invalid MySQL URL: {}", e)))?;
+                // A test issues a single query; one pooled connection is enough.
+                let mysql_opts = mysql_opts_with_pool_constraints(&mysql_url, 1)?;
                 let pool = mysql_async::Pool::new(mysql_opts);
-                match pool.get_conn().await {
-                    Ok(mut conn) => {
-                        conn.ping().await?;
-                        Ok(true)
-                    }
-                    Err(e) => Err(Error::Any(anyhow::anyhow!("MySQL connect failed: {}", e))),
+
+                let conn_attempt =
+                    tokio::time::timeout(crate::http::CONNECT_TIMEOUT, pool.get_conn()).await;
+                let result = match conn_attempt {
+                    Ok(Ok(mut conn)) => match conn.ping().await {
+                        Ok(()) => Ok(true),
+                        Err(e) => Err(Error::Any(anyhow::anyhow!("MySQL ping failed: {}", e))),
+                    },
+                    Ok(Err(e)) => Err(Error::Any(anyhow::anyhow!("MySQL connect failed: {}", e))),
+                    Err(_) => Err(Error::Any(anyhow::anyhow!(
+                        "MySQL connect timed out after {:?}",
+                        crate::http::CONNECT_TIMEOUT
+                    ))),
+                };
+
+                if let Err(e) = pool.disconnect().await {
+                    log::warn!("MySQL pool disconnect failed: {e}");
                 }
+
+                result
             }
             DatabaseInfo::D1 { url } => {
                 log::info!("Testing Cloudflare D1 connection: {}", url);

--- a/apps/desktop/src-tauri/src/http.rs
+++ b/apps/desktop/src-tauri/src/http.rs
@@ -1,0 +1,39 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// How long any outbound dial (TCP/TLS) may take before failing. Shared by the
+/// HTTP clients and the database connect paths so a black-holed host errors out
+/// instead of hanging the invoking command forever.
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Total per-request budget for provider API calls (list databases, exchange
+/// tokens, ...). These are small JSON round-trips; 30s is generous.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Total per-request budget for query-over-HTTP engines (D1, PostHog HogQL),
+/// where a single request can legitimately run a slow analytical query.
+pub const QUERY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Shared client for provider API calls. One client means one connection pool,
+/// so TLS sessions and keep-alives are reused across calls, and every request
+/// inherits the connect/request timeouts.
+pub fn client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .expect("default reqwest client with timeouts")
+    })
+}
+
+/// Client for HTTP query engines (D1, PostHog): same connect timeout, longer
+/// request budget.
+pub fn query_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(QUERY_TIMEOUT)
+        .build()
+        .expect("default reqwest client with timeouts")
+}

--- a/apps/desktop/src-tauri/src/integrations/cloudflare.rs
+++ b/apps/desktop/src-tauri/src/integrations/cloudflare.rs
@@ -164,7 +164,7 @@ async fn get_paginated<T>(token: &str, path: &str, context: &str) -> Result<Vec<
 where
     T: for<'de> Deserialize<'de>,
 {
-    let client = reqwest::Client::new();
+    let client = crate::http::client();
     let per_page = PAGE_SIZE.to_string();
     let mut all = Vec::new();
     let mut page: u64 = 1;

--- a/apps/desktop/src-tauri/src/integrations/neon.rs
+++ b/apps/desktop/src-tauri/src/integrations/neon.rs
@@ -156,7 +156,7 @@ async fn read_body(response: reqwest::Response) -> String {
 }
 
 async fn get_projects(token: &str) -> Result<Vec<ProjectResponse>> {
-    let client = reqwest::Client::new();
+    let client = crate::http::client();
     let limit = PROJECTS_PAGE_LIMIT.to_string();
     let mut projects = Vec::new();
     let mut cursor: Option<String> = None;
@@ -215,7 +215,7 @@ async fn get_projects(token: &str) -> Result<Vec<ProjectResponse>> {
 /// which account is connected.
 pub async fn current_account(storage: &Storage) -> Result<NeonAccount> {
     let token = require_token(storage)?;
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!("{API_BASE_URL}/users/me"))
         .bearer_auth(&token)
         .send()
@@ -256,7 +256,7 @@ pub async fn save_token(storage: &Storage, token: String) -> Result<()> {
 /// Fetches every branch of a project. Shared by `get_default_branch` (which just
 /// wants the primary) and `list_branches` (which surfaces all of them to the UI).
 async fn get_branches(token: &str, project_id: &str) -> Result<Vec<BranchResponse>> {
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!("{API_BASE_URL}/projects/{project_id}/branches"))
         .bearer_auth(token)
         .send()
@@ -311,7 +311,7 @@ async fn get_branch_databases(
     project_id: &str,
     branch_id: &str,
 ) -> Result<Vec<DatabaseResponse>> {
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!(
             "{API_BASE_URL}/projects/{project_id}/branches/{branch_id}/databases"
         ))
@@ -369,7 +369,7 @@ pub async fn create_connection_uri(
     role_name: &str,
 ) -> Result<String> {
     let token = require_token(storage)?;
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!("{API_BASE_URL}/projects/{project_id}/connection_uri"))
         .query(&[
             ("branch_id", branch_id),

--- a/apps/desktop/src-tauri/src/integrations/planetscale.rs
+++ b/apps/desktop/src-tauri/src/integrations/planetscale.rs
@@ -180,7 +180,7 @@ fn has_next_page(next_page: &Option<serde_json::Value>) -> bool {
 /// Maps 401/403 to a scope/credential-specific error and any other non-2xx to an
 /// error carrying the response body.
 async fn authed_get(token: &str, url: &str, query: &[(&str, &str)], what: &str) -> Result<String> {
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(url)
         .header(reqwest::header::AUTHORIZATION, token)
         .query(query)
@@ -387,7 +387,7 @@ pub async fn create_password(
             .unwrap_or(0)
     );
 
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .post(format!(
             "{API_BASE_URL}/organizations/{organization}/databases/{database}/branches/{branch}/passwords"
         ))

--- a/apps/desktop/src-tauri/src/integrations/posthog.rs
+++ b/apps/desktop/src-tauri/src/integrations/posthog.rs
@@ -133,7 +133,7 @@ async fn execute(config: &StoredConfig, hogql: &str) -> Result<PosthogQueryResul
         "query": { "kind": "HogQLQuery", "query": hogql }
     });
 
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .post(&url)
         .bearer_auth(&config.api_key)
         .json(&body)

--- a/apps/desktop/src-tauri/src/integrations/supabase.rs
+++ b/apps/desktop/src-tauri/src/integrations/supabase.rs
@@ -198,7 +198,7 @@ async fn read_body(response: reqwest::Response) -> String {
 /// decide how to treat a 401 (validate-only paths surface it; `authed_get`
 /// refreshes and retries).
 async fn send_get(token: &str, path: &str) -> Result<(reqwest::StatusCode, String)> {
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!("{API_BASE_URL}{path}"))
         .bearer_auth(token)
         .send()
@@ -387,7 +387,7 @@ impl From<ProxyTokens> for OAuthTokens {
 }
 
 async fn refresh_oauth(refresh_token: &str) -> Result<OAuthTokens> {
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .post(format!("{}/api/oauth/supabase/refresh", proxy_base()))
         .json(&serde_json::json!({ "refreshToken": refresh_token }))
         .send()

--- a/apps/desktop/src-tauri/src/integrations/turso.rs
+++ b/apps/desktop/src-tauri/src/integrations/turso.rs
@@ -84,7 +84,7 @@ pub fn disconnect(storage: &Storage) -> Result<()> {
 }
 
 async fn fetch_organizations(token: &str) -> Result<Vec<TursoOrganization>> {
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!("{API_BASE_URL}/organizations"))
         .bearer_auth(token)
         .send()
@@ -143,7 +143,7 @@ pub async fn save_token(storage: &Storage, token: String) -> Result<()> {
 /// Lists every database the token can see, across all of its organizations.
 pub async fn list_databases(storage: &Storage) -> Result<Vec<TursoDatabase>> {
     let token = require_token(storage)?;
-    let client = reqwest::Client::new();
+    let client = crate::http::client();
     let mut databases = Vec::new();
 
     for slug in get_organizations(&token).await? {
@@ -194,7 +194,7 @@ pub async fn create_token(
     database_name: &str,
 ) -> Result<String> {
     let token = require_token(storage)?;
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .post(format!(
             "{API_BASE_URL}/organizations/{organization_slug}/databases/{database_name}/auth/tokens"
         ))

--- a/apps/desktop/src-tauri/src/integrations/vercel.rs
+++ b/apps/desktop/src-tauri/src/integrations/vercel.rs
@@ -176,7 +176,7 @@ async fn read_body(response: reqwest::Response) -> String {
 }
 
 async fn get_projects(token: &str) -> Result<Vec<ProjectResponse>> {
-    let client = reqwest::Client::new();
+    let client = crate::http::client();
     let limit = PROJECTS_PAGE_LIMIT.to_string();
     let mut projects = Vec::new();
     let mut from: Option<String> = None;
@@ -236,7 +236,7 @@ async fn get_projects(token: &str) -> Result<Vec<ProjectResponse>> {
 /// show which account is connected.
 pub async fn current_account(storage: &Storage) -> Result<VercelAccount> {
     let token = require_token(storage)?;
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!("{API_BASE_URL}/v2/user"))
         .bearer_auth(&token)
         .send()
@@ -306,7 +306,7 @@ fn pick_connection_string(envs: &[EnvVar]) -> Option<(String, String)> {
 /// fetch are swallowed (returns `None`) so one inaccessible project doesn't sink
 /// the whole store list.
 async fn project_connection_string(token: &str, project_id: &str) -> Option<(String, String)> {
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!("{API_BASE_URL}/v10/projects/{project_id}/env"))
         .query(&[("decrypt", "true")])
         .bearer_auth(token)

--- a/apps/desktop/src-tauri/src/integrations/xata.rs
+++ b/apps/desktop/src-tauri/src/integrations/xata.rs
@@ -134,7 +134,7 @@ async fn read_body(response: reqwest::Response) -> String {
 }
 
 async fn get_workspaces(token: &str) -> Result<Vec<WorkspaceResponse>> {
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!("{CORE_API_BASE_URL}/workspaces"))
         .bearer_auth(token)
         .send()
@@ -163,7 +163,7 @@ async fn get_workspaces(token: &str) -> Result<Vec<WorkspaceResponse>> {
 }
 
 async fn get_workspace_databases(token: &str, workspace_id: &str) -> Result<Vec<DatabaseResponse>> {
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!("{CORE_API_BASE_URL}/workspaces/{workspace_id}/dbs"))
         .bearer_auth(token)
         .send()
@@ -190,7 +190,7 @@ async fn get_workspace_databases(token: &str, workspace_id: &str) -> Result<Vec<
 /// which account is connected.
 pub async fn current_account(storage: &Storage) -> Result<XataAccount> {
     let token = require_token(storage)?;
-    let response = reqwest::Client::new()
+    let response = crate::http::client()
         .get(format!("{CORE_API_BASE_URL}/user"))
         .bearer_auth(&token)
         .send()

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ pub mod credential_storage;
 pub mod credentials;
 pub mod database;
 mod error;
+pub mod http;
 mod init;
 mod integrations;
 mod observability;

--- a/apps/desktop/src-tauri/src/utils.rs
+++ b/apps/desktop/src-tauri/src/utils.rs
@@ -26,6 +26,57 @@ pub fn is_json(input: &[u8]) -> bool {
     serde_json::from_slice::<IgnoredAny>(input).is_ok()
 }
 
+/// Replaces the password of a connection URL (userinfo and/or `password=`
+/// query param) with `****` so the string is safe to embed in user-visible
+/// errors and logs. Handles malformed input too, since the call sites are
+/// exactly the ones where URL parsing failed.
+pub fn redact_connection_string(connection_string: &str) -> String {
+    let Ok(mut url) = url::Url::parse(connection_string) else {
+        return redact_unparseable_connection_string(connection_string);
+    };
+
+    if url.password().is_some() {
+        let _ = url.set_password(Some("****"));
+    }
+
+    let has_password_param = url
+        .query_pairs()
+        .any(|(key, _)| key.eq_ignore_ascii_case("password"));
+    if has_password_param {
+        let pairs: Vec<(String, String)> = url
+            .query_pairs()
+            .map(|(key, value)| {
+                let value = if key.eq_ignore_ascii_case("password") {
+                    "****".to_string()
+                } else {
+                    value.into_owned()
+                };
+                (key.into_owned(), value)
+            })
+            .collect();
+        url.query_pairs_mut().clear().extend_pairs(pairs);
+    }
+
+    url.to_string()
+}
+
+fn redact_unparseable_connection_string(connection_string: &str) -> String {
+    match connection_string.split_once("://") {
+        Some((scheme, rest)) if rest.contains('@') => {
+            let (userinfo, host) = rest
+                .rsplit_once('@')
+                .expect("rest contains '@' per the guard");
+            match userinfo.split_once(':') {
+                Some((user, _password)) => format!("{scheme}://{user}:****@{host}"),
+                None => connection_string.to_string(),
+            }
+        }
+        // Could be a keyword/value DSN ("host=x password=y") or anything else;
+        // over-redact rather than risk echoing a secret.
+        _ => "<unparseable connection string redacted>".to_string(),
+    }
+}
+
 #[tauri::command]
 pub fn check_tcp_port(port: u16) -> bool {
     std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
@@ -48,6 +99,41 @@ mod tests {
         let iter = [];
         let json = serialize_as_json_array(iter.iter().copied()).unwrap();
         assert_eq!(serde_json::to_string(&json).unwrap(), r#"[]"#);
+    }
+
+    #[test]
+    fn redacts_userinfo_password() {
+        let redacted = redact_connection_string("postgres://user:hunter2@db.example.com:5432/app");
+        assert!(!redacted.contains("hunter2"));
+        assert_eq!(redacted, "postgres://user:****@db.example.com:5432/app");
+    }
+
+    #[test]
+    fn leaves_passwordless_url_untouched() {
+        let url = "postgres://user@db.example.com/app?sslmode=require";
+        assert_eq!(redact_connection_string(url), url);
+    }
+
+    #[test]
+    fn redacts_password_query_param() {
+        let redacted = redact_connection_string(
+            "postgres://db.example.com/app?password=hunter2&sslmode=require",
+        );
+        assert!(!redacted.contains("hunter2"));
+        assert!(redacted.contains("sslmode=require"));
+    }
+
+    #[test]
+    fn redacts_unparseable_url_with_userinfo() {
+        let redacted = redact_connection_string("postgres://user:secret@@@/db");
+        assert!(!redacted.contains("secret"));
+        assert!(redacted.starts_with("postgres://user:****@"));
+    }
+
+    #[test]
+    fn over_redacts_unrecognized_input() {
+        let redacted = redact_connection_string("host=localhost password=hunter2");
+        assert!(!redacted.contains("hunter2"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Batch fix for the four connection-layer bugs from the 2026-07-26 audit.

### #190 — password leaks into user-visible errors
New `utils::redact_connection_string` (userinfo password, `password=` query param, and an over-redacting fallback for unparseable input — which is exactly the case at these call sites). Applied at all four leak sites (2× Postgres parse, 2× MySQL parse). Unit-tested.

### #191 — ConnectionMonitor kills reconnected connections
Store switched from `Vec<(id, handle)>` to `HashMap<id, handle>`, so one handle per connection is enforced by the type. `add_connection` aborts+replaces a stale handle; new `remove_connection` deregisters on explicit disconnect/delete (wired into both commands). Poll cleanup no longer id-scans a Vec. Decision logic extracted into pure `upsert`/`take_finished` helpers with unit tests.

### #192 — no connect timeout anywhere
- Postgres: `connect_timeout(10s)` set once in `connect()`, inherited by the IPv4 fallback attempt.
- MySQL: `get_conn` wrapped in the same 10s budget; timeout yields a clear error instead of a forever-pending invoke.
- HTTP: all 26 `reqwest::Client::new()` provider-API sites replaced with one shared client (`src/http.rs`, `OnceLock`): connect 10s, request 30s, and as a bonus one connection pool → TLS session/keep-alive reuse across provider calls. D1/PostHog query handles use a 60s request budget since a single HogQL/D1 query can legitimately be slow.
- Timeouts are named constants, not literals.

### #193 — MySQL opens 10 idle server connections per Dora connection
Pool constraints now min 0 / max 4 (test-connection path: max 1); an idle Dora holds zero server sessions. Every teardown path (`disconnect_from_database`, `remove_connection`, `update_connection` config change, monitor `persist_disconnect`, test path, failed-connect path) now calls `Pool::disconnect()` — mysql_async's deterministic close — instead of dropping the pool.

## Verification
- `cargo check` clean; `cargo test --lib`: 229 passed (the 2 pgtemp failures also fail on master here — missing local `initdb`).
- Clippy: two fewer warnings than master in touched files; no new ones.
- AI-service clients (`ollama.rs` etc.) intentionally untouched: they build their own clients and stream LLM responses, where a 30s cap would be wrong.

Closes #190, closes #191, closes #192, closes #193

## Summary by Sourcery

Improve connection-layer robustness and hygiene across the desktop app by redacting secrets in error messages, enforcing safer connection monitoring semantics, introducing standardized connect/request timeouts for databases and HTTP clients, and tightening MySQL pool lifecycle and resource usage.

Bug Fixes:
- Prevent passwords from leaking into user-visible Postgres and MySQL connection error messages via connection string redaction.
- Ensure the connection monitor no longer drops freshly reconnected connections by tracking one handle per connection and deregistering on explicit disconnect or delete.
- Add bounded connect timeouts for Postgres and MySQL connections so black-holed hosts fail instead of hanging indefinitely.
- Introduce shared HTTP clients with standardized connect and request timeouts for provider APIs and longer budgets for query-over-HTTP engines.
- Fix MySQL pooling so idle Dora connections do not hold excess server sessions and pools are deterministically torn down on all disconnect paths.

Enhancements:
- Refine MySQL connection pooling constraints for normal and test paths to limit concurrent server connections.
- Centralize reqwest client construction into a new HTTP module with reusable connection and request timeout configuration.
- Add unit tests for connection string redaction and connection monitor behavior to guard against regressions.

Tests:
- Add tests for connection string redaction behavior across well-formed and malformed inputs.
- Add unit tests validating connection monitor upsert semantics and finished-task cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection cleanup when disconnecting, removing, or updating database connections.
  * Added connection timeouts and safer handling of failed MySQL and PostgreSQL connection attempts.
  * Prevented stale connection monitoring states and reduced unintended server-side disconnect reports.
  * Sensitive connection details are now redacted in connection errors.
* **Improvements**
  * Standardized network request behavior across database and integration services.
  * Improved cleanup of idle MySQL sessions and connection pools.
  * Added longer timeout support for analytical database queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->