### PR TITLE
fix(studio): repaint pending dry edits after every table reload + beforeunload guard

### DIFF
--- a/packages/studio/src/core/pending-edits/index.ts
+++ b/packages/studio/src/core/pending-edits/index.ts
@@ -1,1 +1,2 @@
 export { PendingEditsProvider, usePendingEdits, type PendingEdit } from './pending-edits-store'
+export { overlayPendingEditsOnRows } from './overlay'

--- a/packages/studio/src/core/pending-edits/overlay.test.ts
+++ b/packages/studio/src/core/pending-edits/overlay.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { overlayPendingEditsOnRows } from './overlay'
+import type { PendingEdit } from './pending-edits-store'
+
+function makeEdit(primaryKeyValue: unknown, columnName: string, newValue: unknown): PendingEdit {
+	return { primaryKeyColumn: 'id', primaryKeyValue, columnName, oldValue: 'old', newValue }
+}
+
+describe('overlayPendingEditsOnRows', function () {
+	it('returns the rows untouched when there are no edits', function () {
+		const rows = [{ id: 1, name: 'a' }]
+		expect(overlayPendingEditsOnRows(rows, [])).toBe(rows)
+	})
+
+	it('repaints an edit onto the matching row by primary key', function () {
+		const rows = [
+			{ id: 1, name: 'a' },
+			{ id: 2, name: 'b' }
+		]
+		const result = overlayPendingEditsOnRows(rows, [makeEdit(2, 'name', 'edited')])
+		expect(result[0]).toEqual({ id: 1, name: 'a' })
+		expect(result[1]).toEqual({ id: 2, name: 'edited' })
+	})
+
+	it('applies multiple edits to the same row', function () {
+		const rows = [{ id: 1, name: 'a', email: 'a@x' }]
+		const result = overlayPendingEditsOnRows(rows, [
+			makeEdit(1, 'name', 'edited'),
+			makeEdit(1, 'email', 'edited@x')
+		])
+		expect(result[0]).toEqual({ id: 1, name: 'edited', email: 'edited@x' })
+	})
+
+	it('leaves rows for off-page edits alone', function () {
+		const rows = [{ id: 1, name: 'a' }]
+		const result = overlayPendingEditsOnRows(rows, [makeEdit(999, 'name', 'edited')])
+		expect(result[0]).toEqual({ id: 1, name: 'a' })
+	})
+
+	it('matches on the edit\'s own primary key column', function () {
+		const rows = [{ uuid: 'k1', name: 'a' }]
+		const edit: PendingEdit = {
+			primaryKeyColumn: 'uuid',
+			primaryKeyValue: 'k1',
+			columnName: 'name',
+			oldValue: 'a',
+			newValue: 'edited'
+		}
+		expect(overlayPendingEditsOnRows(rows, [edit])[0]).toEqual({ uuid: 'k1', name: 'edited' })
+	})
+
+	it('does not mutate the input rows', function () {
+		const rows = [{ id: 1, name: 'a' }]
+		overlayPendingEditsOnRows(rows, [makeEdit(1, 'name', 'edited')])
+		expect(rows[0]).toEqual({ id: 1, name: 'a' })
+	})
+})

--- a/packages/studio/src/core/pending-edits/overlay.ts
+++ b/packages/studio/src/core/pending-edits/overlay.ts
@@ -1,0 +1,30 @@
+import type { PendingEdit } from './pending-edits-store'
+
+/**
+ * Repaints buffered dry-mode edits over rows freshly loaded from the
+ * database. Every reload path (table switch, page/sort/filter change,
+ * live-monitor refresh) replaces the grid rows with database values; without
+ * this overlay the grid would show the original values while the
+ * pending-changes bar still counts N unsaved edits, and Apply would write
+ * values the user can no longer see. Rows are matched by primary key, so
+ * edits whose row is not on the current page stay buffered but untouched.
+ */
+export function overlayPendingEditsOnRows(
+	rows: Record<string, unknown>[],
+	edits: PendingEdit[]
+): Record<string, unknown>[] {
+	if (edits.length === 0) return rows
+
+	return rows.map(function (row) {
+		const matching = edits.filter(function (edit) {
+			return row[edit.primaryKeyColumn] === edit.primaryKeyValue
+		})
+		if (matching.length === 0) return row
+
+		const patched = { ...row }
+		for (const edit of matching) {
+			patched[edit.columnName] = edit.newValue
+		}
+		return patched
+	})
+}

--- a/packages/studio/src/features/database-studio/database-studio.tsx
+++ b/packages/studio/src/features/database-studio/database-studio.tsx
@@ -309,6 +309,7 @@ export function DatabaseStudio({
 		draftInsertIndex,
 		isApplyingEdits,
 		hasPendingEdits: Boolean(tableId) && hasEdits(tableId as string),
+		getEditsForTable,
 		selectedRows,
 		selectedCells,
 		focusedCell,
@@ -329,6 +330,21 @@ export function DatabaseStudio({
 		setDraftRow,
 		setDraftInsertIndex
 	})
+
+	useEffect(
+		function guardUnloadWithPendingEdits() {
+			if (!hasEdits()) return
+			function onBeforeUnload(event: BeforeUnloadEvent) {
+				event.preventDefault()
+				event.returnValue = ''
+			}
+			window.addEventListener('beforeunload', onBeforeUnload)
+			return function () {
+				window.removeEventListener('beforeunload', onBeforeUnload)
+			}
+		},
+		[hasEdits]
+	)
 
 	const handleEscapeToGrid = useCallback(function () {
 		const grid = gridContainerRef.current?.querySelector<HTMLElement>('table[role="grid"]')

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, type Dispatch, type SetStateAction } from "react";
 import { useLiveMonitor } from "@studio/core/live-monitor";
+import { overlayPendingEditsOnRows, type PendingEdit } from "@studio/core/pending-edits";
 import { useNuqsState } from "@studio/core/url-state/use-nuqs-state";
 import { tableDataCache } from "@studio/core/table-cache";
 import { getAdapterError } from "@studio/core/data-provider/types";
@@ -29,6 +30,7 @@ type Args = {
   draftInsertIndex: number | null;
   isApplyingEdits: boolean;
   hasPendingEdits: boolean;
+  getEditsForTable: (tableId: string) => PendingEdit[];
   selectedRows: Set<number>;
   selectedCells: Set<string>;
   focusedCell: { row: number; col: number } | null;
@@ -68,6 +70,7 @@ export function useDatabaseStudioSync(args: Args) {
     draftInsertIndex,
     isApplyingEdits,
     hasPendingEdits,
+    getEditsForTable,
     selectedRows,
     selectedCells,
     focusedCell,
@@ -107,6 +110,21 @@ export function useDatabaseStudioSync(args: Args) {
   // in-place refresh of the view already shown (don't paint the now-stale
   // cache — it flashes the pre-mutation rows before the fetch returns).
   const displayedCacheKeyRef = useRef<string | null>(null);
+  // Read through a ref so loadTableData's identity doesn't change on every
+  // buffered edit — its identity drives the loadWhenQueryChanges effect, and
+  // reloading on each keystroke of a dry edit would defeat the buffer.
+  const getEditsForTableRef = useRef(getEditsForTable);
+  getEditsForTableRef.current = getEditsForTable;
+
+  const withPendingEdits = useCallback(
+    function (data: TableData, forTableId: string | null): TableData {
+      if (!forTableId) return data;
+      const edits = getEditsForTableRef.current(forTableId);
+      if (edits.length === 0) return data;
+      return { ...data, rows: overlayPendingEditsOnRows(data.rows, edits) };
+    },
+    [],
+  );
 
   const stableUrlState = useMemo(
     function () {
@@ -143,7 +161,7 @@ export function useDatabaseStudioSync(args: Args) {
     // is stale relative to the mutation, so painting it here is the "flash back
     // to the old state". Keep the current rows visible and swap in fresh data.
     if (cached && currentCacheKey !== displayedCacheKeyRef.current) {
-      setTableData(cached.data);
+      setTableData(withPendingEdits(cached.data, tableId));
       if (cached.visibleColumns.length > 0) {
         setVisibleColumns(new Set(cached.visibleColumns));
       }
@@ -199,7 +217,7 @@ export function useDatabaseStudioSync(args: Args) {
           );
         }
 
-        setTableData(data);
+        setTableData(withPendingEdits(data, tableId));
         displayedCacheKeyRef.current = currentCacheKey;
         let nextVisibleColumns: string[] = [];
         if (data.columns.length > 0) {
@@ -257,6 +275,7 @@ export function useDatabaseStudioSync(args: Args) {
     sort,
     tableId,
     tableRefName,
+    withPendingEdits,
   ]);
 
   useEffect(
@@ -312,7 +331,7 @@ export function useDatabaseStudioSync(args: Args) {
       const cached = tableDataCache.get(defaultCacheKey);
 
       if (cached) {
-        setTableData(cached.data);
+        setTableData(withPendingEdits(cached.data, tableId));
         setVisibleColumns(new Set(cached.visibleColumns));
         setIsTableTransitioning(false);
         return;
@@ -330,6 +349,7 @@ export function useDatabaseStudioSync(args: Args) {
       setTableData,
       setVisibleColumns,
       tableId,
+      withPendingEdits,
     ],
   );
 


### PR DESCRIPTION
## What
Finishes the remaining scope of #195 (the live-monitor reload guard and undo-by-PK already landed in #213).

Dry-mode edits are buffered per table and painted optimistically into the grid — but switching tables, changing page/sort/filter, or any cache paint replaced the rows with database values. The grid then showed originals while the pending-changes bar still counted N unsaved edits, and Apply wrote values the user could no longer see. There was also no unsaved-changes guard on window close.

## How
- New pure `overlayPendingEditsOnRows(rows, edits)` in `packages/studio/src/core/pending-edits/overlay.ts`: repaints buffered edits onto rows by primary key (edits for rows not on the current page stay buffered, untouched).
- `use-database-studio-sync.ts` applies the overlay at all three paint sites: the instant cache paint and the fresh fetch in `loadTableData`, and the cache paint in `handleTableChange`. The edits getter is read through a ref so `loadTableData`'s identity doesn't churn (and re-trigger loads) on every buffered keystroke. The table-data cache itself still stores raw database truth.
- `database-studio.tsx` registers a `beforeunload` prompt whenever any pending edits exist.

## Verification
- 6 new unit tests for the overlay (`overlay.test.ts`)
- `bun run test:desktop`: 783 passed; studio + desktop `typecheck` and `bun run lint` clean

Closes #195

## Summary by Sourcery

Ensure dry-mode pending edits are re-applied to table rows after any data reload and guard against losing unsaved edits on window close.

New Features:
- Overlay pending dry-mode edits onto freshly loaded table rows so the grid consistently reflects buffered changes.
- Prompt the user with a beforeunload dialog when there are unsaved edits in the database studio.

Enhancements:
- Integrate the pending-edits overlay into all table data paint paths without affecting table-data cache semantics.

Tests:
- Add unit test coverage for the pending-edits overlay logic, including primary-key matching, multi-column edits, off-page edits, and immutability.