### PR TITLE
fix(studio): resolve SQL-console mutation PK from declared metadata, drop the 'id'-name guess

### DIFF
--- a/__tests__/apps/desktop/src/features/sql-console/mutation-primary-key.test.ts
+++ b/__tests__/apps/desktop/src/features/sql-console/mutation-primary-key.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+import { resolveMutationPrimaryKey } from '@/features/sql-console/mutation-primary-key'
+import type { TableInfo } from '@/features/sql-console/types'
+
+function makeColumn(name: string, primaryKey: boolean) {
+	return { name, type: 'integer', nullable: false, primaryKey }
+}
+
+function makeTable(
+	name: string,
+	columns: { name: string; primaryKey?: boolean }[],
+	schema?: string
+): TableInfo {
+	return {
+		name,
+		schema,
+		type: 'table',
+		rowCount: 0,
+		columns: columns.map(function (column) {
+			return { name: column.name, type: 'integer', primaryKey: column.primaryKey ?? false }
+		})
+	}
+}
+
+describe('resolveMutationPrimaryKey', function () {
+	it('uses a single declared primary key from the result column definitions', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'users',
+			resultColumns: ['user_id', 'name'],
+			columnDefinitions: [makeColumn('user_id', true), makeColumn('name', false)],
+			schemaTables: []
+		})
+		expect(resolution).toEqual({ kind: 'ok', name: 'user_id' })
+	})
+
+	it('disables mutations when there is no source table', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: undefined,
+			resultColumns: ['id'],
+			columnDefinitions: [],
+			schemaTables: []
+		})
+		expect(resolution.kind).toBe('disabled')
+	})
+
+	it('does NOT fall back to a column merely named "id"', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'staging_events',
+			resultColumns: ['id', 'payload'],
+			columnDefinitions: [makeColumn('id', false), makeColumn('payload', false)],
+			schemaTables: [
+				makeTable('staging_events', [{ name: 'id' }, { name: 'payload' }])
+			]
+		})
+		expect(resolution.kind).toBe('disabled')
+	})
+
+	it('resolves the primary key from the schema when the result carries no PK metadata', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'users',
+			resultColumns: ['id', 'name'],
+			columnDefinitions: [makeColumn('id', false), makeColumn('name', false)],
+			schemaTables: [makeTable('users', [{ name: 'id', primaryKey: true }, { name: 'name' }])]
+		})
+		expect(resolution).toEqual({ kind: 'ok', name: 'id' })
+	})
+
+	it('resolves a non-id primary key from the schema', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'users',
+			resultColumns: ['user_uuid', 'name'],
+			columnDefinitions: [],
+			schemaTables: [
+				makeTable('users', [{ name: 'user_uuid', primaryKey: true }, { name: 'name' }])
+			]
+		})
+		expect(resolution).toEqual({ kind: 'ok', name: 'user_uuid' })
+	})
+
+	it('matches schema-qualified source tables against the schema list', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'public.users',
+			resultColumns: ['id'],
+			columnDefinitions: [],
+			schemaTables: [makeTable('users', [{ name: 'id', primaryKey: true }], 'public')]
+		})
+		expect(resolution).toEqual({ kind: 'ok', name: 'id' })
+	})
+
+	it('does not match a table from a different schema', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'audit.users',
+			resultColumns: ['id'],
+			columnDefinitions: [],
+			schemaTables: [makeTable('users', [{ name: 'id', primaryKey: true }], 'public')]
+		})
+		expect(resolution.kind).toBe('disabled')
+	})
+
+	it('disables mutations for composite primary keys declared in the result', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'memberships',
+			resultColumns: ['user_id', 'team_id'],
+			columnDefinitions: [makeColumn('user_id', true), makeColumn('team_id', true)],
+			schemaTables: []
+		})
+		expect(resolution).toEqual({
+			kind: 'disabled',
+			reason: 'Composite primary keys are not yet supported for SQL result mutations.'
+		})
+	})
+
+	it('disables mutations for composite primary keys declared in the schema', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'memberships',
+			resultColumns: ['user_id', 'team_id'],
+			columnDefinitions: [],
+			schemaTables: [
+				makeTable('memberships', [
+					{ name: 'user_id', primaryKey: true },
+					{ name: 'team_id', primaryKey: true }
+				])
+			]
+		})
+		expect(resolution).toEqual({
+			kind: 'disabled',
+			reason: 'Composite primary keys are not yet supported for SQL result mutations.'
+		})
+	})
+
+	it('disables mutations when the primary key column is not in the result set', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'users',
+			resultColumns: ['name', 'email'],
+			columnDefinitions: [],
+			schemaTables: [makeTable('users', [{ name: 'id', primaryKey: true }, { name: 'name' }])]
+		})
+		expect(resolution.kind).toBe('disabled')
+		if (resolution.kind === 'disabled') {
+			expect(resolution.reason).toContain('"id"')
+		}
+	})
+
+	it('matches primary key names case-insensitively and returns the result spelling', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'Users',
+			resultColumns: ['ID', 'Name'],
+			columnDefinitions: [],
+			schemaTables: [makeTable('users', [{ name: 'id', primaryKey: true }, { name: 'name' }])]
+		})
+		expect(resolution).toEqual({ kind: 'ok', name: 'ID' })
+	})
+
+	it('disables mutations when the table is unknown to the schema', function () {
+		const resolution = resolveMutationPrimaryKey({
+			sourceTable: 'mystery_table',
+			resultColumns: ['id'],
+			columnDefinitions: [],
+			schemaTables: [makeTable('users', [{ name: 'id', primaryKey: true }])]
+		})
+		expect(resolution.kind).toBe('disabled')
+	})
+})

--- a/packages/studio/src/features/sql-console/components/sql-results.tsx
+++ b/packages/studio/src/features/sql-console/components/sql-results.tsx
@@ -42,7 +42,8 @@ import type { ResultChartConfig } from '@studio/features/result-charts/types'
 import { formatCellValue as renderCellValue } from '@studio/features/database-studio/components/data-grid/cell-value'
 import type { ColumnDefinition } from '@studio/features/database-studio/types'
 import { inferColumnDefinitions } from '../lib/infer-column-definitions'
-import { SqlQueryResult, ResultViewMode } from '../types'
+import { resolveMutationPrimaryKey } from '../mutation-primary-key'
+import { SqlQueryResult, ResultViewMode, TableInfo } from '../types'
 
 type Props = {
 	result: SqlQueryResult | null
@@ -56,6 +57,7 @@ type Props = {
 	onRefresh?: () => void
 	sourceTable?: string
 	query?: string
+	schemaTables?: TableInfo[]
 }
 
 type EditingCell = {
@@ -76,7 +78,8 @@ export function SqlResults({
 	showFilter,
 	onRefresh,
 	sourceTable,
-	query
+	query,
+	schemaTables
 }: Props) {
 	const asyncRowCount = useAsyncRowCount(
 		connectionId,
@@ -198,58 +201,35 @@ export function SqlResults({
 		return value
 	}
 
-	function getPrimaryKey() {
-		if (!result?.columnDefinitions) return null
-		const primaryKeys = result.columnDefinitions.filter(function (column) {
-			return column.primaryKey
+	const primaryKeyResolution = useMemo(() => {
+		if (!result) return null
+		return resolveMutationPrimaryKey({
+			sourceTable: result.sourceTable,
+			resultColumns: result.columns,
+			columnDefinitions: result.columnDefinitions,
+			schemaTables: schemaTables ?? []
 		})
-		if (primaryKeys.length !== 1) return null
-		return primaryKeys[0]
-	}
+	}, [result, schemaTables])
 
 	const mutationContext = useMemo(() => {
-		if (!result || !connectionId) return null
-
-		const primaryKey = getPrimaryKey()
-		const primaryKeyName =
-			primaryKey?.name || result.columns.find((column) => column.toLowerCase() === 'id')
-
-		if (!result.sourceTable || !primaryKeyName) {
-			return null
-		}
+		if (!result?.sourceTable || !connectionId) return null
+		if (primaryKeyResolution?.kind !== 'ok') return null
 
 		return {
 			tableName: result.sourceTable,
-			primaryKeyName
+			primaryKeyName: primaryKeyResolution.name
 		}
-	}, [connectionId, result])
+	}, [connectionId, result, primaryKeyResolution])
 
 	const mutationDisabledReason = useMemo(() => {
 		if (!result || !connectionId) {
 			return 'Connect to a database to enable row mutations.'
 		}
-
-		if (!result.sourceTable) {
-			return 'This result set is not tied to a single source table, so edit/delete is disabled.'
+		if (primaryKeyResolution?.kind === 'disabled') {
+			return primaryKeyResolution.reason
 		}
-
-		const primaryKeys = (result.columnDefinitions || []).filter(function (column) {
-			return column.primaryKey
-		})
-		if (primaryKeys.length > 1) {
-			return 'Composite primary keys are not yet supported for SQL result mutations.'
-		}
-
-		const primaryKey = getPrimaryKey()
-		const primaryKeyName =
-			primaryKey?.name || result.columns.find((column) => column.toLowerCase() === 'id')
-
-		if (!primaryKeyName) {
-			return 'No primary key metadata was found for this result set, so edit/delete is disabled.'
-		}
-
 		return null
-	}, [connectionId, result])
+	}, [connectionId, result, primaryKeyResolution])
 
 	function handleCellDoubleClick(
 		rowData: Record<string, unknown>,

--- a/packages/studio/src/features/sql-console/mutation-primary-key.ts
+++ b/packages/studio/src/features/sql-console/mutation-primary-key.ts
@@ -1,0 +1,92 @@
+import type { ColumnDefinition } from '@studio/features/database-studio/types'
+import type { TableInfo } from './types'
+
+export type MutationPrimaryKeyResolution =
+	| { kind: 'ok'; name: string }
+	| { kind: 'disabled'; reason: string }
+
+type ResolveArgs = {
+	sourceTable: string | undefined
+	resultColumns: string[]
+	columnDefinitions?: ColumnDefinition[]
+	schemaTables: TableInfo[]
+}
+
+const NO_SOURCE_TABLE_REASON =
+	'This result set is not tied to a single source table, so edit/delete is disabled.'
+const COMPOSITE_KEY_REASON =
+	'Composite primary keys are not yet supported for SQL result mutations.'
+const NO_PRIMARY_KEY_REASON =
+	'No primary key was found for this result set, so edit/delete is disabled.'
+
+/**
+ * Resolves which column is safe to use as the `WHERE` key for editing or
+ * deleting rows in a SQL-console result set. Only declared primary-key
+ * metadata is trusted — from the result's own column definitions, or from the
+ * loaded database schema for the query's source table. A column merely named
+ * `id` is never assumed to be unique: on tables without a real primary key
+ * that heuristic turns a single-cell edit into an update of every matching
+ * row.
+ */
+export function resolveMutationPrimaryKey(args: ResolveArgs): MutationPrimaryKeyResolution {
+	const { sourceTable, resultColumns, columnDefinitions, schemaTables } = args
+
+	if (!sourceTable) {
+		return { kind: 'disabled', reason: NO_SOURCE_TABLE_REASON }
+	}
+
+	const declaredKeys = (columnDefinitions ?? []).filter(function (column) {
+		return column.primaryKey
+	})
+	if (declaredKeys.length > 1) {
+		return { kind: 'disabled', reason: COMPOSITE_KEY_REASON }
+	}
+	if (declaredKeys.length === 1) {
+		return requireInResult(declaredKeys[0].name, resultColumns)
+	}
+
+	const table = findSchemaTable(sourceTable, schemaTables)
+	if (!table) {
+		return { kind: 'disabled', reason: NO_PRIMARY_KEY_REASON }
+	}
+
+	const schemaKeys = (table.columns ?? []).filter(function (column) {
+		return column.primaryKey
+	})
+	if (schemaKeys.length > 1) {
+		return { kind: 'disabled', reason: COMPOSITE_KEY_REASON }
+	}
+	if (schemaKeys.length === 0) {
+		return { kind: 'disabled', reason: NO_PRIMARY_KEY_REASON }
+	}
+
+	return requireInResult(schemaKeys[0].name, resultColumns)
+}
+
+function requireInResult(
+	primaryKeyName: string,
+	resultColumns: string[]
+): MutationPrimaryKeyResolution {
+	const match = resultColumns.find(function (column) {
+		return column.toLowerCase() === primaryKeyName.toLowerCase()
+	})
+	if (!match) {
+		return {
+			kind: 'disabled',
+			reason: `The primary key column "${primaryKeyName}" is not part of this result set, so edit/delete is disabled. Include it in the SELECT to enable mutations.`
+		}
+	}
+	return { kind: 'ok', name: match }
+}
+
+function findSchemaTable(sourceTable: string, schemaTables: TableInfo[]): TableInfo | undefined {
+	const separatorIndex = sourceTable.lastIndexOf('.')
+	const schemaPart = separatorIndex === -1 ? undefined : sourceTable.slice(0, separatorIndex)
+	const namePart = separatorIndex === -1 ? sourceTable : sourceTable.slice(separatorIndex + 1)
+
+	return schemaTables.find(function (table) {
+		if (table.name.toLowerCase() !== namePart.toLowerCase()) return false
+		if (!schemaPart) return true
+		return (table.schema ?? '').toLowerCase() === schemaPart.toLowerCase()
+	})
+}

--- a/packages/studio/src/features/sql-console/sql-console.tsx
+++ b/packages/studio/src/features/sql-console/sql-console.tsx
@@ -1320,6 +1320,7 @@ function SqlConsoleInner({
                     showFilter={showFilter}
                     onRefresh={() => handleExecute()}
                     query={mode === "sql" ? currentSqlQuery : currentDrizzleQuery}
+                    schemaTables={tables}
                   />
                 }
               />


### PR DESCRIPTION
## What
SQL-console cell edit / row delete used to pick its `WHERE` key by falling back to *any column named `id`*, case-insensitively, with no uniqueness check. On a table without a declared primary key but with a non-unique `id`-named column (staging/join/log tables), editing one cell silently updated **every** matching row, and deleting one row deleted all of them.

## How
- New pure, unit-tested `resolveMutationPrimaryKey()` in `packages/studio/src/features/sql-console/mutation-primary-key.ts` (mirrors the existing `query-target.ts` pattern). It only trusts **declared** PK metadata:
  1. a single PK declared in the result's own column definitions, else
  2. the loaded database schema for the query's extracted source table (schema-qualified names matched case-insensitively).
- The resolved PK must actually be present in the result columns, otherwise mutations are disabled with a message telling the user to include it in the SELECT.
- Composite PKs stay disabled (now caught from schema metadata too, not just result metadata).
- `sql-results.tsx` loses the duplicated inline derivation; `sql-console.tsx` passes its already-loaded `tables` schema down.

Net effect: mutations now also work on tables whose PK **isn't** named `id` (previously impossible, since engines return result columns as bare name strings), and never fire on an unverified `id` column.

## Verification
- 12 new unit tests in `__tests__/apps/desktop/src/features/sql-console/mutation-primary-key.test.ts`
- `bun run test:desktop`: 789 passed
- `bun run lint`, studio + desktop `typecheck`: clean

Closes #207

## Summary by Sourcery

Resolve SQL-console row mutation primary key strictly from declared metadata and disable unsafe mutations when no reliable primary key is available.

Bug Fixes:
- Prevent SQL-console edits and deletes from using a non-unique column named "id" as a fallback primary key, avoiding unintended bulk updates and deletes.

Enhancements:
- Introduce a shared mutation primary key resolution helper that consults result metadata and loaded schema, including schema-qualified tables, and surfaces clear disablement reasons when mutations are not supported.

Tests:
- Add unit test coverage for mutation primary key resolution across declared, schema-derived, composite, missing, and case-insensitive primary key scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SQL Console row editing and deletion safety by reliably identifying table primary keys.
  * Supports primary-key information from query results or database schema metadata.
  * Handles schema-qualified tables and case differences in primary-key names.

* **Bug Fixes**
  * Prevents mutations when primary keys are missing, composite, ambiguous, or unavailable in the displayed results.
  * Provides clearer reasons when row editing or deletion is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->