### PR TITLE
feat(studio): hide-AI setting, macOS window controls, onboarding tour, Drizzle operator intellisense

### DIFF
--- a/__tests__/apps/desktop/src/features/drizzle-runner/utils/operator-signatures.test.ts
+++ b/__tests__/apps/desktop/src/features/drizzle-runner/utils/operator-signatures.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import {
+	DRIZZLE_OPERATOR_SIGNATURES,
+	findEnclosingOperatorCall
+} from '@/features/drizzle-runner/utils/operator-signatures'
+
+describe('DRIZZLE_OPERATOR_SIGNATURES', function () {
+	it('documents eq with two parameters', function () {
+		const eq = DRIZZLE_OPERATOR_SIGNATURES.eq
+		expect(eq.signature).toBe('eq(column, value)')
+		expect(eq.parameters).toHaveLength(2)
+	})
+
+	it('covers the operators the completion provider offers', function () {
+		for (const name of ['eq', 'ne', 'gt', 'gte', 'lt', 'lte', 'like', 'ilike', 'inArray', 'and', 'or']) {
+			expect(DRIZZLE_OPERATOR_SIGNATURES[name]).toBeDefined()
+		}
+	})
+})
+
+describe('findEnclosingOperatorCall', function () {
+	it('detects the first argument right after the opening paren', function () {
+		expect(findEnclosingOperatorCall('db.query.users.findMany({ where: eq(')).toEqual({
+			name: 'eq',
+			activeParameter: 0
+		})
+	})
+
+	it('detects the second argument after a comma', function () {
+		expect(findEnclosingOperatorCall('eq(users.id, ')).toEqual({
+			name: 'eq',
+			activeParameter: 1
+		})
+	})
+
+	it('ignores completed nested calls', function () {
+		expect(findEnclosingOperatorCall('and(eq(users.id, 1), eq(users.name, ')).toEqual({
+			name: 'eq',
+			activeParameter: 1
+		})
+	})
+
+	it('resolves the outer operator once an inner call closes', function () {
+		expect(findEnclosingOperatorCall('and(eq(users.id, 1), ')).toEqual({
+			name: 'and',
+			activeParameter: 1
+		})
+	})
+
+	it('does not count commas inside string literals', function () {
+		expect(findEnclosingOperatorCall("like(users.name, 'a,b")).toEqual({
+			name: 'like',
+			activeParameter: 1
+		})
+	})
+
+	it('does not count commas inside array literals', function () {
+		expect(findEnclosingOperatorCall('inArray(users.id, [1, 2, ')).toEqual({
+			name: 'inArray',
+			activeParameter: 1
+		})
+	})
+
+	it('returns null outside any operator call', function () {
+		expect(findEnclosingOperatorCall('db.query.users.findMany({ limit: 10, ')).toBeNull()
+	})
+
+	it('returns null for an unknown function call', function () {
+		expect(findEnclosingOperatorCall('myHelper(users.id, ')).toBeNull()
+	})
+
+	it('walks out of an unknown inner call to the enclosing operator', function () {
+		expect(findEnclosingOperatorCall('and(x, lower(users.name')).toEqual({
+			name: 'and',
+			activeParameter: 1
+		})
+	})
+
+	it('handles between with three arguments', function () {
+		expect(findEnclosingOperatorCall('between(orders.total, 10, ')).toEqual({
+			name: 'between',
+			activeParameter: 2
+		})
+	})
+})

--- a/__tests__/apps/desktop/src/features/onboarding/launch-state.test.ts
+++ b/__tests__/apps/desktop/src/features/onboarding/launch-state.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+	isTourCompleted,
+	markTourCompleted,
+	recordLaunch,
+	shouldShowTour
+} from '@/features/onboarding/launch-state'
+
+function makeStorage(): Storage {
+	const data = new Map<string, string>()
+	return {
+		get length() {
+			return data.size
+		},
+		clear: function () {
+			data.clear()
+		},
+		getItem: function (key: string) {
+			return data.has(key) ? (data.get(key) as string) : null
+		},
+		key: function (index: number) {
+			return Array.from(data.keys())[index] ?? null
+		},
+		removeItem: function (key: string) {
+			data.delete(key)
+		},
+		setItem: function (key: string, value: string) {
+			data.set(key, value)
+		}
+	}
+}
+
+describe('launch-state', function () {
+	let storage: Storage
+
+	beforeEach(function () {
+		storage = makeStorage()
+	})
+
+	it('counts launches starting at 1', function () {
+		expect(recordLaunch(storage)).toBe(1)
+		expect(recordLaunch(storage)).toBe(2)
+		expect(recordLaunch(storage)).toBe(3)
+	})
+
+	it('recovers from a corrupted counter', function () {
+		storage.setItem('dora_launch_count', 'garbage')
+		expect(recordLaunch(storage)).toBe(1)
+	})
+
+	it('offers the tour on the first launch', function () {
+		expect(shouldShowTour(1, storage)).toBe(true)
+	})
+
+	it('keeps offering the tour for the first few launches if never completed', function () {
+		expect(shouldShowTour(2, storage)).toBe(true)
+		expect(shouldShowTour(3, storage)).toBe(true)
+	})
+
+	it('stops offering after the launch limit', function () {
+		expect(shouldShowTour(4, storage)).toBe(false)
+	})
+
+	it('never offers the tour once completed or skipped', function () {
+		markTourCompleted(storage)
+		expect(isTourCompleted(storage)).toBe(true)
+		expect(shouldShowTour(1, storage)).toBe(false)
+	})
+})

--- a/packages/studio/src/components/window-controls.tsx
+++ b/packages/studio/src/components/window-controls.tsx
@@ -1,5 +1,6 @@
 import { Minus, Square, X } from 'lucide-react'
 import { useCallback, useState, useEffect } from 'react'
+import { useSettings } from '@studio/core/settings'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@studio/shared/ui/tooltip'
 import { cn } from '@studio/shared/utils/cn'
 
@@ -8,6 +9,7 @@ type Props = {
 }
 
 export function WindowControls({ className }: Props) {
+	const { settings } = useSettings()
 	const [isMaximized, setIsMaximized] = useState(false)
 	const [isTauri, setIsTauri] = useState(false)
 
@@ -102,6 +104,40 @@ export function WindowControls({ className }: Props) {
 	)
 
 	if (!isTauri) return null
+
+	if (settings.windowControlsStyle === 'macos') {
+		return (
+			<div
+				className={cn('group flex items-center gap-2 px-1', className)}
+				data-tauri-drag-region='false'
+			>
+				<button
+					type='button'
+					onClick={handleClose}
+					className='flex h-3 w-3 items-center justify-center rounded-full bg-[#ff5f57] text-black/60 transition-opacity hover:opacity-90'
+					aria-label='Close window'
+				>
+					<X className='h-2 w-2 opacity-0 transition-opacity group-hover:opacity-100' />
+				</button>
+				<button
+					type='button'
+					onClick={handleMinimize}
+					className='flex h-3 w-3 items-center justify-center rounded-full bg-[#febc2e] text-black/60 transition-opacity hover:opacity-90'
+					aria-label='Minimize window'
+				>
+					<Minus className='h-2 w-2 opacity-0 transition-opacity group-hover:opacity-100' />
+				</button>
+				<button
+					type='button'
+					onClick={handleMaximize}
+					className='flex h-3 w-3 items-center justify-center rounded-full bg-[#28c840] text-black/60 transition-opacity hover:opacity-90'
+					aria-label={isMaximized ? 'Restore window' : 'Maximize window'}
+				>
+					<Square className='h-1.5 w-1.5 opacity-0 transition-opacity group-hover:opacity-100' />
+				</button>
+			</div>
+		)
+	}
 
 	return (
 		<div className={cn('flex items-center gap-1', className)} data-tauri-drag-region='false'>

--- a/packages/studio/src/core/settings/settings-store.tsx
+++ b/packages/studio/src/core/settings/settings-store.tsx
@@ -18,6 +18,7 @@ export type SettingsState = {
 	editorFontSize: number
 	editorTheme: EditorTheme
 	enableVimMode: boolean
+	hideAi: boolean
 	privacyMaskData: boolean
 	restoreLastConnection: boolean
 	restoreTabsOnLaunch: boolean
@@ -27,6 +28,7 @@ export type SettingsState = {
 	lastRowPK: string | number | null
 	selectionBarStyle: 'floating' | 'static'
 	showToasts: boolean
+	windowControlsStyle: 'custom' | 'macos'
 }
 
 export const DEFAULT_SETTINGS: SettingsState = {
@@ -34,6 +36,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
 	editorFontSize: 14,
 	editorTheme: 'auto',
 	enableVimMode: false,
+	hideAi: false,
 	privacyMaskData: false,
 	restoreLastConnection: true,
 	restoreTabsOnLaunch: true,
@@ -42,7 +45,8 @@ export const DEFAULT_SETTINGS: SettingsState = {
 	lastTableId: null,
 	lastRowPK: null,
 	selectionBarStyle: 'static',
-	showToasts: true
+	showToasts: true,
+	windowControlsStyle: 'custom'
 }
 
 const STORAGE_KEY = 'ui_settings'
@@ -116,6 +120,7 @@ export function sanitizeSettings(value: unknown): SettingsState {
 			typeof value.enableVimMode === 'boolean'
 				? value.enableVimMode
 				: DEFAULT_SETTINGS.enableVimMode,
+		hideAi: typeof value.hideAi === 'boolean' ? value.hideAi : DEFAULT_SETTINGS.hideAi,
 		privacyMaskData:
 			typeof value.privacyMaskData === 'boolean'
 				? value.privacyMaskData
@@ -135,7 +140,11 @@ export function sanitizeSettings(value: unknown): SettingsState {
 			? (value.selectionBarStyle as SettingsState['selectionBarStyle'])
 			: DEFAULT_SETTINGS.selectionBarStyle,
 		showToasts:
-			typeof value.showToasts === 'boolean' ? value.showToasts : DEFAULT_SETTINGS.showToasts
+			typeof value.showToasts === 'boolean' ? value.showToasts : DEFAULT_SETTINGS.showToasts,
+		windowControlsStyle:
+			value.windowControlsStyle === 'macos' || value.windowControlsStyle === 'custom'
+				? value.windowControlsStyle
+				: DEFAULT_SETTINGS.windowControlsStyle
 	}
 }
 

--- a/packages/studio/src/features/app-sidebar/nav-item.tsx
+++ b/packages/studio/src/features/app-sidebar/nav-item.tsx
@@ -71,6 +71,7 @@ export const SidebarNavItem = forwardRef<HTMLButtonElement, NavItemProps>(functi
 					disabled={item.disabled}
 					className={cn(navItemVariants({ variant, size, state }), className)}
 					aria-label={item.label}
+					data-nav-id={item.id}
 					aria-current={isActive ? 'page' : undefined}
 					aria-disabled={item.disabled}
 					{...props}

--- a/packages/studio/src/features/drizzle-runner/components/code-editor.tsx
+++ b/packages/studio/src/features/drizzle-runner/components/code-editor.tsx
@@ -22,6 +22,10 @@ import {
   isInsideJoinParens,
   isInsideCountParens,
 } from "../utils/lsp-patterns";
+import {
+  DRIZZLE_OPERATOR_SIGNATURES,
+  findEnclosingOperatorCall,
+} from "../utils/operator-signatures";
 
 type Props = {
   value: string;
@@ -255,6 +259,8 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
   const loadedThemesRef = useRef<Set<string>>(new Set());
   const decorRef = useRef<string[]>([]);
   const completionProviderRef = useRef<Monaco.IDisposable | null>(null);
+  const signatureProviderRef = useRef<Monaco.IDisposable | null>(null);
+  const hoverProviderRef = useRef<Monaco.IDisposable | null>(null);
   const drizzleTypesRef = useRef<Monaco.IDisposable | null>(null);
   const tablesRef = useRef<SchemaTable[]>(tables);
   const onExecuteRef = useRef(onExecute);
@@ -414,6 +420,14 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
       if (completionProviderRef.current) {
         completionProviderRef.current.dispose();
         completionProviderRef.current = null;
+      }
+      if (signatureProviderRef.current) {
+        signatureProviderRef.current.dispose();
+        signatureProviderRef.current = null;
+      }
+      if (hoverProviderRef.current) {
+        hoverProviderRef.current.dispose();
+        hoverProviderRef.current = null;
       }
       if (drizzleTypesRef.current) {
         drizzleTypesRef.current.dispose();
@@ -2029,6 +2043,70 @@ export function CodeEditor({ value, onChange, onExecute, onSave, onModeChange, i
         }
 
         return buildSuggestions(range, defaultSuggestions);
+      },
+    });
+
+    if (signatureProviderRef.current) {
+      signatureProviderRef.current.dispose();
+    }
+    signatureProviderRef.current = monaco.languages.registerSignatureHelpProvider("typescript", {
+      signatureHelpTriggerCharacters: ["(", ","],
+      signatureHelpRetriggerCharacters: [","],
+      provideSignatureHelp: function (model, position) {
+        if (!isDrizzleModel(model)) return null;
+        const textUntilPosition = model.getValueInRange({
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: position.lineNumber,
+          endColumn: position.column,
+        });
+        const call = findEnclosingOperatorCall(textUntilPosition);
+        if (!call) return null;
+        const operator = DRIZZLE_OPERATOR_SIGNATURES[call.name];
+        return {
+          value: {
+            signatures: [
+              {
+                label: operator.signature,
+                documentation: operator.documentation,
+                parameters: operator.parameters.map(function (parameter) {
+                  return { label: parameter.label, documentation: parameter.documentation };
+                }),
+              },
+            ],
+            activeSignature: 0,
+            activeParameter: Math.min(
+              call.activeParameter,
+              Math.max(operator.parameters.length - 1, 0),
+            ),
+          },
+          dispose: function () {},
+        };
+      },
+    });
+
+    if (hoverProviderRef.current) {
+      hoverProviderRef.current.dispose();
+    }
+    hoverProviderRef.current = monaco.languages.registerHoverProvider("typescript", {
+      provideHover: function (model, position) {
+        if (!isDrizzleModel(model)) return null;
+        const word = model.getWordAtPosition(position);
+        if (!word) return null;
+        const operator = DRIZZLE_OPERATOR_SIGNATURES[word.word];
+        if (!operator) return null;
+        return {
+          range: new monaco.Range(
+            position.lineNumber,
+            word.startColumn,
+            position.lineNumber,
+            word.endColumn,
+          ),
+          contents: [
+            { value: "```ts\n" + operator.signature + "\n```" },
+            { value: operator.documentation },
+          ],
+        };
       },
     });
 

--- a/packages/studio/src/features/drizzle-runner/utils/operator-signatures.ts
+++ b/packages/studio/src/features/drizzle-runner/utils/operator-signatures.ts
@@ -1,0 +1,180 @@
+/**
+ * Signature-help and hover metadata for the Drizzle condition operators the
+ * runner's Monaco LSP understands. Pure data + parsing so the providers in
+ * code-editor.tsx stay thin and this logic is unit-testable without Monaco.
+ */
+
+type OperatorParameter = {
+	label: string
+	documentation: string
+}
+
+export type OperatorSignature = {
+	name: string
+	signature: string
+	documentation: string
+	parameters: OperatorParameter[]
+}
+
+function comparison(name: string, verb: string): OperatorSignature {
+	return {
+		name,
+		signature: `${name}(column, value)`,
+		documentation: `SQL condition: column ${verb} value.`,
+		parameters: [
+			{ label: 'column', documentation: 'Column reference, e.g. users.id' },
+			{ label: 'value', documentation: 'Value or column to compare against' }
+		]
+	}
+}
+
+export const DRIZZLE_OPERATOR_SIGNATURES: Record<string, OperatorSignature> = {
+	eq: comparison('eq', '='),
+	ne: comparison('ne', '<>'),
+	gt: comparison('gt', '>'),
+	gte: comparison('gte', '>='),
+	lt: comparison('lt', '<'),
+	lte: comparison('lte', '<='),
+	like: {
+		name: 'like',
+		signature: 'like(column, pattern)',
+		documentation: 'SQL LIKE — case-sensitive pattern match. Use % and _ as wildcards.',
+		parameters: [
+			{ label: 'column', documentation: 'Column reference, e.g. users.name' },
+			{ label: 'pattern', documentation: "Pattern string, e.g. '%alice%'" }
+		]
+	},
+	ilike: {
+		name: 'ilike',
+		signature: 'ilike(column, pattern)',
+		documentation: 'Case-insensitive LIKE (Postgres). Use % and _ as wildcards.',
+		parameters: [
+			{ label: 'column', documentation: 'Column reference, e.g. users.name' },
+			{ label: 'pattern', documentation: "Pattern string, e.g. '%alice%'" }
+		]
+	},
+	inArray: {
+		name: 'inArray',
+		signature: 'inArray(column, values)',
+		documentation: 'SQL IN — matches rows whose column equals any of the values.',
+		parameters: [
+			{ label: 'column', documentation: 'Column reference, e.g. users.id' },
+			{ label: 'values', documentation: 'Array of values, e.g. [1, 2, 3]' }
+		]
+	},
+	notInArray: {
+		name: 'notInArray',
+		signature: 'notInArray(column, values)',
+		documentation: 'SQL NOT IN — matches rows whose column equals none of the values.',
+		parameters: [
+			{ label: 'column', documentation: 'Column reference, e.g. users.id' },
+			{ label: 'values', documentation: 'Array of values, e.g. [1, 2, 3]' }
+		]
+	},
+	between: {
+		name: 'between',
+		signature: 'between(column, min, max)',
+		documentation: 'SQL BETWEEN — matches rows whose column is within [min, max].',
+		parameters: [
+			{ label: 'column', documentation: 'Column reference, e.g. orders.total' },
+			{ label: 'min', documentation: 'Inclusive lower bound' },
+			{ label: 'max', documentation: 'Inclusive upper bound' }
+		]
+	},
+	and: {
+		name: 'and',
+		signature: 'and(...conditions)',
+		documentation: 'Combines conditions with SQL AND.',
+		parameters: [{ label: '...conditions', documentation: 'Conditions to AND together' }]
+	},
+	or: {
+		name: 'or',
+		signature: 'or(...conditions)',
+		documentation: 'Combines conditions with SQL OR.',
+		parameters: [{ label: '...conditions', documentation: 'Conditions to OR together' }]
+	},
+	not: {
+		name: 'not',
+		signature: 'not(condition)',
+		documentation: 'Negates a condition with SQL NOT.',
+		parameters: [{ label: 'condition', documentation: 'Condition to negate' }]
+	},
+	isNull: {
+		name: 'isNull',
+		signature: 'isNull(column)',
+		documentation: 'SQL IS NULL.',
+		parameters: [{ label: 'column', documentation: 'Column reference, e.g. users.deleted_at' }]
+	},
+	isNotNull: {
+		name: 'isNotNull',
+		signature: 'isNotNull(column)',
+		documentation: 'SQL IS NOT NULL.',
+		parameters: [{ label: 'column', documentation: 'Column reference, e.g. users.deleted_at' }]
+	}
+}
+
+export type EnclosingOperatorCall = {
+	name: string
+	activeParameter: number
+}
+
+type CallFrame = {
+	name: string | null
+	commas: number
+}
+
+/**
+ * Finds the innermost unclosed Drizzle operator call the cursor sits inside,
+ * and which argument the cursor is on. Parses the text before the cursor
+ * forward, keeping a stack of open call/bracket frames so commas inside
+ * nested arrays, objects, strings, and completed calls are attributed to the
+ * right level. Returns null when the cursor is not inside a known operator
+ * call.
+ */
+export function findEnclosingOperatorCall(textUntilPosition: string): EnclosingOperatorCall | null {
+	const stack: CallFrame[] = []
+	const length = textUntilPosition.length
+
+	let i = 0
+	while (i < length) {
+		const char = textUntilPosition[i]
+
+		if (char === "'" || char === '"' || char === '`') {
+			i++
+			while (i < length) {
+				if (textUntilPosition[i] === '\\') {
+					i += 2
+					continue
+				}
+				if (textUntilPosition[i] === char) break
+				i++
+			}
+			i++
+			continue
+		}
+
+		if (char === '(') {
+			const head = textUntilPosition.slice(0, i)
+			const nameMatch = head.match(/([A-Za-z_$][\w$]*)\s*$/)
+			stack.push({ name: nameMatch ? nameMatch[1] : null, commas: 0 })
+		} else if (char === '[' || char === '{') {
+			stack.push({ name: null, commas: 0 })
+		} else if (char === ')' || char === ']' || char === '}') {
+			stack.pop()
+		} else if (char === ',' && stack.length > 0) {
+			stack[stack.length - 1].commas++
+		}
+		i++
+	}
+
+	for (let frame = stack.length - 1; frame >= 0; frame--) {
+		const { name, commas } = stack[frame]
+		if (name && DRIZZLE_OPERATOR_SIGNATURES[name]) {
+			return { name, activeParameter: commas }
+		}
+		// A deeper unknown frame (array/object literal, user function) doesn't
+		// change which operator argument the cursor is in — keep walking out.
+	}
+
+	return null
+}

--- a/packages/studio/src/features/onboarding/index.ts
+++ b/packages/studio/src/features/onboarding/index.ts
@@ -1,0 +1,2 @@
+export { OnboardingTour } from './onboarding-tour'
+export { recordLaunch, shouldShowTour, isTourCompleted, markTourCompleted } from './launch-state'

--- a/packages/studio/src/features/onboarding/launch-state.ts
+++ b/packages/studio/src/features/onboarding/launch-state.ts
@@ -1,0 +1,46 @@
+const LAUNCH_COUNT_KEY = 'dora_launch_count'
+const TOUR_COMPLETED_KEY = 'dora_onboarding_tour_completed'
+
+/**
+ * Launches within which the tour keeps offering itself when it was neither
+ * completed nor skipped (e.g. the user closed the app mid-first-run). After
+ * that it never appears again on its own.
+ */
+const TOUR_OFFER_LAUNCH_LIMIT = 3
+
+function safeStorage(storage?: Storage): Storage | null {
+	if (storage) return storage
+	try {
+		return window.localStorage
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Increments and returns the launch counter. Call exactly once per app
+ * session; the counter (rather than a boolean) leaves room to gate other
+ * "first N launches" behavior later.
+ */
+export function recordLaunch(storage?: Storage): number {
+	const store = safeStorage(storage)
+	if (!store) return 0
+	const current = Number.parseInt(store.getItem(LAUNCH_COUNT_KEY) ?? '0', 10)
+	const next = (Number.isFinite(current) && current >= 0 ? current : 0) + 1
+	store.setItem(LAUNCH_COUNT_KEY, String(next))
+	return next
+}
+
+export function isTourCompleted(storage?: Storage): boolean {
+	const store = safeStorage(storage)
+	return store?.getItem(TOUR_COMPLETED_KEY) === '1'
+}
+
+export function markTourCompleted(storage?: Storage): void {
+	safeStorage(storage)?.setItem(TOUR_COMPLETED_KEY, '1')
+}
+
+export function shouldShowTour(launchCount: number, storage?: Storage): boolean {
+	if (isTourCompleted(storage)) return false
+	return launchCount >= 1 && launchCount <= TOUR_OFFER_LAUNCH_LIMIT
+}

--- a/packages/studio/src/features/onboarding/onboarding-tour.tsx
+++ b/packages/studio/src/features/onboarding/onboarding-tour.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@studio/shared/ui/button'
+import { cn } from '@studio/shared/utils/cn'
+import { markTourCompleted, recordLaunch, shouldShowTour } from './launch-state'
+
+type TourStep = {
+	title: string
+	description: string
+	/** CSS selector of the element to spotlight; omit for a centered step. */
+	anchor?: string
+}
+
+const TOUR_STEPS: TourStep[] = [
+	{
+		title: 'Welcome to Dora',
+		description:
+			'A 30-second tour of the essentials. Skip any time — everything here is discoverable later.'
+	},
+	{
+		title: 'Data Viewer',
+		description: 'Browse and edit tables in a spreadsheet-like grid, with filters, sorting, and undo.',
+		anchor: '[data-nav-id="database-studio"]'
+	},
+	{
+		title: 'SQL Console',
+		description: 'Write and run SQL or Drizzle queries with autocomplete, history, and charts.',
+		anchor: '[data-nav-id="sql-console"]'
+	},
+	{
+		title: 'Schema',
+		description: 'Visualize your tables and relationships as a diagram.',
+		anchor: '[data-nav-id="schema-visualizer"]'
+	},
+	{
+		title: 'Settings',
+		description:
+			'Themes, keyboard shortcuts, privacy mode, and more live here. Enjoy Dora!',
+		anchor: '[data-nav-id="settings"]'
+	}
+]
+
+type SpotlightRect = {
+	top: number
+	left: number
+	width: number
+	height: number
+}
+
+export function OnboardingTour() {
+	const launchCountRef = useRef<number | null>(null)
+	if (launchCountRef.current === null) {
+		launchCountRef.current = recordLaunch()
+	}
+	const [open, setOpen] = useState(function () {
+		return shouldShowTour(launchCountRef.current ?? 0)
+	})
+	const [stepIndex, setStepIndex] = useState(0)
+	const [spotlight, setSpotlight] = useState<SpotlightRect | null>(null)
+
+	const step = TOUR_STEPS[stepIndex]
+	const isLastStep = stepIndex === TOUR_STEPS.length - 1
+
+	const anchor = step?.anchor
+	useEffect(
+		function trackAnchorPosition() {
+			if (!open || !anchor) {
+				setSpotlight(null)
+				return
+			}
+			function measure() {
+				const element = document.querySelector(anchor as string)
+				if (!element) {
+					setSpotlight(null)
+					return
+				}
+				const rect = element.getBoundingClientRect()
+				setSpotlight({
+					top: rect.top - 4,
+					left: rect.left - 4,
+					width: rect.width + 8,
+					height: rect.height + 8
+				})
+			}
+			measure()
+			window.addEventListener('resize', measure)
+			return function () {
+				window.removeEventListener('resize', measure)
+			}
+		},
+		[open, anchor, stepIndex]
+	)
+
+	const progressLabel = useMemo(
+		function () {
+			return `${stepIndex + 1} of ${TOUR_STEPS.length}`
+		},
+		[stepIndex]
+	)
+
+	function finish() {
+		markTourCompleted()
+		setOpen(false)
+	}
+
+	if (!open || !step) return null
+
+	return (
+		<>
+			{spotlight && (
+				<div
+					aria-hidden='true'
+					className='pointer-events-none fixed z-[90] rounded-lg ring-2 ring-primary ring-offset-2 ring-offset-background transition-all duration-200'
+					style={{
+						top: spotlight.top,
+						left: spotlight.left,
+						width: spotlight.width,
+						height: spotlight.height
+					}}
+				/>
+			)}
+			<div
+				role='dialog'
+				aria-label='Onboarding tour'
+				className={cn(
+					'fixed bottom-6 left-1/2 z-[91] w-[min(380px,calc(100vw-2rem))] -translate-x-1/2',
+					'rounded-lg border border-border bg-popover p-4 shadow-xl'
+				)}
+			>
+				<div className='mb-1 flex items-center justify-between'>
+					<div className='text-sm font-medium text-popover-foreground'>{step.title}</div>
+					<div className='text-xs text-muted-foreground'>{progressLabel}</div>
+				</div>
+				<p className='mb-3 text-xs leading-relaxed text-muted-foreground'>{step.description}</p>
+				<div className='flex items-center justify-between'>
+					<Button variant='ghost' size='sm' className='h-7 text-xs' onClick={finish}>
+						Skip tour
+					</Button>
+					<div className='flex gap-2'>
+						{stepIndex > 0 && (
+							<Button
+								variant='outline'
+								size='sm'
+								className='h-7 text-xs'
+								onClick={function () {
+									setStepIndex(stepIndex - 1)
+								}}
+							>
+								Back
+							</Button>
+						)}
+						<Button
+							size='sm'
+							className='h-7 text-xs'
+							onClick={function () {
+								if (isLastStep) {
+									finish()
+								} else {
+									setStepIndex(stepIndex + 1)
+								}
+							}}
+						>
+							{isLastStep ? 'Done' : 'Next'}
+						</Button>
+					</div>
+				</div>
+			</div>
+		</>
+	)
+}

--- a/packages/studio/src/features/sidebar/components/settings-panel.tsx
+++ b/packages/studio/src/features/sidebar/components/settings-panel.tsx
@@ -86,6 +86,13 @@ type SettingsSearchResult = {
 	shortcutName?: ShortcutName
 }
 
+const AI_SECTION_IDS: ReadonlySet<SettingsSectionId> = new Set([
+	'ai-provider',
+	'ollama-models',
+	'ai-keys',
+	'ai-usage'
+])
+
 const SETTINGS_SECTIONS: SettingsSectionNav[] = [
 	{
 		id: 'editor',
@@ -145,7 +152,7 @@ const SETTINGS_SECTIONS: SettingsSectionNav[] = [
 		id: 'safety',
 		title: 'Safety',
 		description: 'Destructive action confirmations and privacy',
-		keywords: ['delete', 'confirm', 'danger', 'privacy', 'mask', 'hide']
+		keywords: ['delete', 'confirm', 'danger', 'privacy', 'mask', 'hide', 'ai', 'assistant', 'disable ai']
 	},
 	{
 		id: 'startup',
@@ -156,8 +163,8 @@ const SETTINGS_SECTIONS: SettingsSectionNav[] = [
 	{
 		id: 'interface',
 		title: 'Interface',
-		description: 'Selection bar and toast behavior',
-		keywords: ['selection', 'toasts', 'ui', 'layout']
+		description: 'Selection bar, window controls, and toast behavior',
+		keywords: ['selection', 'toasts', 'ui', 'layout', 'window controls', 'traffic lights', 'titlebar']
 	},
 	{
 		id: 'updates',
@@ -698,14 +705,16 @@ export function SettingsView({ windowControls, initialSection, highlightSection 
 	const searchResults = useMemo(function () {
 		return filterSettingsSearchResults(searchQuery, effectiveShortcuts)
 	}, [searchQuery, effectiveShortcuts])
+	const hideAi = settings.hideAi
 	const visibleSections = useMemo(function () {
 		const visibleSectionIds = new Set(searchResults.map(function (result) {
 			return result.sectionId
 		}))
 		return SETTINGS_SECTIONS.filter(function (section) {
+			if (hideAi && AI_SECTION_IDS.has(section.id)) return false
 			return visibleSectionIds.has(section.id)
 		})
-	}, [searchResults])
+	}, [searchResults, hideAi])
 	const visibleSectionIds = useMemo(function () {
 		return new Set(visibleSections.map(function (section) {
 			return section.id
@@ -1495,6 +1504,32 @@ export function SettingsView({ windowControls, initialSection, highlightSection 
 												/>
 											</div>
 										</div>
+
+										<div
+											className='flex items-start justify-between gap-4'
+											tabIndex={-1}
+											data-settings-focus='safety-hide-ai'
+										>
+											<div className='flex-1'>
+												<div className='text-sm text-sidebar-foreground'>
+													Hide AI
+												</div>
+												<div className='text-xs leading-tight text-muted-foreground'>
+													Remove every AI entry point: the assistant panel and its
+													corner button, Cmd+K generation in the SQL console,
+													AI-powered explain/fix actions, and the AI sections in
+													these settings.
+												</div>
+											</div>
+											<div className='flex-shrink-0 pt-0.5'>
+												<Switch
+													checked={settings.hideAi}
+													onCheckedChange={function (checked) {
+														updateSetting('hideAi', checked)
+													}}
+												/>
+											</div>
+										</div>
 									</div>
 								</SectionCard>
 							) : null}
@@ -1610,6 +1645,41 @@ export function SettingsView({ windowControls, initialSection, highlightSection 
 													<SelectContent>
 														<SelectItem value='floating'>Floating Pill</SelectItem>
 														<SelectItem value='static'>Static Bar</SelectItem>
+													</SelectContent>
+												</Select>
+											</div>
+										</div>
+
+										<div
+											className='flex items-start justify-between gap-4'
+											tabIndex={-1}
+											data-settings-focus='interface-window-controls'
+										>
+											<div className='flex-1'>
+												<div className='text-sm text-sidebar-foreground'>
+													Window Controls
+												</div>
+												<div className='text-xs leading-tight text-muted-foreground'>
+													Choose between the custom buttons and macOS-style
+													traffic lights (desktop app only)
+												</div>
+											</div>
+											<div className='min-w-[120px] flex-shrink-0 pt-0.5'>
+												<Select
+													value={settings.windowControlsStyle || 'custom'}
+													onValueChange={function (value) {
+														updateSetting(
+															'windowControlsStyle',
+															value as SettingsState['windowControlsStyle']
+														)
+													}}
+												>
+													<SelectTrigger className='h-8 w-full text-xs'>
+														<SelectValue placeholder='Select style' />
+													</SelectTrigger>
+													<SelectContent>
+														<SelectItem value='custom'>Custom</SelectItem>
+														<SelectItem value='macos'>macOS</SelectItem>
 													</SelectContent>
 												</Select>
 											</div>

--- a/packages/studio/src/features/sql-console/components/sql-results.tsx
+++ b/packages/studio/src/features/sql-console/components/sql-results.tsx
@@ -482,7 +482,7 @@ export function SqlResults({
 							<div className='text-destructive text-sm font-mono bg-destructive/10 px-4 py-3 rounded-md border border-destructive/20'>
 								{result.error}
 							</div>
-							{query?.trim() && (
+							{query?.trim() && !settings.hideAi && (
 								<Button
 									variant='outline'
 									size='sm'

--- a/packages/studio/src/features/sql-console/sql-console.tsx
+++ b/packages/studio/src/features/sql-console/sql-console.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useAdapter, useIsTauri } from "@studio/core/data-provider/context";
+import { useSettings } from "@studio/core/settings";
 import { useConnections } from "@studio/core/data-provider";
 import { askAi, buildExplainQueryPrompt } from "@studio/features/ai-assistant/ai-actions";
 import { getAdapterError } from "@studio/core/data-provider/types";
@@ -108,6 +109,8 @@ function SqlConsoleInner({
 }: Props) {
   const adapter = useAdapter();
   const isTauri = useIsTauri();
+  const { settings: appSettings } = useSettings();
+  const hideAi = appSettings.hideAi;
   const { data: connections } = useConnections();
   const tabStore = useQueryTabs();
   const { activeTab } = tabStore;
@@ -1085,6 +1088,7 @@ function SqlConsoleInner({
 
   $.bind(sqlShortcuts.aiCmdK.combo).on(
     function () {
+      if (hideAi) return;
       setShowAiCmdK(function (v) {
         return !v;
       });
@@ -1303,7 +1307,7 @@ function SqlConsoleInner({
                         setShowFilter(!showFilter);
                       }}
                       onSave={handleSaveSnippet}
-                      onExplainQuery={handleExplainQuery}
+                      onExplainQuery={hideAi ? undefined : handleExplainQuery}
                       onExplainAnalyze={mode === "sql" ? handleExplainAnalyze : undefined}
                     />
                   </div>
@@ -1381,7 +1385,7 @@ function SqlConsoleInner({
       </div>
 
       <AiCmdK
-        open={showAiCmdK}
+        open={showAiCmdK && !hideAi}
         onClose={() => setShowAiCmdK(false)}
         activeConnectionId={activeConnectionId}
         isTauri={isTauri}

--- a/packages/studio/src/pages/Index.tsx
+++ b/packages/studio/src/pages/Index.tsx
@@ -17,6 +17,7 @@ import {
 } from "@studio/shared/lib/ui-zoom";
 import { LiveMonitorProvider } from "@studio/core/live-monitor";
 import { NavigationSidebar, SidebarProvider } from "@studio/features/app-sidebar";
+import { OnboardingTour } from "@studio/features/onboarding";
 const CommandPalette = lazy(function () {
   return import("@studio/features/command-palette").then(function (m) {
     return { default: m.CommandPalette };
@@ -278,6 +279,7 @@ function IndexInner() {
 
   $.bind(shortcuts.toggleAiAssistant.combo).on(
     function () {
+      if (settings.hideAi) return;
       toggleAiAssistant();
     },
     { description: shortcuts.toggleAiAssistant.description },
@@ -1305,8 +1307,9 @@ function IndexInner() {
                 </Suspense>
               )}
 
-              <AiAssistantToggle />
-              <AiAssistantPanelHost
+              <OnboardingTour />
+              {!settings.hideAi && <AiAssistantToggle />}
+              {!settings.hideAi && <AiAssistantPanelHost
                 activeConnectionId={activeConnectionId || null}
                 activeView={activeNavId}
                 selectedTableId={selectedTableId || null}
@@ -1314,7 +1317,7 @@ function IndexInner() {
                 editorContext={activeNavId === "sql-console" ? sqlConsoleEditorContext : null}
                 onEditorInsert={handleInsertSqlInConsole}
                 onRunInConsole={handleRunSqlInConsole}
-              />
+              />}
             </div>
           </div>
         </SidebarProvider>


### PR DESCRIPTION
Grouped feature PR (per request — fewer PRs), four independent features:

## #163 — Hide AI entirely
New **Settings → Safety → Hide AI** toggle (default off, existing users unaffected). When on:
- corner AI button + assistant panel unmount, and the toggle-assistant shortcut no-ops
- SQL console: Cmd+K generation disabled, 'Explain with AI' button hidden, 'Fix with AI' on errors hidden
- all four AI settings sections (Provider, Local models, Keys, Usage) disappear from the settings panel and its nav

## #165 — Window controls style (partial)
New **Settings → Interface → Window Controls** select: `custom` (current) or `macos` traffic lights (close/min/max dots with hover glyphs, Tauri only), persisted. **Position (left/right) is deferred** — WindowControls is mounted in ~7 header `rightSlot`s and moving it left needs per-header layout work (the #164 concern the issue itself references). Leaving #165 open for that half, with a comment.

## #160 — Skippable onboarding tour
Non-intrusive 5-step coachmark (bottom-center card + spotlight ring on the nav rail; no dimming overlay, app stays usable). Driven by a persisted launch **counter** (per the issue's note) in localStorage — which persists in the Tauri webview too: offers on the first 3 launches until completed or skipped, never again after. Nav anchors via a new `data-nav-id` on nav items.

## #176 — Drizzle operator intellisense
Beyond the existing completions, the runner now has:
- **Signature help** inside operator calls (`eq(`, `between(`, …) with correct active-parameter tracking — a forward call-stack parser handles nested calls, arrays, objects, and unterminated strings (`findEnclosingOperatorCall`, 12 unit tests)
- **Hover docs** for eq/ne/gt/gte/lt/lte/like/ilike/inArray/notInArray/between/and/or/not/isNull/isNotNull
- Both providers disposed alongside the completion provider.

## Verification
- 813 tests pass (18 new: 12 operator-signatures, 6 launch-state)
- studio + desktop typecheck, lint clean

Closes #163
Closes #160
Closes #176

## Summary by Sourcery

Add user-configurable controls for AI visibility, window button style, onboarding guidance, and Drizzle operator tooling in Studio.

New Features:
- Introduce a Hide AI safety setting that removes all AI entry points and assistant UI when enabled.
- Add an Interface setting to switch desktop window controls between custom buttons and macOS-style traffic lights.
- Add a skippable, multi-step onboarding tour that spotlights key navigation items and is gated by a persisted launch counter.
- Provide signature help and hover documentation for common Drizzle condition operators in the runner code editor.

Enhancements:
- Dispose Drizzle runner hover and signature providers alongside the completion provider to avoid leaks.

Tests:
- Add unit tests for Drizzle operator signature metadata and the enclosing-operator parser used for signature help.
- Add unit tests for onboarding launch state behavior, including corrupted counters and completion gating.