### PR TITLE
ci(release): make packaging channels propagate real status into the Release run

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -12,6 +12,17 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing GitHub release tag (e.g. v0.26.6). Leave empty to use latest.
+        required: false
+        type: string
+      publish:
+        description: Publish to GitHub Pages (requires pages to be enabled).
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -7,6 +7,12 @@ on:
         description: "Release tag to publish to AUR (e.g. v0.26.6)."
         required: true
         type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to publish to AUR (e.g. v0.26.6)."
+        required: true
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/brew.yml
+++ b/.github/workflows/brew.yml
@@ -12,6 +12,17 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing GitHub release tag like v0.26.6. Leave empty to use latest.
+        required: false
+        type: string
+      publish:
+        description: Push the updated Cask to remcostoeten/homebrew-dora.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -7,6 +7,12 @@ on:
         description: Existing GitHub release tag like v0.26.6. Leave empty for artifact-only builds.
         required: false
         type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing GitHub release tag like v0.26.6. Leave empty for artifact-only builds.
+        required: false
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,86 +402,66 @@ jobs:
           git commit -m "chore(release): update README for ${VERSION}"
           git push origin master
 
+  # Each channel runs as a reusable-workflow job so its real outcome shows up
+  # in this run: a failed AUR push or Winget manifest turns the release run
+  # red instead of vanishing into a detached fire-and-forget dispatch.
   publish-aur:
     needs: publish-release
     permissions:
-      actions: write
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-
-      - name: Dispatch AUR publish workflow
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run aur.yml --ref master -f tag="${{ github.ref_name }}"
+      contents: write
+    uses: ./.github/workflows/aur.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit
 
   publish-homebrew:
     needs: publish-release
     permissions:
-      actions: write
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-
-      - name: Dispatch Homebrew publish workflow
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run brew.yml --ref master -f tag="${{ github.ref_name }}" -f publish=true
+      contents: write
+    uses: ./.github/workflows/brew.yml
+    with:
+      tag: ${{ github.ref_name }}
+      publish: true
+    secrets: inherit
 
   publish-apt:
     needs: publish-release
     permissions:
-      actions: write
       contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-
-      - name: Dispatch APT repository workflow
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run apt.yml --ref master -f tag="${{ github.ref_name }}" -f publish=true
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/apt.yml
+    with:
+      tag: ${{ github.ref_name }}
+      publish: true
+    secrets: inherit
 
   publish-winget:
     needs: publish-release
     permissions:
-      actions: write
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-
-      - name: Dispatch Winget workflow
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run winget.yml --ref master -f tag="${{ github.ref_name }}" -f submit_update=true
+      contents: write
+    uses: ./.github/workflows/winget.yml
+    with:
+      tag: ${{ github.ref_name }}
+      submit_update: true
+    secrets: inherit
 
   publish-snap:
     needs: publish-release
     permissions:
-      actions: write
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-
-      - name: Dispatch Snap workflow
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run snap.yml --ref master -f tag="${{ github.ref_name }}" -f publish=true -f release_channel=stable
+      contents: write
+    uses: ./.github/workflows/snap.yml
+    with:
+      tag: ${{ github.ref_name }}
+      publish: true
+      release_channel: stable
+    secrets: inherit
 
   build-flatpak:
     needs: publish-release
     permissions:
-      actions: write
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-
-      - name: Dispatch Flatpak build workflow
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run flatpak.yml --ref master -f tag="${{ github.ref_name }}"
+      contents: write
+    uses: ./.github/workflows/flatpak.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -22,6 +22,24 @@ on:
           - candidate
           - beta
           - edge
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing GitHub release tag like v0.26.6. Leave empty for artifact-only builds.
+        required: false
+        type: string
+      publish:
+        description: Publish the built snap to the Snap Store.
+        required: false
+        type: boolean
+        default: false
+      # workflow_call has no `choice` input type; the dispatch UI keeps the
+      # dropdown, callers pass a plain string.
+      release_channel:
+        description: Snap Store channel to release to.
+        required: false
+        type: string
+        default: stable
 
 permissions:
   contents: write

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -12,6 +12,17 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing GitHub release tag like v0.26.6.
+        required: true
+        type: string
+      submit_update:
+        description: Submit a wingetcreate update PR.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write

--- a/docs/distribution/release-guide.md
+++ b/docs/distribution/release-guide.md
@@ -91,9 +91,11 @@ flowchart TD
 | 2 | `release-macos` | `macos-latest` | macOS ARM `.dmg` |
 | 3 | `publish-release` | `ubuntu-latest` | Upload assets, create GitHub release |
 | 4 | `post-release` | `ubuntu-latest` | Update `README.md` on `master` |
-| 5 | package managers | `ubuntu-latest` | Dispatch AUR, Homebrew, APT, Winget, Snap, Flatpak |
+| 5 | package managers | varies | AUR, Homebrew, APT, Winget, Snap, Flatpak as reusable-workflow jobs |
 
-Platform builds in phase 2 run **in parallel** after preflight passes. Package-manager dispatches in phase 5 also run **in parallel** after the GitHub release is published.
+Platform builds in phase 2 run **in parallel** after preflight passes. Package-manager jobs in phase 5 also run **in parallel** after the GitHub release is published.
+
+The phase-5 jobs call `aur.yml`, `brew.yml`, `apt.yml`, `winget.yml`, `snap.yml`, and `flatpak.yml` via `workflow_call`, so each channel's real outcome is part of the `Release` run itself: **if the Release run for a tag is green, every channel published; if any channel fails, the run goes red on that job.** There is no need to separately check each channel workflow's history under Actions — that was only necessary when these were fire-and-forget `gh workflow run` dispatches. The channel workflows all keep their `workflow_dispatch` triggers for manual re-runs of a single channel (e.g. re-publishing Homebrew after fixing a tap secret).
 
 ---
 
@@ -236,9 +238,9 @@ chore(release): update README for v0.27.0
 
 ---
 
-## Phase 5 — Package manager dispatches
+## Phase 5 — Package manager channels
 
-These jobs run in parallel after `publish-release` succeeds. Each dispatches a dedicated workflow on `master` with the release tag:
+These jobs run in parallel after `publish-release` succeeds. Each calls a dedicated channel workflow as a reusable workflow (`workflow_call`) with the release tag, so the channel's success or failure is the job's own status inside the `Release` run:
 
 | Job | Workflow | Notes |
 | --- | --- | --- |
@@ -320,7 +322,7 @@ Built by `release.yml` and attached to every release. Users install directly fro
 | `dora-x86_64-unknown-linux-gnu.tar.gz` | Arch tarball | Also feeds AUR |
 | `checksums-linux.txt`, `checksums-windows.txt` | All | Used by Winget manifest generation |
 
-### Store / registry (automatic — dispatched after publish)
+### Store / registry (automatic — run as part of the Release workflow after publish)
 
 | Channel | Workflow | Install example |
 | --- | --- | --- |


### PR DESCRIPTION
## What
`release.yml`'s six `publish-*`/`build-flatpak` jobs were fire-and-forget: `gh workflow run <channel>.yml` only confirms the dispatch was accepted, so the Release run — the thing a maintainer watches after tagging — showed all-green even if AUR checksum computation, the Homebrew tap push, Winget manifest generation, etc. later failed in a detached run.

## How
- `aur.yml`, `brew.yml`, `apt.yml`, `winget.yml`, `snap.yml`, `flatpak.yml` each gain a `workflow_call` trigger mirroring their `workflow_dispatch` inputs (all six already read inputs via the `inputs.` context, which serves both trigger types; snap's `choice` input becomes a plain `string` for the call trigger since `workflow_call` has no choice type — the dispatch UI keeps its dropdown).
- `release.yml` replaces the six dispatch jobs with reusable-workflow calls (`uses: ./.github/workflows/<x>.yml` + `secrets: inherit`), with caller-job permissions matching each channel's needs (`pages`/`id-token` for APT, `contents: write` for the rest). **A failure in any channel now turns the Release run red on that job.**
- `workflow_dispatch` stays on every channel workflow for manual single-channel re-runs.
- `docs/distribution/release-guide.md` updated: a green Release run now means every channel published; no more checking six workflow histories under Actions.

## Behavior notes
- Channels now run at the **tag's commit** instead of `master` (reusable local `uses:` runs at the caller's ref). Tags are cut from master by release-dispatch moments earlier, so these are the same commit in practice — and pinning to the tag is the more reproducible choice.
- Channel jobs now count toward the Release run's wall-clock, but total compute is unchanged (the same jobs ran before, just detached).

## Verification
- `actionlint` clean on all seven workflows; YAML parses.
- Full end-to-end validation necessarily happens on the next real release tag — worth watching that run's phase-5 jobs.

Closes #202

## Summary by Sourcery

Integrate package manager channel workflows directly into the main Release workflow so their success or failure is reflected in the Release run, and update documentation to describe the new behavior.

Enhancements:
- Replace fire-and-forget workflow dispatches in `release.yml` with reusable workflow calls for AUR, Homebrew, APT, Winget, Snap, and Flatpak, using appropriate permissions and passing the release tag.
- Add `workflow_call` triggers with matching inputs to each channel workflow (`aur.yml`, `brew.yml`, `apt.yml`, `winget.yml`, `snap.yml`, `flatpak.yml`) so they can be invoked from the Release workflow while retaining manual `workflow_dispatch` runs.
- Ensure package manager jobs now run at the tagged commit and count as part of the Release workflow’s wall-clock time, without increasing total compute.

Documentation:
- Revise the release guide to explain that phase-5 package manager jobs run as reusable workflows whose outcomes determine the Release run status, removing the need to inspect separate workflow histories and clarifying the new “all channels green means release green” behavior.