### PR TITLE
fix(release): ship macOS updater artifacts (.app.tar.gz + .sig) and fail loudly on a missing platform

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -27,4 +27,21 @@ jobs:
               run: bun install
 
             - name: Build desktop app
+              env:
+                  TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+                  TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
               run: bun run desktop:build
+
+            - name: Verify macOS updater artifacts
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  BUNDLE=apps/desktop/src-tauri/target/release/bundle
+                  for pattern in "$BUNDLE/dmg"/*.dmg "$BUNDLE/macos"/*.app.tar.gz "$BUNDLE/macos"/*.app.tar.gz.sig; do
+                    if ! compgen -G "$pattern" >/dev/null; then
+                      echo "Missing macOS artifact matching $pattern" >&2
+                      find "$BUNDLE" -maxdepth 2 -mindepth 1 >&2 || true
+                      exit 1
+                    fi
+                  done
+                  echo "macOS updater artifacts present"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,17 @@ jobs:
           const fs = require('fs')
           const config = require('./apps/desktop/src-tauri/tauri.conf.json')
           const targets = new Set(config.bundle?.targets || [])
-          const requiredTargets = ['deb', 'rpm', 'appimage', 'nsis', 'dmg']
+          // `app` is what makes the macOS updater tarball (.app.tar.gz) exist: with an
+          // explicit targets list that omits it, the bundler warns "no updater-enabled
+          // targets were built" and deletes the .app, so darwin never reaches latest.json.
+          const requiredTargets = ['app', 'deb', 'rpm', 'appimage', 'nsis', 'dmg']
           const missingTargets = requiredTargets.filter((target) => !targets.has(target))
           if (missingTargets.length > 0) {
             throw new Error(`Missing Tauri bundle targets: ${missingTargets.join(', ')}`)
+          }
+
+          if (config.bundle?.createUpdaterArtifacts !== true) {
+            throw new Error('bundle.createUpdaterArtifacts must be true to publish updater assets')
           }
 
           const requiredFiles = [
@@ -172,6 +179,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-linux-assets
+          if-no-files-found: error
           path: |
             dora-x86_64-unknown-linux-gnu.tar.gz
             ./apps/desktop/src-tauri/target/release/bundle/deb/*.deb
@@ -240,6 +248,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-assets
+          if-no-files-found: error
           path: |
             ./apps/desktop/src-tauri/target/release/bundle/nsis/*.exe
             ./apps/desktop/src-tauri/target/release/bundle/nsis/*.exe.sig
@@ -279,10 +288,24 @@ jobs:
         with:
           projectPath: ./apps/desktop
 
+      - name: verify macOS updater artifacts exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          BUNDLE=./apps/desktop/src-tauri/target/release/bundle
+          for pattern in "$BUNDLE/dmg"/*.dmg "$BUNDLE/macos"/*.app.tar.gz "$BUNDLE/macos"/*.app.tar.gz.sig; do
+            if ! compgen -G "$pattern" >/dev/null; then
+              echo "Missing macOS release artifact matching $pattern" >&2
+              find "$BUNDLE" -maxdepth 2 -mindepth 1 >&2 || true
+              exit 1
+            fi
+          done
+
       - name: upload macOS assets
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-assets
+          if-no-files-found: error
           path: |
             ./apps/desktop/src-tauri/target/release/bundle/dmg/*.dmg
             ./apps/desktop/src-tauri/target/release/bundle/macos/*.app.tar.gz
@@ -317,14 +340,32 @@ jobs:
           gh run download "${{ github.run_id }}" -D /tmp/release-assets
 
           mapfile -t ASSETS < <(find /tmp/release-assets -type f | sort)
-          if [ "${#ASSETS[@]}" -lt 9 ]; then
-            echo "Expected at least 9 release assets, found ${#ASSETS[@]}" >&2
+          if [ "${#ASSETS[@]}" -lt 11 ]; then
+            echo "Expected at least 11 release assets, found ${#ASSETS[@]}" >&2
             find /tmp/release-assets -type f || true
             exit 1
           fi
 
-          if ! printf '%s\n' "${ASSETS[@]}" | grep -q '\.exe$'; then
-            echo "Missing Windows .exe installer in release assets." >&2
+          # Every updater channel needs its signed artifact here or latest.json
+          # silently ships without that platform (see #223 for the macOS case).
+          REQUIRED_PATTERNS=(
+            '\.exe$'
+            '\.exe\.sig$'
+            '\.AppImage$'
+            '\.AppImage\.sig$'
+            '\.dmg$'
+            '\.app\.tar\.gz$'
+            '\.app\.tar\.gz\.sig$'
+          )
+          MISSING=()
+          for pattern in "${REQUIRED_PATTERNS[@]}"; do
+            if ! printf '%s\n' "${ASSETS[@]}" | grep -q "$pattern"; then
+              MISSING+=("$pattern")
+            fi
+          done
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo "Missing required release assets matching: ${MISSING[*]}" >&2
+            printf '%s\n' "${ASSETS[@]}" >&2
             exit 1
           fi
 

--- a/__tests__/generate-latest-json.test.ts
+++ b/__tests__/generate-latest-json.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+	assertPlatformsPresent,
+	buildManifest,
+	collectPlatforms,
+	parseRequiredPlatforms,
+	platformFor,
+	REQUIRED_PLATFORMS
+} from '../tools/scripts/generate-latest-json'
+
+const LINUX = '/assets/release-linux-assets/appimage/Dora_0.38.0_amd64.AppImage'
+const WINDOWS = '/assets/release-windows-assets/nsis/Dora_0.38.0_x64-setup.exe'
+const MACOS = '/assets/release-macos-assets/macos/Dora.app.tar.gz'
+
+function sigsFor(artifacts: string[]): string[] {
+	return artifacts.flatMap((artifact) => [artifact, `${artifact}.sig`])
+}
+
+function fakeSignature(path: string): string {
+	return `signature-for:${path.split('/').pop()}\n`
+}
+
+describe('generate-latest-json platform mapping', function () {
+	it('maps updater artifacts to platform keys', function () {
+		expect(platformFor(LINUX)).toBe('linux-x86_64')
+		expect(platformFor(WINDOWS)).toBe('windows-x86_64')
+		expect(platformFor(MACOS)).toBe('darwin-aarch64')
+	})
+
+	it('ignores installer-only artifacts', function () {
+		expect(platformFor('/assets/Dora_0.38.0_aarch64.dmg')).toBeNull()
+		expect(platformFor('/assets/Dora_0.38.0_amd64.deb')).toBeNull()
+		expect(platformFor('/assets/Dora-0.38.0-1.x86_64.rpm')).toBeNull()
+	})
+
+	it('builds one entry per platform with a tag-scoped download url', function () {
+		const platforms = collectPlatforms(sigsFor([LINUX, WINDOWS, MACOS]), {
+			repo: 'remcostoeten/dora',
+			tag: 'v0.38.0',
+			readSignature: fakeSignature
+		})
+
+		expect(Object.keys(platforms).sort()).toEqual([
+			'darwin-aarch64',
+			'linux-x86_64',
+			'windows-x86_64'
+		])
+		expect(platforms['darwin-aarch64']).toEqual({
+			signature: 'signature-for:Dora.app.tar.gz.sig',
+			url: 'https://github.com/remcostoeten/dora/releases/download/v0.38.0/Dora.app.tar.gz'
+		})
+	})
+})
+
+describe('generate-latest-json missing-platform guard', function () {
+	it('accepts a manifest that covers every required platform', function () {
+		const manifest = buildManifest({
+			files: sigsFor([LINUX, WINDOWS, MACOS]),
+			rawVersion: 'v0.38.0',
+			repo: 'remcostoeten/dora',
+			notes: 'release notes',
+			readSignature: fakeSignature,
+			now: new Date('2026-07-27T00:00:00.000Z')
+		})
+
+		expect(manifest.version).toBe('0.38.0')
+		expect(Object.keys(manifest.platforms)).toHaveLength(3)
+	})
+
+	it('fails when the macOS updater artifacts are missing (#223)', function () {
+		expect(() =>
+			buildManifest({
+				files: sigsFor([LINUX, WINDOWS]),
+				rawVersion: 'v0.38.0',
+				repo: 'remcostoeten/dora',
+				notes: '',
+				readSignature: fakeSignature
+			})
+		).toThrow(/missing updater platforms: darwin-aarch64/)
+	})
+
+	it('does not treat a .dmg as macOS updater coverage', function () {
+		const dmg = '/assets/release-macos-assets/dmg/Dora_0.38.0_aarch64.dmg'
+		expect(() =>
+			buildManifest({
+				files: [...sigsFor([LINUX, WINDOWS]), dmg],
+				rawVersion: 'v0.38.0',
+				repo: 'remcostoeten/dora',
+				notes: '',
+				readSignature: fakeSignature
+			})
+		).toThrow(/darwin-aarch64/)
+	})
+
+	it('lists every missing platform when nothing is signed', function () {
+		expect(() => assertPlatformsPresent({})).toThrow(
+			/linux-x86_64, windows-x86_64, darwin-aarch64/
+		)
+	})
+
+	it('reports which platforms were found alongside the missing ones', function () {
+		expect(() =>
+			assertPlatformsPresent({ 'linux-x86_64': { signature: 'sig', url: 'https://example' } })
+		).toThrow(/Found: linux-x86_64/)
+	})
+
+	it('parses the require-platforms override', function () {
+		expect(parseRequiredPlatforms('')).toEqual(REQUIRED_PLATFORMS)
+		expect(parseRequiredPlatforms('none')).toEqual([])
+		expect(parseRequiredPlatforms('linux-x86_64, darwin-aarch64')).toEqual([
+			'linux-x86_64',
+			'darwin-aarch64'
+		])
+	})
+})

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -45,6 +45,7 @@
 			"binaries/duckdb_helper"
 		],
 		"targets": [
+			"app",
 			"deb",
 			"rpm",
 			"appimage",

--- a/tools/scripts/generate-latest-json.ts
+++ b/tools/scripts/generate-latest-json.ts
@@ -13,32 +13,30 @@
  *     --version=v0.30.0 \
  *     --notes-file=/tmp/release-notes.md \
  *     --repo=remcostoeten/dora \
- *     --output=/tmp/latest.json
+ *     --output=/tmp/latest.json \
+ *     [--require-platforms=linux-x86_64,windows-x86_64,darwin-aarch64]
  */
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+
+export type PlatformEntry = { signature: string; url: string }
+
+export type UpdaterManifest = {
+	version: string
+	notes: string
+	pub_date: string
+	platforms: Record<string, PlatformEntry>
+}
+
+/** Platforms every release must ship an updater artifact for. */
+export const REQUIRED_PLATFORMS = ['linux-x86_64', 'windows-x86_64', 'darwin-aarch64'] as const
 
 function arg(name: string, fallback = ''): string {
 	const hit = process.argv.find((a) => a.startsWith(`--${name}=`))
 	return hit ? hit.slice(name.length + 3) : fallback
 }
 
-const assetsDir = arg('assets-dir')
-const rawVersion = arg('version')
-const notesFile = arg('notes-file')
-const repo = arg('repo', 'remcostoeten/dora')
-const output = arg('output', 'latest.json')
-
-if (!assetsDir || !rawVersion) {
-	console.error('Missing required --assets-dir / --version')
-	process.exit(2)
-}
-
-// The updater compares against the installed app version, which carries no "v".
-const version = rawVersion.replace(/^v/, '')
-const tag = rawVersion.startsWith('v') ? rawVersion : `v${rawVersion}`
-
-function walk(dir: string): string[] {
+export function walk(dir: string): string[] {
 	const out: string[] = []
 	for (const entry of readdirSync(dir)) {
 		const full = join(dir, entry)
@@ -48,48 +46,139 @@ function walk(dir: string): string[] {
 	return out
 }
 
-// Map an updater artifact filename to its platform key. Returns null for files
-// that are not updater targets (e.g. .deb, .rpm, .dmg, .msi installers).
-function platformFor(file: string): string | null {
+/**
+ * Maps an updater artifact filename to its platform key, or null when the file
+ * is not an updater target (e.g. .deb, .rpm, .dmg, .msi installers).
+ */
+export function platformFor(file: string): string | null {
 	if (file.endsWith('.AppImage')) return 'linux-x86_64'
 	if (file.endsWith('.app.tar.gz')) return 'darwin-aarch64'
 	if (file.endsWith('-setup.exe') || file.endsWith('.exe')) return 'windows-x86_64'
 	return null
 }
 
-const files = walk(assetsDir)
-const sigs = files.filter((f) => f.endsWith('.sig'))
+/**
+ * Collects one updater entry per platform from the `.sig` files in `files`.
+ * NSIS `-setup.exe` and bare `.exe` both map to windows — the first match wins
+ * deterministically.
+ */
+export function collectPlatforms(
+	files: string[],
+	options: { repo: string; tag: string; readSignature?: (path: string) => string }
+): Record<string, PlatformEntry> {
+	const read = options.readSignature ?? ((path: string) => readFileSync(path, 'utf8'))
+	const platforms: Record<string, PlatformEntry> = {}
 
-const platforms: Record<string, { signature: string; url: string }> = {}
+	for (const sig of files.filter((f) => f.endsWith('.sig'))) {
+		const artifact = sig.slice(0, -'.sig'.length)
+		const platform = platformFor(artifact)
+		if (!platform) continue
+		if (platforms[platform]) continue
+		const filename = artifact.split('/').pop() as string
+		platforms[platform] = {
+			signature: read(sig).trim(),
+			url: `https://github.com/${options.repo}/releases/download/${options.tag}/${encodeURIComponent(filename)}`
+		}
+	}
 
-for (const sig of sigs) {
-	const artifact = sig.slice(0, -'.sig'.length)
-	const platform = platformFor(artifact)
-	if (!platform) continue
-	const filename = artifact.split('/').pop() as string
-	const signature = readFileSync(sig, 'utf8').trim()
-	const url = `https://github.com/${repo}/releases/download/${tag}/${encodeURIComponent(filename)}`
-	// Prefer the first artifact found per platform; NSIS `-setup.exe` and bare
-	// `.exe` both map to windows — keep whichever appears first deterministically.
-	if (!platforms[platform]) {
-		platforms[platform] = { signature, url }
+	return platforms
+}
+
+/**
+ * Throws with an actionable message when any expected platform has no updater
+ * artifact, so a release never silently ships without a channel (see #223).
+ */
+export function assertPlatformsPresent(
+	platforms: Record<string, PlatformEntry>,
+	expected: readonly string[] = REQUIRED_PLATFORMS
+): void {
+	const missing = expected.filter((platform) => !platforms[platform])
+	if (missing.length === 0) return
+
+	const found = Object.keys(platforms)
+	throw new Error(
+		[
+			`latest.json is missing updater platforms: ${missing.join(', ')}`,
+			`Found: ${found.length > 0 ? found.join(', ') : '(none)'}`,
+			'Each platform needs its signed updater artifact in the assets dir:',
+			'  linux-x86_64   -> *.AppImage + *.AppImage.sig',
+			'  windows-x86_64 -> *-setup.exe + *-setup.exe.sig',
+			'  darwin-aarch64 -> *.app.tar.gz + *.app.tar.gz.sig (needs the "app" bundle target)'
+		].join('\n')
+	)
+}
+
+export function buildManifest(input: {
+	files: string[]
+	rawVersion: string
+	repo: string
+	notes: string
+	expectedPlatforms?: readonly string[]
+	readSignature?: (path: string) => string
+	now?: Date
+}): UpdaterManifest {
+	const version = input.rawVersion.replace(/^v/, '')
+	const tag = input.rawVersion.startsWith('v') ? input.rawVersion : `v${input.rawVersion}`
+	const platforms = collectPlatforms(input.files, {
+		repo: input.repo,
+		tag,
+		readSignature: input.readSignature
+	})
+
+	assertPlatformsPresent(platforms, input.expectedPlatforms)
+
+	return {
+		version,
+		notes: input.notes,
+		pub_date: (input.now ?? new Date()).toISOString(),
+		platforms
 	}
 }
 
-if (Object.keys(platforms).length === 0) {
-	console.error('No signed updater artifacts (.sig) found — did createUpdaterArtifacts + signing run?')
-	console.error(`Scanned: ${files.length} files under ${assetsDir}`)
-	process.exit(1)
+export function parseRequiredPlatforms(raw: string): readonly string[] {
+	if (!raw) return REQUIRED_PLATFORMS
+	if (raw === 'none') return []
+	return raw
+		.split(',')
+		.map((entry) => entry.trim())
+		.filter(Boolean)
 }
 
-const notes = notesFile ? readFileSync(notesFile, 'utf8').trim() : ''
+function main(): void {
+	const assetsDir = arg('assets-dir')
+	const rawVersion = arg('version')
+	const notesFile = arg('notes-file')
+	const repo = arg('repo', 'remcostoeten/dora')
+	const output = arg('output', 'latest.json')
 
-const manifest = {
-	version,
-	notes,
-	pub_date: new Date().toISOString(),
-	platforms
+	if (!assetsDir || !rawVersion) {
+		console.error('Missing required --assets-dir / --version')
+		process.exit(2)
+	}
+
+	const files = walk(assetsDir)
+
+	try {
+		const manifest = buildManifest({
+			files,
+			rawVersion,
+			repo,
+			notes: notesFile ? readFileSync(notesFile, 'utf8').trim() : '',
+			expectedPlatforms: parseRequiredPlatforms(arg('require-platforms'))
+		})
+		writeFileSync(output, JSON.stringify(manifest, null, 2))
+		console.log(`Wrote ${output} with platforms: ${Object.keys(manifest.platforms).join(', ')}`)
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error))
+		console.error(`Scanned ${files.length} files under ${assetsDir}`)
+		process.exit(1)
+	}
 }
 
-writeFileSync(output, JSON.stringify(manifest, null, 2))
-console.log(`Wrote ${output} with platforms: ${Object.keys(platforms).join(', ')}`)
+function isDirectInvocation(): boolean {
+	return Boolean(process.argv[1]?.endsWith('generate-latest-json.ts'))
+}
+
+if (isDirectInvocation()) {
+	main()
+}


### PR DESCRIPTION
Fixes #223

## Root cause (confirmed from the v0.37.0 macOS job log)

`bundle.targets` in `apps/desktop/src-tauri/tauri.conf.json` was an explicit list — `deb, rpm, appimage, nsis, dmg` — with no `app`. On macOS that is the only updater-enabled target, so the bundler did exactly this in run [30212273445](https://github.com/remcostoeten/dora/actions/runs/30212273445):

```
Warn The bundler was configured to create updater artifacts but no updater-enabled
     targets were built. Please enable one of these targets: app, appimage, msi, nsis
Cleaning .../bundle/macos/Dora.app
Finished 1 bundle at:
    .../bundle/dmg/Dora_0.37.0_aarch64.dmg
...
Looking for artifacts in:
    .../bundle/macos/Dora.app.tar.gz
    .../bundle/macos/Dora.app.tar.gz.sig
Found artifacts:
    .../bundle/dmg/Dora_0.37.0_aarch64.dmg
```

So: no `.app` -> no `.app.tar.gz` -> the upload glob matched nothing. It was silent because `actions/upload-artifact` defaults to `if-no-files-found: warn`, and `generate-latest-json.ts` derives platforms purely from the `.sig` files it happens to find, so it happily wrote a two-platform manifest and exited 0.

Ruled out: the signing secrets **are** passed to `release-macos` exactly like the other jobs (the log shows `TAURI_SIGNING_PRIVATE_KEY: ***` / `..._PASSWORD: ***`), and `createUpdaterArtifacts` was already `true`.

## Changes

- **`tauri.conf.json`** — add `app` to `bundle.targets`. It is macOS-only; Tauri filters package types per target OS, so Linux/Windows bundling is unchanged.
- **`release.yml` preflight** — require the `app` target and assert `createUpdaterArtifacts === true`.
- **`release.yml` per-platform uploads** — `if-no-files-found: error` on all three, plus an explicit pre-upload check in `release-macos` that the `.dmg`, `.app.tar.gz` and `.app.tar.gz.sig` all exist (the upload action only errors when *every* pattern misses, so the glob-level check is what actually catches this class of bug).
- **`release.yml` publish gate** — the "at least N assets" check now also requires each signed updater asset by pattern: `.exe`, `.exe.sig`, `.AppImage`, `.AppImage.sig`, `.dmg`, `.app.tar.gz`, `.app.tar.gz.sig` (count bumped 9 -> 11).
- **`generate-latest-json.ts`** — refactored into exported pure functions (`collectPlatforms`, `assertPlatformsPresent`, `buildManifest`) with a thin CLI `main()`. It now exits non-zero with an actionable message when any of `linux-x86_64`, `windows-x86_64`, `darwin-aarch64` is missing. `--require-platforms=` overrides the set (`none` disables the check) for local use.
- **`ci-mac.yml`** — pass the signing secrets and assert the three macOS artifacts, so the existing `workflow_dispatch` mac build doubles as a dry-run for this fix. This is also required: with `app` in the targets, a macOS build now signs, and would fail without the key.

## Verification

- New `__tests__/generate-latest-json.test.ts` — 9 tests, all passing. Covers platform mapping, the tag-scoped URL, and the missing-platform failure (including "a `.dmg` alone does not count as macOS coverage", i.e. the exact v0.36/v0.37 shape).
- CLI smoke: against a fake assets dir with only linux+windows `.sig` files the script exits 1 with the missing-platform message; adding `Dora.app.tar.gz.sig` makes it exit 0 with all three platforms.
- The new publish-gate bash was replayed against the literal v0.37.0 asset list — it fails with `Missing required release assets matching: \.app\.tar\.gz$ \.app\.tar\.gz\.sig$` — and against the expected post-fix list, where it passes.
- Preflight target/updater check and both workflow YAML files parse and evaluate locally.
- `oxfmt --check` and `oxlint` clean on the changed TS files.

## Not verifiable without a real macOS run

That the bundler now actually emits `bundle/macos/Dora.app.tar.gz{,.sig}` can only be proven on a mac runner. The `CI Mac` workflow_dispatch run on this branch is the dry-run for it; otherwise the next tagged release is the proof — and if it regresses, the release now fails red instead of shipping a darwin-less `latest.json`.

Note: the mac updater channel is `darwin-aarch64` only (release-macos runs on `macos-latest`, which is Apple Silicon). Intel macs still have no updater channel — out of scope here.

## Summary by Sourcery

Ensure macOS updater artifacts are built and shipped for releases and fail the pipeline when required updater platforms or assets are missing.

New Features:
- Add a configurable required-platforms check to generate-latest-json so releases must include updater artifacts for specific platforms.

Bug Fixes:
- Fix missing macOS updater artifacts by including the app bundle target and ensuring its updater tarball and signature are produced and uploaded.

Enhancements:
- Refactor generate-latest-json into reusable pure functions with a thin CLI wrapper for easier testing and extension.
- Tighten the release workflow to require the app target, enforce updater artifact creation, and validate that each updater platform has its corresponding signed asset before publishing.
- Update the macOS CI workflow to run signed builds and verify the presence of macOS updater artifacts as a dry run for releases.

CI:
- Make upload-artifact steps in release workflows fail on missing files and add a publish gate that checks for all required updater asset patterns across platforms.

Tests:
- Add unit tests for generate-latest-json covering platform mapping, manifest construction, required-platform overrides, and missing-platform failure behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS desktop releases now include signed updater artifacts.
  * Release bundles now generate and validate updater packages for Windows, Linux, and macOS.
  * Updater manifests now include downloads for all required platforms.

* **Bug Fixes**
  * Releases now fail clearly when expected installers, signatures, or platform artifacts are missing.

* **Tests**
  * Added coverage for platform detection, manifest generation, and missing-artifact validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->