### PR TITLE
fix(studio): grid paste sanitization, per-tab query cancel, resettable ErrorBoundary

### DIFF
--- a/apps/desktop/src-tauri/src/bindings.rs
+++ b/apps/desktop/src-tauri/src/bindings.rs
@@ -94,6 +94,7 @@ pub fn generate_bindings() -> Builder<tauri::Wry> {
         db_commands::set_connection_pin,
         db_commands::verify_pin_and_get_credentials,
         db_commands::cancel_query,
+        db_commands::cancel_queries,
         db_commands::start_query,
         db_commands::fetch_query,
         db_commands::fetch_page,

--- a/apps/desktop/src-tauri/src/database/commands/query.rs
+++ b/apps/desktop/src-tauri/src/database/commands/query.rs
@@ -21,6 +21,16 @@ pub async fn cancel_query(state: State<'_, AppState>) -> Result<(), Error> {
 
 #[tauri::command]
 #[specta::specta]
+pub async fn cancel_queries(
+    query_ids: Vec<usize>,
+    state: State<'_, AppState>,
+) -> Result<(), Error> {
+    state.stmt_manager.cancel_queries(&query_ids);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn start_query(
     connection_id: Uuid,
     query: &str,

--- a/apps/desktop/src-tauri/src/database/stmt_manager.rs
+++ b/apps/desktop/src-tauri/src/database/stmt_manager.rs
@@ -76,6 +76,40 @@ struct ExecState {
     pg_cancel: RwLock<Option<PgCancel>>,
 }
 
+/// Signals the database engine itself to stop a running statement: interrupts
+/// SQLite, and for Postgres/CockroachDB issues a real `CancelRequest` over a
+/// fresh connection — aborting the executor future alone only drops our
+/// socket while the server keeps running the (possibly expensive) query.
+/// Best-effort and fire-and-forget; the caller still aborts the executor.
+fn signal_engine_cancel(entry: &ExecState) {
+    if let Some(handle) = entry
+        .sqlite_interrupt_handle
+        .read()
+        .expect("RwLock poisoned")
+        .as_ref()
+    {
+        handle.interrupt();
+    }
+
+    if let Some(pg) = entry.pg_cancel.read().expect("RwLock poisoned").as_ref() {
+        let token = pg.token.clone();
+        let ssl_mode = pg.ssl_mode;
+        spawn(async move {
+            // Mirror the SSL strategy `postgres::connect::connect` uses so the
+            // cancel connection negotiates the same way the live one did
+            // (encrypt-only, no cert verification, which is enough for a
+            // single control message).
+            let outcome = match ssl_mode {
+                SslMode::Require | SslMode::Prefer => token.cancel_query(no_verify_tls()).await,
+                _ => token.cancel_query(NoTls).await,
+            };
+            if let Err(err) = outcome {
+                log::warn!("Postgres cancel request failed: {err}");
+            }
+        });
+    }
+}
+
 /// How many finished statements to keep addressable before the oldest are
 /// reaped. Submissions no longer wipe the map, so this is what bounds memory;
 /// it must stay comfortably above the largest batch a single view issues (the
@@ -113,62 +147,49 @@ impl StatementManager {
 
     /// Cancels all currently running queries, marking them as errors and aborting their listener tasks.
     pub fn cancel_active_queries(&self) {
-        for entry in self.queries.iter() {
-            let status = entry.status.load(Ordering::Relaxed);
-            if status == QueryStatus::Running as u8 || status == QueryStatus::Pending as u8 {
-                if let Some(handle) = entry
-                    .sqlite_interrupt_handle
-                    .read()
-                    .expect("RwLock poisoned")
-                    .as_ref()
-                {
-                    handle.interrupt();
-                }
+        let active_ids: Vec<QueryId> = self
+            .queries
+            .iter()
+            .filter(|entry| {
+                let status = entry.status.load(Ordering::Relaxed);
+                status == QueryStatus::Running as u8 || status == QueryStatus::Pending as u8
+            })
+            .map(|entry| *entry.key())
+            .collect();
 
-                // Postgres/CockroachDB: aborting the executor future below only
-                // drops our socket; the server keeps running the query. Issue a
-                // real CancelRequest over a fresh connection. Best-effort and
-                // fire-and-forget — if it fails we still fall back to the abort.
-                if let Some(pg) = entry.pg_cancel.read().expect("RwLock poisoned").as_ref() {
-                    let token = pg.token.clone();
-                    let ssl_mode = pg.ssl_mode;
-                    spawn(async move {
-                        // Mirror the SSL strategy `postgres::connect::connect`
-                        // uses so the cancel connection negotiates the same way
-                        // the live one did (encrypt-only, no cert verification,
-                        // which is enough for a single control message).
-                        let outcome = match ssl_mode {
-                            SslMode::Require | SslMode::Prefer => {
-                                token.cancel_query(no_verify_tls()).await
-                            }
-                            _ => token.cancel_query(NoTls).await,
-                        };
-                        if let Err(err) = outcome {
-                            log::warn!("Postgres cancel request failed: {err}");
-                        }
-                    });
-                }
-            }
-        }
+        self.cancel_queries(&active_ids);
 
-        for entry in self.execution_handles.iter() {
-            entry.value().abort();
-        }
-        for entry in self.queries.iter() {
-            let status = entry.status.load(Ordering::Relaxed);
-            if status == QueryStatus::Running as u8 || status == QueryStatus::Pending as u8 {
-                *entry.error.write().expect("RwLock poisoned") =
-                    Some("Query cancelled".to_string());
-                entry
-                    .status
-                    .store(QueryStatus::Error as u8, Ordering::Relaxed);
-            }
-        }
-        for entry in self.listener_handles.iter() {
-            entry.value().abort();
-        }
         self.execution_handles.clear();
         self.listener_handles.clear();
+    }
+
+    /// Cancels only the given statements, so one SQL-console tab can cancel its
+    /// own query without killing queries running in other tabs.
+    pub fn cancel_queries(&self, query_ids: &[QueryId]) {
+        for query_id in query_ids {
+            let Some(entry) = self.queries.get(query_id) else {
+                continue;
+            };
+            let status = entry.status.load(Ordering::Relaxed);
+            if status != QueryStatus::Running as u8 && status != QueryStatus::Pending as u8 {
+                continue;
+            }
+
+            signal_engine_cancel(&entry);
+
+            if let Some((_, handle)) = self.execution_handles.remove(query_id) {
+                handle.abort();
+            }
+
+            *entry.error.write().expect("RwLock poisoned") = Some("Query cancelled".to_string());
+            entry
+                .status
+                .store(QueryStatus::Error as u8, Ordering::Relaxed);
+
+            if let Some((_, handle)) = self.listener_handles.remove(query_id) {
+                handle.abort();
+            }
+        }
     }
 
     /// Submits a new query (possibly containing multiple statements) for execution.
@@ -619,5 +640,39 @@ mod tests {
         let cancelled = stmt_manager.fetch_query(0).unwrap();
         assert_eq!(cancelled.status, QueryStatus::Error);
         assert_eq!(cancelled.error.as_deref(), Some("Query cancelled"));
+    }
+
+    #[tokio::test]
+    async fn cancel_queries_only_cancels_the_given_statements() {
+        let stmt_manager = StatementManager::new();
+        let slow_query = "WITH RECURSIVE t(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM t WHERE x < 100000000) SELECT count(*) FROM t;";
+
+        let client_a = DatabaseClient::SQLite {
+            connection: Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap())),
+        };
+        let client_b = DatabaseClient::SQLite {
+            connection: Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap())),
+        };
+
+        let ids_a = stmt_manager.submit_query(client_a, slow_query).unwrap();
+        let ids_b = stmt_manager.submit_query(client_b, slow_query).unwrap();
+
+        for _ in 0..10 {
+            if stmt_manager.get_query_status(ids_a[0]).unwrap() == QueryStatus::Running {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        stmt_manager.cancel_queries(&ids_a);
+
+        let cancelled = stmt_manager.fetch_query(ids_a[0]).unwrap();
+        assert_eq!(cancelled.status, QueryStatus::Error);
+        assert_eq!(cancelled.error.as_deref(), Some("Query cancelled"));
+
+        let untouched = stmt_manager.get_query_status(ids_b[0]).unwrap();
+        assert_ne!(untouched, QueryStatus::Error);
+
+        stmt_manager.cancel_active_queries();
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -174,6 +174,7 @@ pub fn run() {
             database::commands::import_files_into_duckdb,
             database::commands::disconnect_from_database,
             database::commands::cancel_query,
+            database::commands::cancel_queries,
             database::commands::start_query,
             database::commands::fetch_query,
             database::commands::fetch_page,

--- a/apps/desktop/src/lib/bindings.ts
+++ b/apps/desktop/src/lib/bindings.ts
@@ -779,6 +779,14 @@ async cancelQuery() : Promise<Result<null, { kind: string; detail: string }>> {
     else return { status: "error", error: e  as any };
 }
 },
+async cancelQueries(queryIds: number[]) : Promise<Result<null, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("cancel_queries", { queryIds }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async startQuery(connectionId: string, query: string) : Promise<Result<number[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("start_query", { connectionId, query }) };

--- a/packages/studio/src/core/data-provider/adapters/mock.ts
+++ b/packages/studio/src/core/data-provider/adapters/mock.ts
@@ -698,6 +698,10 @@ CREATE TABLE posts (
 			// no-op in mock adapter
 		},
 
+		async cancelQueries(_queryIds: number[]): Promise<void> {
+			// no-op in mock adapter
+		},
+
 		async updateCell(
 			connectionId: string,
 			tableName: string,

--- a/packages/studio/src/core/data-provider/adapters/tauri.ts
+++ b/packages/studio/src/core/data-provider/adapters/tauri.ts
@@ -19,7 +19,7 @@ import type {
 import { commands } from '@studio/lib/bindings'
 import { formatBackendError } from '@studio/shared/utils/backend-error'
 import { buildDropColumnSql, getTableRefParts, getTableSqlIdentifier, type TableDialect } from '@studio/shared/utils/table-ref'
-import type { DataAdapter, AdapterResult, QueryResult } from '../types'
+import type { DataAdapter, AdapterResult, ExecuteQueryOptions, QueryResult } from '../types'
 
 import { backendToFrontendConnection } from '@studio/features/connections/utils/mapping'
 import type { Connection } from '@studio/features/connections/types'
@@ -378,7 +378,8 @@ export function createTauriAdapter(): DataAdapter {
 
 		async executeQuery(
 			connectionId: string,
-			query: string
+			query: string,
+			options?: ExecuteQueryOptions
 		): Promise<AdapterResult<QueryResult>> {
 			const startTime = performance.now()
 
@@ -393,6 +394,8 @@ export function createTauriAdapter(): DataAdapter {
 				console.error('[TauriAdapter] No query ID returned:', startResult)
 				return err('Backend returned no query ID')
 			}
+
+			options?.onStarted?.(startResult.data)
 
 			const queryId = startResult.data[0]
 
@@ -431,6 +434,10 @@ export function createTauriAdapter(): DataAdapter {
 
 		async cancelActiveQuery(_connectionId: string): Promise<void> {
 			await commands.cancelQuery()
+		},
+
+		async cancelQueries(queryIds: number[]): Promise<void> {
+			await commands.cancelQueries(queryIds)
 		},
 
 		async updateCell(

--- a/packages/studio/src/core/data-provider/types.ts
+++ b/packages/studio/src/core/data-provider/types.ts
@@ -45,6 +45,11 @@ export type QueryResult = {
 }
 import type { Connection } from '@studio/features/connections/types'
 
+export type ExecuteQueryOptions = {
+	/** Called with the backend statement ids as soon as the query starts, so the caller can cancel just those statements. */
+	onStarted?: (queryIds: number[]) => void
+}
+
 export type DataAdapter = {
 	getConnections(): Promise<AdapterResult<Connection[]>>
 	addConnection(
@@ -91,8 +96,13 @@ export type DataAdapter = {
 		filterGroup?: FilterGroup
 	): Promise<AdapterResult<TableData>>
 
-	executeQuery(connectionId: string, query: string): Promise<AdapterResult<QueryResult>>
+	executeQuery(
+		connectionId: string,
+		query: string,
+		options?: ExecuteQueryOptions
+	): Promise<AdapterResult<QueryResult>>
 	cancelActiveQuery(connectionId: string): Promise<void>
+	cancelQueries(queryIds: number[]): Promise<void>
 
 	updateCell(
 		connectionId: string,

--- a/packages/studio/src/features/database-studio/components/data-grid/use-grid-keyboard.test.ts
+++ b/packages/studio/src/features/database-studio/components/data-grid/use-grid-keyboard.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { parseClipboardGrid } from './use-grid-keyboard'
+
+describe('parseClipboardGrid', () => {
+	it('splits LF-delimited TSV into rows and cells', () => {
+		expect(parseClipboardGrid('a\tb\nc\td')).toEqual([
+			['a', 'b'],
+			['c', 'd']
+		])
+	})
+
+	it('strips CRLF line endings so no \\r lands in cell values', () => {
+		expect(parseClipboardGrid('a\tb\r\nc\td')).toEqual([
+			['a', 'b'],
+			['c', 'd']
+		])
+	})
+
+	it('handles bare CR line endings', () => {
+		expect(parseClipboardGrid('a\tb\rc\td')).toEqual([
+			['a', 'b'],
+			['c', 'd']
+		])
+	})
+
+	it('drops the single trailing newline instead of producing a phantom row', () => {
+		expect(parseClipboardGrid('a\tb\n')).toEqual([['a', 'b']])
+		expect(parseClipboardGrid('a\tb\r\n')).toEqual([['a', 'b']])
+	})
+
+	it('keeps interior blank lines positional', () => {
+		expect(parseClipboardGrid('a\n\nb')).toEqual([['a'], [''], ['b']])
+	})
+
+	it('keeps a deliberate empty trailing cell', () => {
+		expect(parseClipboardGrid('a\t')).toEqual([['a', '']])
+	})
+})

--- a/packages/studio/src/features/database-studio/components/data-grid/use-grid-keyboard.ts
+++ b/packages/studio/src/features/database-studio/components/data-grid/use-grid-keyboard.ts
@@ -381,6 +381,26 @@ function copySelectionToClipboard(
 	}
 }
 
+/**
+ * Splits clipboard text into a grid of cell values. Normalises CRLF/CR line
+ * endings (Excel, Sheets, Windows apps) so no `\r` ends up in cell values,
+ * and drops the single trailing newline most copy sources append so it does
+ * not become a phantom row that overwrites the row below the paste target.
+ */
+export function parseClipboardGrid(clipboardText: string): string[][] {
+	return clipboardText
+		.replace(/\r\n?/g, '\n')
+		.replace(/\n$/, '')
+		.split('\n')
+		.map(function (line) {
+			return line.split('\t')
+		})
+}
+
+function isEmptyPasteRow(pasteRow: string[]): boolean {
+	return pasteRow.length === 1 && pasteRow[0] === ''
+}
+
 function pasteClipboardIntoGrid(
 	focusedCell: CellPosition,
 	rowCount: number,
@@ -391,10 +411,9 @@ function pasteClipboardIntoGrid(
 		.readText()
 		.then(function (clipboardText) {
 			if (!clipboardText) return
-			const pasteRows = clipboardText.split('\n').map(function (line) {
-				return line.split('\t')
-			})
+			const pasteRows = parseClipboardGrid(clipboardText)
 			pasteRows.forEach(function (pasteRow, pasteRowIndex) {
+				if (isEmptyPasteRow(pasteRow)) return
 				const targetRow = focusedCell.row + pasteRowIndex
 				if (targetRow >= rowCount) return
 				pasteRow.forEach(function (pasteValue, pasteColIndex) {

--- a/packages/studio/src/features/sql-console/sql-console.tsx
+++ b/packages/studio/src/features/sql-console/sql-console.tsx
@@ -161,7 +161,11 @@ function SqlConsoleInner({
   const [showRightSidebar, setShowRightSidebar] = useState(true);
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SQL_CONSOLE_SIDEBAR_WIDTH);
   const sbwRef = useRef(DEFAULT_SQL_CONSOLE_SIDEBAR_WIDTH);
-  const cancelledRef = useRef(false);
+  // Cancellation is per tab: each tab tracks its own in-flight backend
+  // statement ids and cancelled flag, so cancelling one tab's query never
+  // cancels or silences a query running in another tab.
+  const cancelledTabsRef = useRef<Set<string>>(new Set());
+  const inFlightQueryIdsRef = useRef<Map<string, number[]>>(new Map());
   const [autoExpandFolder, setAutoExpandFolder] = useState<string | null>(null);
   const [showFilter, setShowFilter] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
@@ -416,7 +420,13 @@ function SqlConsoleInner({
       // Prisma mode is handled by the self-contained PrismaRunner.
       if (!modeOverride && mode === "prisma") return;
 
-      cancelledRef.current = false;
+      const executingTabId = activeTab.id;
+      cancelledTabsRef.current.delete(executingTabId);
+      const trackQueryIds = {
+        onStarted: function (queryIds: number[]) {
+          inFlightQueryIdsRef.current.set(executingTabId, queryIds);
+        },
+      };
       setIsExecuting(true);
       setResult(null);
       const nextMode = modeOverride || mode;
@@ -429,7 +439,7 @@ function SqlConsoleInner({
           if (!activeConnectionId) {
             throw new Error("No connection selected");
           }
-          const res = await adapter.executeQuery(activeConnectionId, queryToRun);
+          const res = await adapter.executeQuery(activeConnectionId, queryToRun, trackQueryIds);
           if (res.ok) {
             const columns = Array.isArray(res.data.columns) ? res.data.columns : [];
             const columnDefinitions = res.data.columnDefinitions;
@@ -502,7 +512,7 @@ function SqlConsoleInner({
           }
 
           const sqlToRun = drizzleQueryToSql(queryToRun);
-          const res = await adapter.executeQuery(activeConnectionId, sqlToRun);
+          const res = await adapter.executeQuery(activeConnectionId, sqlToRun, trackQueryIds);
 
           if (res.ok) {
             setResult({
@@ -541,17 +551,22 @@ function SqlConsoleInner({
           }
         }
       } catch (error) {
-        if (!cancelledRef.current) {
-          const errorMsg = error instanceof Error ? error.message : "An error occurred";
-          setResult({
-            columns: [],
-            rows: [],
-            rowCount: 0,
-            executionTime: 0,
-            error: errorMsg,
-            queryType: "OTHER",
-          });
+        const wasCancelled = cancelledTabsRef.current.has(executingTabId);
+        const errorMsg = wasCancelled
+          ? "Query cancelled"
+          : error instanceof Error
+            ? error.message
+            : "An error occurred";
+        setResult({
+          columns: [],
+          rows: [],
+          rowCount: 0,
+          executionTime: 0,
+          error: errorMsg,
+          queryType: "OTHER",
+        });
 
+        if (!wasCancelled) {
           const historyId = addToHistory({
             query: historyQuery,
             connectionId: activeConnectionId || null,
@@ -562,7 +577,8 @@ function SqlConsoleInner({
           tabStore.setTabHistoryEntry(activeTab.id, historyId);
         }
       } finally {
-        cancelledRef.current = false;
+        cancelledTabsRef.current.delete(executingTabId);
+        inFlightQueryIdsRef.current.delete(executingTabId);
         setIsExecuting(false);
       }
     },
@@ -581,11 +597,17 @@ function SqlConsoleInner({
   );
 
   const handleCancel = useCallback(async () => {
-    cancelledRef.current = true;
-    if (activeConnectionId) {
+    const tabId = activeTab.id;
+    cancelledTabsRef.current.add(tabId);
+    const queryIds = inFlightQueryIdsRef.current.get(tabId);
+    if (queryIds && queryIds.length > 0) {
+      await adapter.cancelQueries(queryIds);
+    } else if (activeConnectionId) {
+      // The query has not reported its statement ids yet (still starting);
+      // fall back to the connection-wide cancel.
       await adapter.cancelActiveQuery(activeConnectionId);
     }
-  }, [adapter, activeConnectionId]);
+  }, [adapter, activeConnectionId, activeTab.id]);
 
   const activeDialect = useMemo(() => {
     const connection = connections?.find(function (c) {

--- a/packages/studio/src/lib/bindings.ts
+++ b/packages/studio/src/lib/bindings.ts
@@ -724,6 +724,14 @@ async cancelQuery() : Promise<Result<null, { kind: string; detail: string }>> {
     else return { status: "error", error: e  as any };
 }
 },
+async cancelQueries(queryIds: number[]) : Promise<Result<null, { kind: string; detail: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("cancel_queries", { queryIds }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async startQuery(connectionId: string, query: string) : Promise<Result<number[], { kind: string; detail: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("start_query", { connectionId, query }) };

--- a/packages/studio/src/pages/Index.tsx
+++ b/packages/studio/src/pages/Index.tsx
@@ -1095,7 +1095,10 @@ function IndexInner() {
                           showConnectionTabBar ? undefined : <WindowControls />
                         }
                       />
-                      <ErrorBoundary feature="Database Studio">
+                      <ErrorBoundary
+                        feature="Database Studio"
+                        resetKeys={[studioConnectionId, selectedTableId]}
+                      >
                         <DatabaseStudio
                           key={studioConnectionId || "empty"}
                           tableId={selectedTableId}
@@ -1126,7 +1129,10 @@ function IndexInner() {
                   ) : activeNavId === "sql-console" ? (
                     <div className="flex flex-col flex-1 min-h-0">
                       {connectionTabBar}
-                      <ErrorBoundary feature="SQL Console">
+                      <ErrorBoundary
+                        feature="SQL Console"
+                        resetKeys={[activeConnectionId]}
+                      >
                         <SqlConsole
                           activeConnectionId={activeConnectionId}
                           onEditorContextChange={setSqlConsoleEditorContext}
@@ -1230,7 +1236,10 @@ function IndexInner() {
                       />
                     </ErrorBoundary>
                   ) : (
-                    <ErrorBoundary feature="SQL Console">
+                    <ErrorBoundary
+                      feature="SQL Console"
+                      resetKeys={[activeConnectionId]}
+                    >
                       <SqlConsole
                         activeConnectionId={activeConnectionId}
                         onEditorContextChange={setSqlConsoleEditorContext}

--- a/packages/studio/src/shared/ui/error-boundary.test.tsx
+++ b/packages/studio/src/shared/ui/error-boundary.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ErrorBoundary } from './error-boundary'
+
+type Props = {
+	shouldThrow: boolean
+}
+
+function Bomb({ shouldThrow }: Props) {
+	if (shouldThrow) {
+		throw new Error('boom')
+	}
+	return <div>recovered</div>
+}
+
+describe('ErrorBoundary resetKeys', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => undefined)
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('renders the fallback when a child throws', () => {
+		render(
+			<ErrorBoundary feature="Test" resetKeys={['table-a']}>
+				<Bomb shouldThrow />
+			</ErrorBoundary>
+		)
+		expect(screen.getByText(/Something Went Wrong/i)).toBeInTheDocument()
+	})
+
+	it('clears the fallback when a reset key changes', () => {
+		const { rerender } = render(
+			<ErrorBoundary feature="Test" resetKeys={['table-a']}>
+				<Bomb shouldThrow />
+			</ErrorBoundary>
+		)
+		expect(screen.getByText(/Something Went Wrong/i)).toBeInTheDocument()
+
+		rerender(
+			<ErrorBoundary feature="Test" resetKeys={['table-b']}>
+				<Bomb shouldThrow={false} />
+			</ErrorBoundary>
+		)
+		expect(screen.getByText('recovered')).toBeInTheDocument()
+	})
+
+	it('keeps the fallback when reset keys are unchanged', () => {
+		const { rerender } = render(
+			<ErrorBoundary feature="Test" resetKeys={['table-a']}>
+				<Bomb shouldThrow />
+			</ErrorBoundary>
+		)
+
+		rerender(
+			<ErrorBoundary feature="Test" resetKeys={['table-a']}>
+				<Bomb shouldThrow={false} />
+			</ErrorBoundary>
+		)
+		expect(screen.getByText(/Something Went Wrong/i)).toBeInTheDocument()
+	})
+})

--- a/packages/studio/src/shared/ui/error-boundary.tsx
+++ b/packages/studio/src/shared/ui/error-boundary.tsx
@@ -1,11 +1,18 @@
 import { Component, ErrorInfo, ReactNode } from 'react'
 import { ErrorFallback } from './error-fallback'
 
+function resetKeysChanged(prev: unknown[] | undefined, next: unknown[] | undefined): boolean {
+	if (prev === next) return false
+	if (!prev || !next) return true
+	return prev.length !== next.length || prev.some((key, index) => !Object.is(key, next[index]))
+}
+
 type Props = {
 	children: ReactNode
 	fallback?: ReactNode
 	onReset?: () => void
 	feature?: string
+	resetKeys?: unknown[]
 }
 
 type State = {
@@ -27,6 +34,13 @@ export class ErrorBoundary extends Component<Props, State> {
 	componentDidCatch(error: Error, errorInfo: ErrorInfo) {
 		console.error('[ErrorBoundary] Caught error:', error)
 		console.error('[ErrorBoundary] Component stack:', errorInfo.componentStack)
+	}
+
+	componentDidUpdate(prevProps: Props) {
+		if (!this.state.hasError) return
+		if (resetKeysChanged(prevProps.resetKeys, this.props.resetKeys)) {
+			this.setState({ hasError: false, error: null })
+		}
 	}
 
 	handleReset() {


### PR DESCRIPTION
## What

Three small user-facing Studio bugs from the audit batch, one PR.

### #196 — grid paste writes `\r` and phantom rows
`parseClipboardGrid` (extracted from `pasteClipboardIntoGrid`, unit-tested) normalises `\r\n`/`\r` → `\n` and strips the single trailing newline, so CRLF clipboards no longer store carriage returns in cells and a trailing newline no longer overwrites the first column of the row below the target. Interior blank lines stay positional (skipped in the paste loop rather than filtered, so rows don't shift).

### #197 — cancel in one SQL tab kills other tabs
Real per-query cancellation end to end:
- Backend: `StatementManager::cancel_queries(&[QueryId])` cancels only the given statements (SQLite interrupt + Postgres CancelRequest signalling extracted into `signal_engine_cancel`, shared with the existing global cancel). New `cancel_queries` Tauri command, registered in both binding surfaces.
- Adapter: `executeQuery` gains an optional `onStarted(queryIds)` callback (the frontend already receives the ids from `start_query`); new `cancelQueries(queryIds)` adapter method (no-op in mock).
- SQL console: the shared `cancelledRef` boolean is gone; each tab tracks its own in-flight ids + cancelled flag. Cancel targets just that tab's statements (connection-wide fallback only if ids haven't arrived yet), and a cancelled query renders an explicit **"Query cancelled"** result instead of a silent blank panel.

### #199 — ErrorBoundary never resets
`ErrorBoundary` now accepts `resetKeys` (standard react-error-boundary contract, `componentDidUpdate` + `Object.is` comparison). Database Studio boundary resets on `[studioConnectionId, selectedTableId]`, both SQL Console boundaries on `[activeConnectionId]` — navigating away from a crashing table recovers the panel. The fallback already surfaces `error.message` under "Technical details". Test covers throw → reset-on-key-change → no-reset-when-unchanged.

## Verification
- `bun run test:desktop`: 99 files, 777 tests passed (includes the 3 new test files/cases).
- `cargo test --lib stmt_manager`: 5 passed, including new `cancel_queries_only_cancels_the_given_statements`.
- `tsc` clean for studio + desktop, `bun run lint` 0 errors, `cargo check` clean.

Closes #196, closes #197, closes #199

## Summary by Sourcery

Improve Studio UX by fixing grid paste newline handling, making SQL query cancellation tab-scoped, and allowing panels to recover after errors via resettable error boundaries.

New Features:
- Add per-tab SQL query cancellation that only targets the active tab’s statements and surfaces an explicit "Query cancelled" result.
- Introduce resettable ErrorBoundary support via reset keys so Database Studio and SQL Console recover when navigating away or changing connections.

Bug Fixes:
- Normalize clipboard line endings and drop trailing newlines when pasting into the data grid to avoid carriage returns in cells and phantom overwrite rows.
- Ensure cancelling a query in one SQL console tab no longer cancels or silences queries running in other tabs.

Enhancements:
- Refine backend statement management to support targeted query cancellation alongside the existing global cancel.
- Extend data adapter and bindings APIs to propagate statement IDs and support selective cancellation across Tauri and mock adapters.

Tests:
- Add unit tests for parseClipboardGrid to cover CRLF/CR handling, trailing newline behavior, and positional blank lines.
- Add ErrorBoundary tests validating resetKeys behavior for throw, reset-on-key-change, and no-reset-when-unchanged.
- Add a StatementManager test verifying cancel_queries only cancels the specified statements.