### PR TITLE
test(e2e): boot smoke test using the existing browser harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,33 @@ jobs:
             - name: Build desktop app
               working-directory: apps/desktop
               run: bun run build
+
+    boot-smoke:
+        name: Boot Smoke
+        needs: [test-typescript, lint, typecheck]
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
+            - name: Setup Bun
+              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+              with:
+                  bun-version: '1.3.14'
+
+            - name: Install dependencies
+              run: bun install
+
+            - name: Install Playwright Chromium
+              run: bunx playwright install --with-deps chromium
+
+            - name: Run boot smoke test
+              run: bun run --cwd packages/studio smoke
+
+            - name: Upload failure screenshot
+              if: failure()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: boot-smoke-failure
+                  path: packages/studio/smoke-artifacts/
+                  if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ dev-menu.config.ts
 
 # promo recorder output
 promo-out/
+smoke-artifacts/

--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "apps/desktop": {
       "name": "@dora/desktop",
-      "version": "0.35.1",
+      "version": "0.36.0",
       "dependencies": {
         "@dora/studio": "workspace:*",
         "@faker-js/faker": "^10.2.0",
@@ -207,6 +207,7 @@
         "zustand": "^5.0.10",
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -10,7 +10,8 @@
 	},
 	"scripts": {
 		"typecheck": "tsc --noEmit",
-		"test": "vitest run -c ../../vitest.config.ts"
+		"test": "vitest run -c ../../vitest.config.ts",
+		"smoke": "node smoke/boot-smoke.mjs"
 	},
 	"peerDependencies": {
 		"react": ">=18",
@@ -73,6 +74,7 @@
 		"@tauri-apps/plugin-updater": "^2.9.0"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.59.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",

--- a/packages/studio/smoke/boot-smoke.mjs
+++ b/packages/studio/smoke/boot-smoke.mjs
@@ -1,0 +1,178 @@
+/**
+ * Boot smoke test: launches Studio in a real browser against the mock data
+ * adapter (no Tauri) and fails on anything a blank-window regression would
+ * produce — an uncaught page error, a console.error, a missing table grid, or
+ * a SQL run that yields no results.
+ *
+ * Scenarios:
+ *   1. Database Studio mounts and the demo table grid renders rows.
+ *   2. The SQL console mounts Monaco, runs a query, and shows a result grid.
+ *
+ * Usage: node smoke/boot-smoke.mjs [--base <url>] [--headed]
+ * Without --base it starts `bun vite --port 1420 --strictPort` in apps/desktop
+ * itself and tears it down afterwards. On failure it writes a screenshot to
+ * smoke-artifacts/ and exits non-zero.
+ */
+import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const DIRNAME = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(DIRNAME, "../../..");
+const ARTIFACT_DIR = path.join(DIRNAME, "..", "smoke-artifacts");
+const PORT = 1420;
+const HEADED = process.argv.includes("--headed");
+const BASE = argFlag("base") || `http://localhost:${PORT}`;
+const CONNECTION = "demo-ecommerce-001";
+
+/**
+ * Console errors that do not indicate a broken boot. Keep this list short and
+ * documented — every entry is a hole in the smoke test.
+ */
+const CONSOLE_ERROR_ALLOWLIST = [
+  // Vite HMR websocket noise when the dev server restarts mid-run.
+  /WebSocket connection/i,
+];
+
+function argFlag(key) {
+  const i = process.argv.indexOf(`--${key}`);
+  return i >= 0 && process.argv[i + 1] && !process.argv[i + 1].startsWith("--")
+    ? process.argv[i + 1]
+    : null;
+}
+
+function log(...a) {
+  console.log("[smoke]", ...a);
+}
+
+async function waitForServer(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // Server not up yet; retry until the deadline.
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`dev server at ${url} did not respond within ${timeoutMs}ms`);
+}
+
+async function startDevServer() {
+  log(`starting vite dev server on port ${PORT}`);
+  const child = spawn("bun", ["vite", "--port", String(PORT), "--strictPort"], {
+    cwd: path.join(REPO_ROOT, "apps", "desktop"),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.on("data", () => {});
+  child.stderr.on("data", (chunk) => process.stderr.write(chunk));
+  await waitForServer(BASE, 60_000);
+  return child;
+}
+
+async function main() {
+  let devServer = null;
+  let serverWasRunning = true;
+  try {
+    await fetch(BASE);
+  } catch {
+    serverWasRunning = false;
+  }
+  if (!serverWasRunning) {
+    devServer = await startDevServer();
+  }
+
+  const browser = await chromium.launch({ headless: !HEADED });
+  const context = await browser.newContext({ viewport: { width: 1600, height: 900 } });
+  const page = await context.newPage();
+
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (error) => {
+    pageErrors.push(String(error));
+  });
+  page.on("console", (message) => {
+    if (message.type() !== "error") return;
+    const text = message.text();
+    if (CONSOLE_ERROR_ALLOWLIST.some((pattern) => pattern.test(text))) return;
+    consoleErrors.push(text);
+  });
+
+  await page.addInitScript(() => {
+    try {
+      sessionStorage.setItem("dora_demo_notice_dismissed", "true");
+      localStorage.setItem("dora_has_seen_scroll_hint", "true");
+    } catch {
+      // Storage unavailable; the demo notice will just be visible.
+    }
+  });
+
+  let failed = false;
+  try {
+    log("scenario 1: database studio mounts and the demo grid renders");
+    await page.goto(`${BASE}/?view=database-studio&connection=${CONNECTION}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForSelector('[data-cell-key="0:1"]', { timeout: 30_000 });
+    log("  grid rendered");
+
+    log("scenario 2: SQL console mounts Monaco and a query returns rows");
+    await page.goto(`${BASE}/?view=sql-console&connection=${CONNECTION}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForSelector(".monaco-editor", { timeout: 30_000 });
+    const editor = page.locator(".monaco-editor").first();
+    await editor.click();
+    await page.keyboard.press("Control+A");
+    await page.keyboard.press("Delete");
+    await page.keyboard.type("SELECT * FROM transactions LIMIT 5;");
+    await page.keyboard.press("Control+Enter");
+    await page.waitForFunction(
+      () => /TXN-/.test(document.body.textContent || ""),
+      null,
+      { timeout: 30_000 },
+    );
+    log("  query executed and results rendered");
+
+    if (pageErrors.length > 0 || consoleErrors.length > 0) {
+      failed = true;
+      for (const error of pageErrors) console.error("[smoke] page error:", error);
+      for (const error of consoleErrors) console.error("[smoke] console.error:", error);
+    }
+  } catch (error) {
+    failed = true;
+    console.error("[smoke] scenario failed:", error);
+    for (const err of pageErrors) console.error("[smoke] page error:", err);
+    for (const err of consoleErrors) console.error("[smoke] console.error:", err);
+  }
+
+  if (failed) {
+    mkdirSync(ARTIFACT_DIR, { recursive: true });
+    const screenshot = path.join(ARTIFACT_DIR, "boot-smoke-failure.png");
+    try {
+      await page.screenshot({ path: screenshot, fullPage: true });
+      console.error(`[smoke] screenshot written to ${screenshot}`);
+    } catch {
+      console.error("[smoke] could not capture a failure screenshot");
+    }
+  }
+
+  await context.close();
+  await browser.close();
+  if (devServer) {
+    devServer.kill("SIGTERM");
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+  log("boot smoke passed");
+}
+
+main().catch((error) => {
+  console.error("[smoke] fatal:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds the repo's first end-to-end check (#209): `packages/studio/smoke/boot-smoke.mjs`, reusing the browser harness pattern from `packages/promo/record-hero-flow.mjs` (plain browser, mock adapter, `localhost:1420`) instead of introducing a test framework.

Two scenarios:
1. **Boot**: Database Studio mounts and the demo table grid renders rows (`[data-cell-key]`).
2. **Editor**: the SQL console mounts Monaco, types and runs a `SELECT` against the mock adapter, and asserts result rows render — this exercises the editor mount, where the Monaco CSP/font class of regression lives.

Failure conditions: any uncaught page error, any `console.error` (short, documented allowlist — currently just Vite HMR websocket noise), or either scenario timing out. On failure it writes a full-page screenshot to `smoke-artifacts/` and exits non-zero.

The script starts `bun vite --port 1420 --strictPort` itself (and tears it down), or targets an already-running server / `--base <url>`.

## CI

New `boot-smoke` job after the TS gates: `bun install` → `bunx playwright install --with-deps chromium` → `bun run --cwd packages/studio smoke`, with the failure screenshot uploaded as an artifact. Local green run is ~30s end to end.

## Verification (the issue's "done when")
- ✅ Green run locally: grid renders, query executes, no console errors.
- ✅ Deliberately throwing from `Index.tsx` turns the run red (exit 1) with a failure screenshot.

Closes #209

## Summary by Sourcery

Add a browser-based boot smoke test for Database Studio and wire it into CI to catch blank-window and editor boot regressions.

New Features:
- Introduce a Playwright-powered boot smoke script that exercises Database Studio and the SQL console against the mock adapter.
- Add a npm script in the Studio package to run the boot smoke test locally.

Enhancements:
- Capture full-page screenshots to a dedicated smoke-artifacts directory on failures for easier debugging.
- Automatically start and stop the desktop Vite dev server when a base URL is not provided for the smoke run.

CI:
- Add a Boot Smoke CI job that installs Playwright Chromium, runs the Studio smoke test, and uploads failure screenshots as artifacts.

Tests:
- Add an end-to-end smoke test that validates Studio mounts correctly, the demo grid renders, and the SQL console can execute a query without page or console errors.