### PR TITLE
fix(rust): canonical identifier quoting — escape TRUNCATE/INSERT/UPDATE paths across all dialects

### DIFF
--- a/apps/desktop/src-tauri/src/database.rs
+++ b/apps/desktop/src-tauri/src/database.rs
@@ -5,6 +5,7 @@ pub mod d1;
 pub mod duckdb;
 pub mod duckdb_backend;
 pub mod duckdb_ipc;
+pub mod ident;
 pub mod libsql;
 pub mod mysql;
 pub mod posthog;

--- a/apps/desktop/src-tauri/src/database/adapter/grid_sql.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/grid_sql.rs
@@ -1,0 +1,116 @@
+//! Generated-SQL builders for the SQLite-family write adapters (SQLite,
+//! libSQL, Cloudflare D1). All three speak the same dialect: ANSI-quoted
+//! identifiers and `?` placeholders. Keeping the statement text in pure
+//! functions makes the generated SQL assertable without a live database.
+
+use crate::database::ident::quote_ansi;
+
+pub fn update_cell_sql(table: &str, column: &str, pk_column: &str) -> String {
+    format!(
+        "UPDATE {} SET {} = ? WHERE {} = ?",
+        quote_ansi(table),
+        quote_ansi(column),
+        quote_ansi(pk_column)
+    )
+}
+
+pub fn delete_rows_sql(table: &str, pk_column: &str, pk_count: usize) -> String {
+    let placeholders: Vec<&str> = (0..pk_count).map(|_| "?").collect();
+    format!(
+        "DELETE FROM {} WHERE {} IN ({})",
+        quote_ansi(table),
+        quote_ansi(pk_column),
+        placeholders.join(", ")
+    )
+}
+
+pub fn insert_row_sql<'a, I: ExactSizeIterator<Item = &'a str>>(table: &str, columns: I) -> String {
+    let count = columns.len();
+    let col_names: Vec<String> = columns.map(quote_ansi).collect();
+    let placeholders: Vec<&str> = (0..count).map(|_| "?").collect();
+    format!(
+        "INSERT INTO {} ({}) VALUES ({})",
+        quote_ansi(table),
+        col_names.join(", "),
+        placeholders.join(", ")
+    )
+}
+
+pub fn select_row_sql(table: &str, pk_column: &str) -> String {
+    format!(
+        "SELECT * FROM {} WHERE {} = ? LIMIT 1",
+        quote_ansi(table),
+        quote_ansi(pk_column)
+    )
+}
+
+pub fn select_blob_sql(table: &str, column: &str, pk_column: &str) -> String {
+    format!(
+        "SELECT {} FROM {} WHERE {} = ? LIMIT 1",
+        quote_ansi(column),
+        quote_ansi(table),
+        quote_ansi(pk_column)
+    )
+}
+
+/// SQLite has no `TRUNCATE`; an unfiltered `DELETE` is the equivalent.
+pub fn delete_all_sql(table: &str) -> String {
+    format!("DELETE FROM {}", quote_ansi(table))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_cell_quotes_all_identifiers() {
+        assert_eq!(
+            update_cell_sql("users", "name", "id"),
+            "UPDATE \"users\" SET \"name\" = ? WHERE \"id\" = ?"
+        );
+        assert_eq!(
+            update_cell_sql("we\"ird", "na\"me", "i\"d"),
+            "UPDATE \"we\"\"ird\" SET \"na\"\"me\" = ? WHERE \"i\"\"d\" = ?"
+        );
+    }
+
+    #[test]
+    fn delete_rows_builds_one_placeholder_per_pk() {
+        assert_eq!(
+            delete_rows_sql("users", "id", 3),
+            "DELETE FROM \"users\" WHERE \"id\" IN (?, ?, ?)"
+        );
+        assert_eq!(
+            delete_rows_sql("we\"ird", "id", 1),
+            "DELETE FROM \"we\"\"ird\" WHERE \"id\" IN (?)"
+        );
+    }
+
+    #[test]
+    fn insert_row_quotes_table_and_columns() {
+        assert_eq!(
+            insert_row_sql("users", ["a", "b\"b"].into_iter()),
+            "INSERT INTO \"users\" (\"a\", \"b\"\"b\") VALUES (?, ?)"
+        );
+    }
+
+    #[test]
+    fn select_builders_quote_identifiers() {
+        assert_eq!(
+            select_row_sql("t\"1", "id"),
+            "SELECT * FROM \"t\"\"1\" WHERE \"id\" = ? LIMIT 1"
+        );
+        assert_eq!(
+            select_blob_sql("t", "da\"ta", "id"),
+            "SELECT \"da\"\"ta\" FROM \"t\" WHERE \"id\" = ? LIMIT 1"
+        );
+    }
+
+    #[test]
+    fn delete_all_neutralizes_injection_shaped_table_name() {
+        assert_eq!(
+            delete_all_sql("x\";DROP TABLE users;--"),
+            "DELETE FROM \"x\"\";DROP TABLE users;--\""
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/database/adapter/mod.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/mod.rs
@@ -6,6 +6,7 @@
 //! - `watch` — live change monitoring per driver.
 
 pub mod duckdb_proxy;
+pub mod grid_sql;
 pub mod read;
 pub mod watch;
 pub mod write;

--- a/apps/desktop/src-tauri/src/database/adapter/watch.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/watch.rs
@@ -248,9 +248,7 @@ fn qualified_table(schema: Option<&str>, table: &str) -> String {
     }
 }
 
-fn quote_identifier(identifier: &str) -> String {
-    format!("\"{}\"", identifier.replace('"', "\"\""))
-}
+use crate::database::ident::quote_ansi as quote_identifier;
 
 fn qualified_mysql_table(schema: Option<&str>, table: &str) -> String {
     if let Some(schema) = schema {
@@ -264,9 +262,7 @@ fn qualified_mysql_table(schema: Option<&str>, table: &str) -> String {
     }
 }
 
-fn quote_mysql_identifier(identifier: &str) -> String {
-    format!("`{}`", identifier.replace('`', "``"))
-}
+use crate::database::ident::quote_mysql as quote_mysql_identifier;
 
 fn sqlite_value_to_json(value: ValueRef<'_>) -> serde_json::Value {
     match value {

--- a/apps/desktop/src-tauri/src/database/adapter/write_d1.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write_d1.rs
@@ -9,6 +9,7 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
+use super::grid_sql;
 use super::read::D1Adapter;
 use super::write::WriteAdapter;
 use crate::database::maintenance::{DumpResult, SoftDeleteResult, TruncateResult};
@@ -48,19 +49,7 @@ impl WriteAdapter for D1Adapter {
             });
         }
 
-        let col_names: String = row_data
-            .keys()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let placeholders: String = std::iter::repeat("?")
-            .take(row_data.len())
-            .collect::<Vec<_>>()
-            .join(", ");
-        let query = format!(
-            "INSERT INTO \"{}\" ({}) VALUES ({})",
-            table, col_names, placeholders
-        );
+        let query = grid_sql::insert_row_sql(&table, row_data.keys().map(String::as_str));
         let params: Vec<Value> = row_data.values().cloned().collect();
 
         let (_rows, changes) = run(self, &query, params).await?;
@@ -80,10 +69,7 @@ impl WriteAdapter for D1Adapter {
         column: String,
         new_value: serde_json::Value,
     ) -> Result<MutationResult, Error> {
-        let query = format!(
-            "UPDATE `{}` SET `{}` = ? WHERE `{}` = ?",
-            table, column, pk_column
-        );
+        let query = grid_sql::update_cell_sql(&table, &column, &pk_column);
         let (_rows, changes) = run(self, &query, vec![new_value, pk_value]).await?;
         Ok(MutationResult {
             success: changes > 0,
@@ -111,13 +97,7 @@ impl WriteAdapter for D1Adapter {
             });
         }
 
-        let placeholders: Vec<&str> = pk_values.iter().map(|_| "?").collect();
-        let query = format!(
-            "DELETE FROM `{}` WHERE `{}` IN ({})",
-            table,
-            pk_column,
-            placeholders.join(", ")
-        );
+        let query = grid_sql::delete_rows_sql(&table, &pk_column, pk_values.len());
         let (_rows, changes) = run(self, &query, pk_values).await?;
         Ok(MutationResult {
             success: changes > 0,
@@ -133,10 +113,7 @@ impl WriteAdapter for D1Adapter {
         pk_column: String,
         pk_value: serde_json::Value,
     ) -> Result<MutationResult, Error> {
-        let query = format!(
-            "SELECT * FROM \"{}\" WHERE \"{}\" = ? LIMIT 1",
-            table, pk_column
-        );
+        let query = grid_sql::select_row_sql(&table, &pk_column);
         let (rows, _changes) = run(self, &query, vec![pk_value]).await?;
         let row = rows.into_iter().next().ok_or_else(|| {
             Error::Any(anyhow::anyhow!(
@@ -168,7 +145,7 @@ impl WriteAdapter for D1Adapter {
         _cascade: Option<bool>,
     ) -> Result<TruncateResult, Error> {
         // SQLite/D1 has no TRUNCATE; an unfiltered DELETE is the equivalent.
-        let query = format!("DELETE FROM \"{}\"", table);
+        let query = grid_sql::delete_all_sql(&table);
         let (_rows, changes) = run(self, &query, Vec::new()).await?;
         Ok(TruncateResult {
             success: true,

--- a/apps/desktop/src-tauri/src/database/adapter/write_duckdb.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write_duckdb.rs
@@ -7,9 +7,7 @@ use crate::database::maintenance::{DumpResult, SoftDeleteResult, TruncateResult}
 use crate::database::services::mutation::MutationResult;
 use crate::Error;
 
-fn quote_ident(identifier: &str) -> String {
-    format!("\"{}\"", identifier.replace('"', "\"\""))
-}
+use crate::database::ident::quote_ansi as quote_ident;
 
 /// Error returned when a mutation is attempted against a read-only data-file
 /// source (a CSV/Parquet/JSON view).

--- a/apps/desktop/src-tauri/src/database/adapter/write_libsql.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write_libsql.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
 
+use super::grid_sql;
 use super::read::LibSqlAdapter;
 use super::write::WriteAdapter;
 use crate::database::adapter::DatabaseAdapter;
@@ -22,10 +23,7 @@ impl WriteAdapter for LibSqlAdapter {
         column: String,
         new_value: serde_json::Value,
     ) -> Result<MutationResult, Error> {
-        let query = format!(
-            "UPDATE `{}` SET `{}` = ? WHERE `{}` = ?",
-            table, column, pk_column
-        );
+        let query = grid_sql::update_cell_sql(&table, &column, &pk_column);
         let new_val = json_to_libsql_value(&new_value);
         let pk_val = json_to_libsql_value(&pk_value);
         let result = self
@@ -61,13 +59,7 @@ impl WriteAdapter for LibSqlAdapter {
             });
         }
 
-        let placeholders: Vec<&str> = pk_values.iter().map(|_| "?").collect();
-        let query = format!(
-            "DELETE FROM `{}` WHERE `{}` IN ({})",
-            table,
-            pk_column,
-            placeholders.join(", ")
-        );
+        let query = grid_sql::delete_rows_sql(&table, &pk_column, pk_values.len());
         let params: Vec<libsql::Value> = pk_values.iter().map(json_to_libsql_value).collect();
         let total_deleted = self
             .connection()
@@ -97,20 +89,7 @@ impl WriteAdapter for LibSqlAdapter {
             });
         }
 
-        let columns: Vec<&String> = row_data.keys().collect();
-        let col_names: String = columns
-            .iter()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let placeholders: String = std::iter::repeat("?")
-            .take(row_data.len())
-            .collect::<Vec<_>>()
-            .join(", ");
-        let query = format!(
-            "INSERT INTO \"{}\" ({}) VALUES ({})",
-            table, col_names, placeholders
-        );
+        let query = grid_sql::insert_row_sql(&table, row_data.keys().map(String::as_str));
         let params: Vec<libsql::Value> = row_data.values().map(json_to_libsql_value).collect();
 
         self.connection()
@@ -132,10 +111,7 @@ impl WriteAdapter for LibSqlAdapter {
         pk_column: String,
         pk_value: serde_json::Value,
     ) -> Result<MutationResult, Error> {
-        let query = format!(
-            "SELECT * FROM \"{}\" WHERE \"{}\" = ? LIMIT 1",
-            table, pk_column
-        );
+        let query = grid_sql::select_row_sql(&table, &pk_column);
         let params = vec![json_to_libsql_value(&pk_value)];
         let mut rows = self
             .connection()
@@ -182,10 +158,7 @@ impl WriteAdapter for LibSqlAdapter {
         pk_value: serde_json::Value,
         column: String,
     ) -> Result<Vec<u8>, Error> {
-        let query = format!(
-            "SELECT \"{}\" FROM \"{}\" WHERE \"{}\" = ? LIMIT 1",
-            column, table, pk_column
-        );
+        let query = grid_sql::select_blob_sql(&table, &column, &pk_column);
         let params = vec![json_to_libsql_value(&pk_value)];
         let mut rows = self
             .connection()

--- a/apps/desktop/src-tauri/src/database/adapter/write_mysql.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write_mysql.rs
@@ -19,15 +19,17 @@ impl WriteAdapter for MySqlAdapter {
     async fn update_cell(
         &self,
         table: String,
-        _schema: Option<String>,
+        schema: Option<String>,
         pk_column: String,
         pk_value: serde_json::Value,
         column: String,
         new_value: serde_json::Value,
     ) -> Result<MutationResult, Error> {
         let query = format!(
-            "UPDATE `{}` SET `{}` = ? WHERE `{}` = ?",
-            table, column, pk_column
+            "UPDATE {} SET {} = ? WHERE {} = ?",
+            mysql_qualified_table_name(&table, schema.as_deref()),
+            mysql_quote_identifier(&column),
+            mysql_quote_identifier(&pk_column)
         );
         let mut conn = self
             .pool()

--- a/apps/desktop/src-tauri/src/database/adapter/write_postgres.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write_postgres.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use super::read::PostgresAdapter;
 use super::write::WriteAdapter;
 use crate::database::adapter::DatabaseAdapter;
+use crate::database::ident::quote_ansi;
 use crate::database::maintenance;
 use crate::database::maintenance::{DumpResult, SoftDeleteResult, TruncateResult};
 use crate::database::services::mutation::{
@@ -28,13 +29,9 @@ impl WriteAdapter for PostgresAdapter {
         // infer $1 as that type and tokio-postgres fails with
         // "error serializing parameter" when the Rust value is a String.
         // Routing through text works for ints, timestamps, bools, uuids, ….
-        let query = format!(
-            "UPDATE {} SET \"{}\" = $1::text::{} WHERE \"{}\" = $2",
-            qualified_table_name(&table, schema.as_deref()),
-            column,
-            pg_column_type(self.client(), &table, schema.as_deref(), &column).await?,
-            pk_column
-        );
+        let col_type = pg_column_type(self.client(), &table, schema.as_deref(), &column).await?;
+        let query =
+            build_update_cell_sql(&table, schema.as_deref(), &column, &col_type, &pk_column);
         let new_val_text: Option<String> = match &new_value {
             serde_json::Value::Null => None,
             serde_json::Value::String(s) => Some(s.clone()),
@@ -74,19 +71,7 @@ impl WriteAdapter for PostgresAdapter {
             });
         }
 
-        let schema_prefix = schema
-            .as_ref()
-            .map(|s| format!("\"{}\".", s))
-            .unwrap_or_default();
-
-        let placeholders: Vec<String> = (1..=pk_values.len()).map(|i| format!("${}", i)).collect();
-        let query = format!(
-            "DELETE FROM {}\"{}\" WHERE \"{}\" IN ({})",
-            schema_prefix,
-            table,
-            pk_column,
-            placeholders.join(", ")
-        );
+        let query = build_delete_rows_sql(&table, schema.as_deref(), &pk_column, pk_values.len());
 
         let params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> =
             pk_values.iter().map(|v| json_to_pg_param(v)).collect();
@@ -118,11 +103,6 @@ impl WriteAdapter for PostgresAdapter {
             });
         }
 
-        let schema_prefix = schema
-            .as_ref()
-            .map(|s| format!("\"{}\".", s))
-            .unwrap_or_default();
-
         // Bind every value as text and let Postgres parse it into the column's
         // type via `$n::text::<type>` — same rationale as update_cell: the UI
         // sends edits as strings, and a string bound straight to a typed param
@@ -134,7 +114,7 @@ impl WriteAdapter for PostgresAdapter {
             Vec::with_capacity(row_data.len());
         for (idx, (col, value)) in row_data.iter().enumerate() {
             let col_type = pg_column_type(self.client(), &table, schema.as_deref(), col).await?;
-            col_names_vec.push(format!("\"{}\"", col));
+            col_names_vec.push(quote_ansi(col));
             placeholders_vec.push(format!("${}::text::{}", idx + 1, col_type));
             let text: Option<String> = match value {
                 serde_json::Value::Null => None,
@@ -144,13 +124,8 @@ impl WriteAdapter for PostgresAdapter {
             params.push(Box::new(text));
         }
 
-        let query = format!(
-            "INSERT INTO {}\"{}\" ({}) VALUES ({})",
-            schema_prefix,
-            table,
-            col_names_vec.join(", "),
-            placeholders_vec.join(", ")
-        );
+        let query =
+            build_insert_row_sql(&table, schema.as_deref(), &col_names_vec, &placeholders_vec);
 
         let params_ref: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
             .iter()
@@ -173,9 +148,9 @@ impl WriteAdapter for PostgresAdapter {
         pk_value: serde_json::Value,
     ) -> Result<MutationResult, Error> {
         let query = format!(
-            "SELECT * FROM {} WHERE \"{}\" = $1 LIMIT 1",
+            "SELECT * FROM {} WHERE {} = $1 LIMIT 1",
             qualified_table_name(&table, schema.as_deref()),
-            pk_column
+            quote_ansi(&pk_column)
         );
         let pk_param = json_to_pg_param(&pk_value);
         let row = self
@@ -215,10 +190,10 @@ impl WriteAdapter for PostgresAdapter {
         column: String,
     ) -> Result<Vec<u8>, Error> {
         let query = format!(
-            "SELECT \"{}\" FROM {} WHERE \"{}\" = $1 LIMIT 1",
-            column,
+            "SELECT {} FROM {} WHERE {} = $1 LIMIT 1",
+            quote_ansi(&column),
             qualified_table_name(&table, schema.as_deref()),
-            pk_column
+            quote_ansi(&pk_column)
         );
         let pk_param = json_to_pg_param(&pk_value);
         let row = self
@@ -346,6 +321,51 @@ impl WriteAdapter for PostgresAdapter {
     }
 }
 
+fn build_update_cell_sql(
+    table: &str,
+    schema: Option<&str>,
+    column: &str,
+    col_type: &str,
+    pk_column: &str,
+) -> String {
+    format!(
+        "UPDATE {} SET {} = $1::text::{} WHERE {} = $2",
+        qualified_table_name(table, schema),
+        quote_ansi(column),
+        col_type,
+        quote_ansi(pk_column)
+    )
+}
+
+fn build_delete_rows_sql(
+    table: &str,
+    schema: Option<&str>,
+    pk_column: &str,
+    pk_count: usize,
+) -> String {
+    let placeholders: Vec<String> = (1..=pk_count).map(|i| format!("${}", i)).collect();
+    format!(
+        "DELETE FROM {} WHERE {} IN ({})",
+        qualified_table_name(table, schema),
+        quote_ansi(pk_column),
+        placeholders.join(", ")
+    )
+}
+
+fn build_insert_row_sql(
+    table: &str,
+    schema: Option<&str>,
+    quoted_columns: &[String],
+    placeholders: &[String],
+) -> String {
+    format!(
+        "INSERT INTO {} ({}) VALUES ({})",
+        qualified_table_name(table, schema),
+        quoted_columns.join(", "),
+        placeholders.join(", ")
+    )
+}
+
 async fn pg_column_type(
     client: &tokio_postgres::Client,
     table: &str,
@@ -375,4 +395,43 @@ async fn pg_column_type(
     };
 
     Ok(row.get::<_, String>(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_cell_sql_quotes_identifiers_and_casts_via_text() {
+        assert_eq!(
+            build_update_cell_sql("users", Some("public"), "name", "text", "id"),
+            "UPDATE \"public\".\"users\" SET \"name\" = $1::text::text WHERE \"id\" = $2"
+        );
+        assert_eq!(
+            build_update_cell_sql("we\"ird", None, "na\"me", "int4", "i\"d"),
+            "UPDATE \"we\"\"ird\" SET \"na\"\"me\" = $1::text::int4 WHERE \"i\"\"d\" = $2"
+        );
+    }
+
+    #[test]
+    fn delete_rows_sql_numbers_placeholders_and_quotes_identifiers() {
+        assert_eq!(
+            build_delete_rows_sql("users", None, "id", 3),
+            "DELETE FROM \"users\" WHERE \"id\" IN ($1, $2, $3)"
+        );
+        assert_eq!(
+            build_delete_rows_sql("t", Some("we\"ird"), "id", 1),
+            "DELETE FROM \"we\"\"ird\".\"t\" WHERE \"id\" IN ($1)"
+        );
+    }
+
+    #[test]
+    fn insert_row_sql_joins_prequoted_columns() {
+        let cols = vec![quote_ansi("a"), quote_ansi("b\"b")];
+        let placeholders = vec!["$1::text::text".to_string(), "$2::text::int4".to_string()];
+        assert_eq!(
+            build_insert_row_sql("users", Some("public"), &cols, &placeholders),
+            "INSERT INTO \"public\".\"users\" (\"a\", \"b\"\"b\") VALUES ($1::text::text, $2::text::int4)"
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/database/adapter/write_sqlite.rs
+++ b/apps/desktop/src-tauri/src/database/adapter/write_sqlite.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
 
+use super::grid_sql;
 use super::read::SqliteAdapter;
 use super::write::WriteAdapter;
 use crate::database::maintenance;
@@ -25,10 +26,7 @@ impl WriteAdapter for SqliteAdapter {
             .connection()
             .lock()
             .map_err(|_| Error::Internal("Mutex poisoned".into()))?;
-        let query = format!(
-            "UPDATE \"{}\" SET \"{}\" = ? WHERE \"{}\" = ?",
-            table, column, pk_column
-        );
+        let query = grid_sql::update_cell_sql(&table, &column, &pk_column);
         let new_val = json_to_sqlite_value(&new_value);
         let pk_val = json_to_sqlite_value(&pk_value);
         let result = conn.execute(
@@ -69,13 +67,7 @@ impl WriteAdapter for SqliteAdapter {
             .connection()
             .lock()
             .map_err(|_| Error::Internal("Mutex poisoned".into()))?;
-        let placeholders: Vec<&str> = pk_values.iter().map(|_| "?").collect();
-        let query = format!(
-            "DELETE FROM \"{}\" WHERE \"{}\" IN ({})",
-            table,
-            pk_column,
-            placeholders.join(", ")
-        );
+        let query = grid_sql::delete_rows_sql(&table, &pk_column, pk_values.len());
         let params: Vec<rusqlite::types::Value> =
             pk_values.iter().map(json_to_sqlite_value).collect();
         let params_ref: Vec<&dyn rusqlite::ToSql> =
@@ -107,20 +99,7 @@ impl WriteAdapter for SqliteAdapter {
             .connection()
             .lock()
             .map_err(|_| Error::Internal("Mutex poisoned".into()))?;
-        let columns: Vec<&String> = row_data.keys().collect();
-        let col_names: String = columns
-            .iter()
-            .map(|c| format!("\"{}\"", c))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let placeholders: String = std::iter::repeat("?")
-            .take(row_data.len())
-            .collect::<Vec<_>>()
-            .join(", ");
-        let query = format!(
-            "INSERT INTO \"{}\" ({}) VALUES ({})",
-            table, col_names, placeholders
-        );
+        let query = grid_sql::insert_row_sql(&table, row_data.keys().map(String::as_str));
         let params: Vec<rusqlite::types::Value> =
             row_data.values().map(json_to_sqlite_value).collect();
         let params_ref: Vec<&dyn rusqlite::ToSql> =
@@ -146,10 +125,7 @@ impl WriteAdapter for SqliteAdapter {
                 .connection()
                 .lock()
                 .map_err(|_| Error::Internal("Mutex poisoned".into()))?;
-            let query = format!(
-                "SELECT * FROM \"{}\" WHERE \"{}\" = ? LIMIT 1",
-                table, pk_column
-            );
+            let query = grid_sql::select_row_sql(&table, &pk_column);
             let pk_val = json_to_sqlite_value(&pk_value);
             let mut stmt = conn.prepare(&query)?;
             let column_names: Vec<String> = stmt
@@ -200,16 +176,11 @@ impl WriteAdapter for SqliteAdapter {
             .connection()
             .lock()
             .map_err(|_| Error::Internal("Mutex poisoned".into()))?;
-        let query = format!(
-            "SELECT \"{}\" FROM \"{}\" WHERE \"{}\" = ? LIMIT 1",
-            column, table, pk_column
-        );
+        let query = grid_sql::select_blob_sql(&table, &column, &pk_column);
         let pk_val = json_to_sqlite_value(&pk_value);
-        let bytes = conn.query_row(
-            &query,
-            [&pk_val as &dyn rusqlite::ToSql],
-            |row| row.get::<_, Option<Vec<u8>>>(0),
-        );
+        let bytes = conn.query_row(&query, [&pk_val as &dyn rusqlite::ToSql], |row| {
+            row.get::<_, Option<Vec<u8>>>(0)
+        });
         match bytes {
             Ok(Some(b)) => Ok(b),
             Ok(None) => Ok(Vec::new()),

--- a/apps/desktop/src-tauri/src/database/duckdb/import_files.rs
+++ b/apps/desktop/src-tauri/src/database/duckdb/import_files.rs
@@ -39,9 +39,7 @@ pub struct FailedDuckDbImport {
 }
 
 #[cfg(feature = "duckdb-engine")]
-fn quote_ident(name: &str) -> String {
-    format!("\"{}\"", name.replace('"', "\"\""))
-}
+use crate::database::ident::quote_ansi as quote_ident;
 
 #[cfg(feature = "duckdb-engine")]
 fn resolve_table_name(base: &str, taken: &HashSet<String>) -> String {

--- a/apps/desktop/src-tauri/src/database/duckdb/save_session.rs
+++ b/apps/desktop/src-tauri/src/database/duckdb/save_session.rs
@@ -80,9 +80,7 @@ fn escape_sql_string(value: &str) -> String {
 }
 
 #[cfg(feature = "duckdb-engine")]
-fn quote_ident(name: &str) -> String {
-    format!("\"{}\"", name.replace('"', "\"\""))
-}
+use crate::database::ident::quote_ansi as quote_ident;
 
 #[cfg(feature = "duckdb-engine")]
 fn resolve_table_name(base: &str, taken: &HashSet<String>) -> String {

--- a/apps/desktop/src-tauri/src/database/ident.rs
+++ b/apps/desktop/src-tauri/src/database/ident.rs
@@ -1,0 +1,103 @@
+//! Canonical SQL identifier quoting.
+//!
+//! Every place that interpolates a runtime identifier (table, schema, column)
+//! into generated SQL must go through these helpers. Identifiers arrive from
+//! live schema introspection and from the webview, so names containing the
+//! quote character itself (legal in every supported engine) must round-trip,
+//! and a malicious name must never break out of its quoted position.
+//!
+//! Two styles cover all supported engines:
+//! - ANSI double quotes: Postgres, CockroachDB, SQLite, libSQL, D1, DuckDB.
+//! - Backticks: MySQL, MariaDB.
+
+/// Quotes an identifier with ANSI double quotes, doubling embedded quotes.
+pub fn quote_ansi(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+/// Quotes an identifier with MySQL backticks, doubling embedded backticks.
+pub fn quote_mysql(identifier: &str) -> String {
+    format!("`{}`", identifier.replace('`', "``"))
+}
+
+/// `"schema"."table"` (or just `"table"`) in ANSI style.
+pub fn qualified_ansi(schema: Option<&str>, table: &str) -> String {
+    match schema {
+        Some(schema) if !schema.is_empty() => {
+            format!("{}.{}", quote_ansi(schema), quote_ansi(table))
+        }
+        _ => quote_ansi(table),
+    }
+}
+
+/// `` `schema`.`table` `` (or just `` `table` ``) in MySQL style.
+pub fn qualified_mysql(schema: Option<&str>, table: &str) -> String {
+    match schema {
+        Some(schema) if !schema.is_empty() => {
+            format!("{}.{}", quote_mysql(schema), quote_mysql(table))
+        }
+        _ => quote_mysql(table),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ansi_plain() {
+        assert_eq!(quote_ansi("users"), "\"users\"");
+    }
+
+    #[test]
+    fn ansi_doubles_embedded_quote() {
+        assert_eq!(quote_ansi("we\"ird"), "\"we\"\"ird\"");
+    }
+
+    #[test]
+    fn ansi_neutralizes_injection_shaped_name() {
+        let quoted = quote_ansi("x\");DROP TABLE users;--");
+        assert_eq!(quoted, "\"x\"\");DROP TABLE users;--\"");
+        // The interior stays inside one quoted identifier: every interior `"`
+        // is doubled, so the only unpaired quotes are the outer delimiters.
+        let interior = &quoted[1..quoted.len() - 1];
+        assert_eq!(interior.matches('"').count() % 2, 0);
+    }
+
+    #[test]
+    fn mysql_plain() {
+        assert_eq!(quote_mysql("users"), "`users`");
+    }
+
+    #[test]
+    fn mysql_doubles_embedded_backtick() {
+        assert_eq!(quote_mysql("we`ird"), "`we``ird`");
+    }
+
+    #[test]
+    fn mysql_neutralizes_injection_shaped_name() {
+        let quoted = quote_mysql("x`;DROP TABLE users;--");
+        assert_eq!(quoted, "`x``;DROP TABLE users;--`");
+    }
+
+    #[test]
+    fn qualified_ansi_with_and_without_schema() {
+        assert_eq!(
+            qualified_ansi(Some("public"), "users"),
+            "\"public\".\"users\""
+        );
+        assert_eq!(qualified_ansi(None, "users"), "\"users\"");
+        assert_eq!(qualified_ansi(Some(""), "users"), "\"users\"");
+        assert_eq!(
+            qualified_ansi(Some("we\"ird"), "ta\"ble"),
+            "\"we\"\"ird\".\"ta\"\"ble\""
+        );
+    }
+
+    #[test]
+    fn qualified_mysql_with_and_without_schema() {
+        assert_eq!(qualified_mysql(Some("app"), "users"), "`app`.`users`");
+        assert_eq!(qualified_mysql(None, "users"), "`users`");
+        assert_eq!(qualified_mysql(Some("a`pp"), "us`ers"), "`a``pp`.`us``ers`");
+    }
+}

--- a/apps/desktop/src-tauri/src/database/live_monitor.rs
+++ b/apps/desktop/src-tauri/src/database/live_monitor.rs
@@ -980,9 +980,7 @@ fn mysql_qualified_table_name(schema: Option<&str>, table: &str) -> String {
     }
 }
 
-fn quote_mysql_identifier(identifier: &str) -> String {
-    format!("`{}`", identifier.replace('`', "``"))
-}
+use crate::database::ident::quote_mysql as quote_mysql_identifier;
 
 fn mysql_value_to_json(value: MySqlValue) -> serde_json::Value {
     match value {
@@ -1325,9 +1323,7 @@ fn split_table_reference(table_name: &str) -> Result<(Option<String>, String), E
     }
 }
 
-fn quote_identifier(identifier: &str) -> String {
-    format!("\"{}\"", identifier.replace('"', "\"\""))
-}
+use crate::database::ident::quote_ansi as quote_identifier;
 
 fn quote_table_reference(table_name: &str) -> Result<String, Error> {
     let (schema, table) = split_table_reference(table_name)?;

--- a/apps/desktop/src-tauri/src/database/maintenance.rs
+++ b/apps/desktop/src-tauri/src/database/maintenance.rs
@@ -81,9 +81,7 @@ pub async fn soft_delete_postgres(
         });
     }
 
-    let schema_prefix = schema_name
-        .map(|s| format!("\"{}\".", s))
-        .unwrap_or_default();
+    let qualified_table = crate::database::ident::qualified_ansi(schema_name, table_name);
 
     // Build parameterized query
     let placeholders: Vec<String> = (1..=primary_key_values.len())
@@ -91,9 +89,11 @@ pub async fn soft_delete_postgres(
         .collect();
 
     let query = format!(
-        "UPDATE {}\"{table_name}\" SET \"{soft_delete_column}\" = NOW() WHERE \"{primary_key_column}\" IN ({}) AND \"{soft_delete_column}\" IS NULL",
-        schema_prefix,
-        placeholders.join(", ")
+        "UPDATE {} SET {sd} = NOW() WHERE {pk} IN ({}) AND {sd} IS NULL",
+        qualified_table,
+        placeholders.join(", "),
+        sd = quote_ansi(soft_delete_column),
+        pk = quote_ansi(primary_key_column),
     );
 
     // Convert values to params
@@ -239,17 +239,17 @@ pub async fn undo_soft_delete_postgres(
         return Ok(0);
     }
 
-    let schema_prefix = schema_name
-        .map(|s| format!("\"{}\".", s))
-        .unwrap_or_default();
+    let qualified_table = crate::database::ident::qualified_ansi(schema_name, table_name);
 
     let placeholders: Vec<String> = (1..=primary_key_values.len())
         .map(|i| format!("${}", i))
         .collect();
 
     let query = format!(
-        "UPDATE {}\"{table_name}\" SET \"{soft_delete_column}\" = NULL WHERE \"{primary_key_column}\" IN ({})",
-        schema_prefix,
+        "UPDATE {} SET {} = NULL WHERE {} IN ({})",
+        qualified_table,
+        quote_ansi(soft_delete_column),
+        quote_ansi(primary_key_column),
         placeholders.join(", ")
     );
 
@@ -281,24 +281,19 @@ pub async fn truncate_table_postgres(
     schema_name: Option<&str>,
     cascade: bool,
 ) -> Result<TruncateResult, Error> {
-    let schema_prefix = schema_name
-        .map(|s| format!("\"{}\".", s))
-        .unwrap_or_default();
+    let qualified_table = crate::database::ident::qualified_ansi(schema_name, table_name);
 
     let cascade_clause = if cascade { " CASCADE" } else { "" };
 
     // Get row count before truncate
-    let count_query = format!("SELECT COUNT(*) FROM {}\"{}\"", schema_prefix, table_name);
+    let count_query = format!("SELECT COUNT(*) FROM {}", qualified_table);
     let row_count: i64 = client
         .query_one(&count_query, &[])
         .await
         .map(|r| r.get(0))
         .unwrap_or(0);
 
-    let query = format!(
-        "TRUNCATE TABLE {}\"{}\"{}",
-        schema_prefix, table_name, cascade_clause
-    );
+    let query = format!("TRUNCATE TABLE {}{}", qualified_table, cascade_clause);
 
     client
         .execute(&query, &[])
@@ -324,13 +319,13 @@ pub fn truncate_table_sqlite(
     // Get row count before delete
     let row_count: i64 = conn
         .query_row(
-            &format!("SELECT COUNT(*) FROM \"{}\"", table_name),
+            &format!("SELECT COUNT(*) FROM {}", quote_ansi(table_name)),
             [],
             |row| row.get(0),
         )
         .unwrap_or(0);
 
-    conn.execute(&format!("DELETE FROM \"{}\"", table_name), [])
+    conn.execute(&format!("DELETE FROM {}", quote_ansi(table_name)), [])
         .map_err(|e| Error::Any(anyhow::anyhow!("Truncate failed: {}", e)))?;
 
     // Reset autoincrement counter
@@ -403,12 +398,11 @@ pub async fn soft_delete_libsql(
     let now = chrono::Utc::now().timestamp();
 
     let query = format!(
-        "UPDATE \"{}\" SET \"{}\" = ? WHERE \"{}\" IN ({}) AND \"{}\" IS NULL",
-        table_name,
-        soft_delete_column,
-        primary_key_column,
+        "UPDATE {} SET {sd} = ? WHERE {pk} IN ({}) AND {sd} IS NULL",
+        quote_ansi(table_name),
         placeholders.join(", "),
-        soft_delete_column
+        sd = quote_ansi(soft_delete_column),
+        pk = quote_ansi(primary_key_column),
     );
 
     let mut params: Vec<libsql::Value> = vec![libsql::Value::Integer(now)];
@@ -447,7 +441,7 @@ pub async fn truncate_table_libsql(
     conn: &libsql::Connection,
     table_name: &str,
 ) -> Result<TruncateResult, Error> {
-    let count_query = format!("SELECT COUNT(*) FROM \"{}\"", table_name);
+    let count_query = format!("SELECT COUNT(*) FROM {}", quote_ansi(table_name));
     let mut rows = conn
         .query(&count_query, ())
         .await
@@ -459,7 +453,7 @@ pub async fn truncate_table_libsql(
         0
     };
 
-    conn.execute(&format!("DELETE FROM \"{}\"", table_name), ())
+    conn.execute(&format!("DELETE FROM {}", quote_ansi(table_name)), ())
         .await
         .map_err(|e| Error::Any(anyhow::anyhow!("Truncate failed: {}", e)))?;
 
@@ -512,7 +506,7 @@ pub async fn truncate_database_postgres(
     // Truncate all tables at once with CASCADE
     let table_list = tables
         .iter()
-        .map(|t| format!("\"{}\".\"{}\"", schema, t))
+        .map(|t| crate::database::ident::qualified_ansi(Some(schema), t))
         .collect::<Vec<_>>()
         .join(", ");
 
@@ -562,7 +556,10 @@ pub async fn dump_database_postgres(
             .map_err(|e| Error::Any(anyhow::anyhow!("Failed to write to dump file: {}", e)))?;
 
         // Export table data as INSERT statements
-        let query = format!("SELECT * FROM \"{}\".\"{}\"", table.schema, table.name);
+        let query = format!(
+            "SELECT * FROM {}",
+            crate::database::ident::qualified_ansi(Some(&table.schema), &table.name)
+        );
 
         let rows = client.query(&query, &[]).await.unwrap_or_default();
         let columns: Vec<String> = table.columns.iter().map(|c| c.name.clone()).collect();
@@ -576,12 +573,11 @@ pub async fn dump_database_postgres(
 
             writeln!(
                 file,
-                "INSERT INTO \"{}\".\"{}\" ({}) VALUES ({});",
-                table.schema,
-                table.name,
+                "INSERT INTO {} ({}) VALUES ({});",
+                crate::database::ident::qualified_ansi(Some(&table.schema), &table.name),
                 columns
                     .iter()
-                    .map(|c| format!("\"{}\"", c))
+                    .map(|c| quote_ansi(c))
                     .collect::<Vec<_>>()
                     .join(", "),
                 values.join(", ")
@@ -690,7 +686,7 @@ pub async fn dump_database_libsql(
         writeln!(file, "\n-- Table: {}", table.name)
             .map_err(|e| Error::Any(anyhow::anyhow!("Failed to write to dump file: {}", e)))?;
 
-        let query = format!("SELECT * FROM \"{}\"", table.name);
+        let query = format!("SELECT * FROM {}", quote_ansi(&table.name));
         let mut rows = conn.query(&query, ()).await.map_err(|e| {
             Error::Any(anyhow::anyhow!(
                 "Failed to query table {}: {}",
@@ -710,11 +706,11 @@ pub async fn dump_database_libsql(
 
             writeln!(
                 file,
-                "INSERT INTO \"{}\" ({}) VALUES ({});",
-                table.name,
+                "INSERT INTO {} ({}) VALUES ({});",
+                quote_ansi(&table.name),
                 columns
                     .iter()
-                    .map(|c| format!("\"{}\"", c))
+                    .map(|c| quote_ansi(c))
                     .collect::<Vec<_>>()
                     .join(", "),
                 values.join(", ")
@@ -840,9 +836,8 @@ pub async fn dump_database_mysql(
     })
 }
 
-fn mysql_quote_identifier(identifier: &str) -> String {
-    format!("`{}`", identifier.replace('`', "``"))
-}
+use crate::database::ident::quote_ansi;
+use crate::database::ident::quote_mysql as mysql_quote_identifier;
 
 fn mysql_qualified_table_name(table_name: &str, schema_name: Option<&str>) -> String {
     match schema_name {

--- a/apps/desktop/src-tauri/src/database/postgres/schema.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/schema.rs
@@ -350,9 +350,7 @@ async fn exact_row_count(client: &Client, schema: &str, table: &str) -> Result<u
     Ok(0)
 }
 
-fn quote_identifier(identifier: &str) -> String {
-    format!("\"{}\"", identifier.replace('"', "\"\""))
-}
+use crate::database::ident::quote_ansi as quote_identifier;
 
 /// Extract the allowed-value list from a single-column `CHECK` constraint
 /// definition as returned by `pg_get_constraintdef`.

--- a/apps/desktop/src-tauri/src/database/services/mutation.rs
+++ b/apps/desktop/src-tauri/src/database/services/mutation.rs
@@ -199,15 +199,14 @@ impl<'a> MutationService<'a> {
 
         let (query, db_type) = match &client {
             DatabaseClient::Postgres { .. } => {
-                let schema_prefix = schema_name
-                    .as_ref()
-                    .map(|s| format!("\"{}\".", s))
-                    .unwrap_or_default();
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
                     format!(
-                        "SELECT * FROM {}\"{}\"{}{}{}",
-                        schema_prefix, table_name, where_sql, order_sql, limit_clause
+                        "SELECT * FROM {}{}{}{}",
+                        crate::database::ident::qualified_ansi(schema_name.as_deref(), &table_name),
+                        where_sql,
+                        order_sql,
+                        limit_clause
                     ),
                     "postgres",
                 )
@@ -216,22 +215,24 @@ impl<'a> MutationService<'a> {
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
                     format!(
-                        "SELECT * FROM \"{}\"{}{}{}",
-                        table_name, where_sql, order_sql, limit_clause
+                        "SELECT * FROM {}{}{}{}",
+                        crate::database::ident::quote_ansi(&table_name),
+                        where_sql,
+                        order_sql,
+                        limit_clause
                     ),
                     "sqlite",
                 )
             }
             DatabaseClient::DuckDB { .. } => {
-                let schema_prefix = schema_name
-                    .as_ref()
-                    .map(|s| format!("\"{}\".", s))
-                    .unwrap_or_default();
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
                     format!(
-                        "SELECT * FROM {}\"{}\"{}{}{}",
-                        schema_prefix, table_name, where_sql, order_sql, limit_clause
+                        "SELECT * FROM {}{}{}{}",
+                        crate::database::ident::qualified_ansi(schema_name.as_deref(), &table_name),
+                        where_sql,
+                        order_sql,
+                        limit_clause
                     ),
                     "duckdb",
                 )
@@ -240,8 +241,11 @@ impl<'a> MutationService<'a> {
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
                     format!(
-                        "SELECT * FROM `{}`{}{}{}",
-                        table_name, where_sql, order_sql, limit_clause
+                        "SELECT * FROM {}{}{}{}",
+                        crate::database::ident::quote_ansi(&table_name),
+                        where_sql,
+                        order_sql,
+                        limit_clause
                     ),
                     "libsql",
                 )
@@ -250,8 +254,11 @@ impl<'a> MutationService<'a> {
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
                     format!(
-                        "SELECT * FROM `{}`{}{}{}",
-                        table_name, where_sql, order_sql, limit_clause
+                        "SELECT * FROM {}{}{}{}",
+                        crate::database::ident::quote_mysql(&table_name),
+                        where_sql,
+                        order_sql,
+                        limit_clause
                     ),
                     "mysql",
                 )
@@ -261,8 +268,11 @@ impl<'a> MutationService<'a> {
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
                     format!(
-                        "SELECT * FROM \"{}\"{}{}{}",
-                        table_name, where_sql, order_sql, limit_clause
+                        "SELECT * FROM {}{}{}{}",
+                        crate::database::ident::quote_ansi(&table_name),
+                        where_sql,
+                        order_sql,
+                        limit_clause
                     ),
                     "d1",
                 )
@@ -272,8 +282,11 @@ impl<'a> MutationService<'a> {
                 let limit_clause = limit.map(|l| format!(" LIMIT {}", l)).unwrap_or_default();
                 (
                     format!(
-                        "SELECT * FROM \"{}\"{}{}{}",
-                        table_name, where_sql, order_sql, limit_clause
+                        "SELECT * FROM {}{}{}{}",
+                        crate::database::ident::quote_ansi(&table_name),
+                        where_sql,
+                        order_sql,
+                        limit_clause
                     ),
                     "posthog",
                 )
@@ -307,21 +320,10 @@ impl<'a> MutationService<'a> {
             }
             ExportFormat::SqlInsert => {
                 let is_mysql = db_type == "mysql";
-                let schema_prefix = if is_mysql {
-                    schema_name
-                        .as_ref()
-                        .map(|s| format!("{}.", mysql_quote_identifier(s)))
-                        .unwrap_or_default()
-                } else {
-                    schema_name
-                        .as_ref()
-                        .map(|s| format!("\"{}\".", s))
-                        .unwrap_or_default()
-                };
                 let table_name_sql = if is_mysql {
-                    mysql_quote_identifier(&table_name)
+                    crate::database::ident::qualified_mysql(schema_name.as_deref(), &table_name)
                 } else {
-                    format!("\"{}\"", table_name)
+                    crate::database::ident::qualified_ansi(schema_name.as_deref(), &table_name)
                 };
                 let column_list = if is_mysql {
                     columns
@@ -332,7 +334,7 @@ impl<'a> MutationService<'a> {
                 } else {
                     columns
                         .iter()
-                        .map(|c| format!("\"{}\"", c))
+                        .map(|c| crate::database::ident::quote_ansi(c))
                         .collect::<Vec<_>>()
                         .join(", ")
                 };
@@ -341,8 +343,7 @@ impl<'a> MutationService<'a> {
                     .map(|row| {
                         let values: Vec<String> = row.iter().map(json_to_sql_literal).collect();
                         format!(
-                            "INSERT INTO {}{} ({}) VALUES ({});",
-                            schema_prefix,
+                            "INSERT INTO {} ({}) VALUES ({});",
                             table_name_sql,
                             column_list,
                             values.join(", ")
@@ -504,10 +505,7 @@ impl<'a> MutationService<'a> {
 
 // Helpers
 pub(crate) fn qualified_table_name(table_name: &str, schema_name: Option<&str>) -> String {
-    match schema_name {
-        Some(schema_name) => format!("\"{schema_name}\".\"{table_name}\""),
-        None => format!("\"{table_name}\""),
-    }
+    crate::database::ident::qualified_ansi(schema_name, table_name)
 }
 
 pub fn json_to_pg_param(
@@ -892,9 +890,7 @@ pub(crate) fn mysql_value_to_json(value: MySqlValue) -> serde_json::Value {
     }
 }
 
-pub(crate) fn mysql_quote_identifier(identifier: &str) -> String {
-    format!("`{}`", identifier.replace('`', "``"))
-}
+pub(crate) use crate::database::ident::quote_mysql as mysql_quote_identifier;
 
 pub(crate) fn mysql_qualified_table_name(table_name: &str, schema_name: Option<&str>) -> String {
     match schema_name {
@@ -921,6 +917,14 @@ mod tests {
         assert_eq!(
             qualified_table_name("users", Some("public")),
             "\"public\".\"users\""
+        );
+    }
+
+    #[test]
+    fn qualified_table_name_escapes_embedded_quotes() {
+        assert_eq!(
+            qualified_table_name("ta\"ble", Some("we\"ird")),
+            "\"we\"\"ird\".\"ta\"\"ble\""
         );
     }
 }

--- a/apps/desktop/src-tauri/src/database/services/schema_export.rs
+++ b/apps/desktop/src-tauri/src/database/services/schema_export.rs
@@ -327,7 +327,7 @@ impl SqlGenerator {
     }
 
     fn quote_identifier(&self, name: &str) -> String {
-        format!("\"{}\"", name)
+        crate::database::ident::quote_ansi(name)
     }
 }
 

--- a/apps/desktop/src-tauri/src/database/services/seeding.rs
+++ b/apps/desktop/src-tauri/src/database/services/seeding.rs
@@ -81,7 +81,7 @@ impl<'a> SeedingService<'a> {
             seed_target_for_client(&client, &table.name, &table.schema, schema_name.as_deref());
         let column_names: Vec<String> = seedable_columns
             .iter()
-            .map(|c| quote_identifier(&c.name, identifier_quote))
+            .map(|c| identifier_quote(&c.name))
             .collect();
         let column_list = column_names.join(", ");
 
@@ -226,10 +226,10 @@ fn seed_target_for_client(
     table_name: &str,
     table_schema: &str,
     requested_schema: Option<&str>,
-) -> (char, String) {
-    let quote = match client {
-        crate::database::types::DatabaseClient::MySQL { .. } => '`',
-        _ => '"',
+) -> (fn(&str) -> String, String) {
+    let quote: fn(&str) -> String = match client {
+        crate::database::types::DatabaseClient::MySQL { .. } => crate::database::ident::quote_mysql,
+        _ => crate::database::ident::quote_ansi,
     };
 
     let schema = requested_schema
@@ -248,19 +248,11 @@ fn seed_target_for_client(
         });
 
     let qualified_table = match schema {
-        Some(schema_name) => format!(
-            "{}.{}",
-            quote_identifier(&schema_name, quote),
-            quote_identifier(table_name, quote)
-        ),
-        None => quote_identifier(table_name, quote),
+        Some(schema_name) => format!("{}.{}", quote(&schema_name), quote(table_name)),
+        None => quote(table_name),
     };
 
     (quote, qualified_table)
-}
-
-fn quote_identifier(identifier: &str, quote: char) -> String {
-    format!("{quote}{identifier}{quote}")
 }
 
 fn sql_string_literal(value: &str) -> String {


### PR DESCRIPTION
## What

Fixes the divergent identifier quoting flagged in #210: nine duplicate helpers, several unescaped `format!("\"{}\"")` sites on real mutation paths (seeding INSERT, Postgres TRUNCATE, D1's `DELETE FROM` truncate emulation, every WriteAdapter's UPDATE/DELETE/INSERT), and backtick/double-quote mixing inside `write_libsql.rs` and `write_d1.rs`.

## How

- **`database::ident`** — the one canonical module: `quote_ansi`, `quote_mysql`, `qualified_ansi`, `qualified_mysql`. Tests cover plain names, embedded quote chars, schema qualification, and injection-shaped names (`x");DROP TABLE users;--`). The nine already-correct duplicates are deleted and re-pointed via `use … as` aliases (zero call-site churn, one implementation).
- **`adapter::grid_sql`** — shared pure statement builders for the SQLite family (SQLite, libSQL, D1): update/delete/insert/select-row/select-blob/delete-all, all ANSI-quoted, all with generated-SQL assertions. This is what ends the backtick/double-quote mixing.
- **write_postgres.rs** — statements extracted into pure `build_update_cell_sql` / `build_delete_rows_sql` / `build_insert_row_sql` with tests; every identifier escaped.
- **write_mysql.rs** — `update_cell` now uses the shared backtick helpers and no longer ignores the schema argument.
- **maintenance.rs** — Postgres truncate table/database (`TRUNCATE … CASCADE`), both soft-delete paths, SQLite/libSQL truncate emulation, and both dump generators now escape.
- **seeding.rs** — the unescaping `quote_identifier(name, quote_char)` is gone; `seed_target_for_client` returns a dialect quoting *function*, so a caller cannot pass an unescaped quote char by construction.
- **mutation.rs** — `qualified_table_name` escapes (new test for the embedded-quote case), fetch/export SQL escapes, libSQL fetch switched from backticks to ANSI quotes.

`grep -rn 'fn quote_' src` → `ident.rs` twice, plus the schema-export trait method which now delegates to `quote_ansi`.

## Verification
- `cargo test --lib`: 233 passed (14 new quoting/builder tests); the 2 pgtemp failures also fail on master locally (missing `initdb`).
- `cargo check` clean, `cargo check --features duckdb-engine` clean, no new clippy warnings in touched files, fmt diffs limited to pre-existing ones.
- Not run against live engines; per-dialect live coverage stays with #208.

Closes #210

## Summary by Sourcery

Centralize SQL identifier quoting and refactor mutation/truncate/dump paths across all dialects to use the shared helpers, ensuring consistent, safe identifier escaping.

Bug Fixes:
- Fix unsafe and inconsistent identifier quoting on INSERT/UPDATE/DELETE/TRUNCATE and seeding paths for Postgres, SQLite/libSQL/D1, MySQL, DuckDB, and related services.

Enhancements:
- Introduce a canonical ident module providing ANSI/backtick quoting and qualified table helpers used by all adapters and schema export.
- Add shared SQL statement builders for SQLite-family write adapters (SQLite, libSQL, D1) to unify generated SQL and make it easily testable.
- Refactor Postgres write adapter and mutation/export services to construct statements via dedicated builders and the canonical quoting helpers.
- Update MySQL write paths, live monitor, and watch adapters to rely on the shared MySQL quoting helpers instead of local implementations.

Tests:
- Add unit tests for the new ident helpers and grid SQL builders, including cases with embedded quote characters and injection-shaped names.
- Add tests for Postgres statement builders and qualified table name behavior to lock in quoting and placeholder conventions.