### PR TITLE
feat: motion polish across the Studio (eight animation improvements)

### DIFF
--- a/__tests__/apps/desktop/src/features/connections/connection-switcher.test.tsx
+++ b/__tests__/apps/desktop/src/features/connections/connection-switcher.test.tsx
@@ -95,13 +95,51 @@ describe('ConnectionSwitcher', function () {
 			expect(screen.getByPlaceholderText('Search connections...')).toBeInTheDocument()
 		})
 
-		fireEvent.click(screen.getByRole('button', { name: /delete local postgres/i }))
+		completeHold(screen.getByRole('button', { name: /hold to delete local postgres/i }))
 		expect(onDeleteConnection).toHaveBeenCalledWith('local-postgres')
 
 		expect(screen.getByPlaceholderText('Search connections...')).toBeInTheDocument()
 
-		fireEvent.click(screen.getByRole('button', { name: /delete analytics/i }))
+		completeHold(screen.getByRole('button', { name: /hold to delete analytics/i }))
 		expect(onDeleteConnection).toHaveBeenCalledWith('analytics')
 		expect(screen.getByPlaceholderText('Search connections...')).toBeInTheDocument()
 	})
+
+	it('never deletes on a plain click — only a completed hold confirms', async function () {
+		const user = userEvent.setup()
+		const onDeleteConnection = vi.fn()
+		renderSwitcher({ onDeleteConnection })
+
+		const trigger = await screen.findByRole('button', {
+			name: /change database connection/i
+		})
+		trigger.focus()
+		await user.keyboard('{Enter}')
+
+		await waitFor(function () {
+			expect(screen.getByPlaceholderText('Search connections...')).toBeInTheDocument()
+		})
+
+		const deleteButton = screen.getByRole('button', { name: /hold to delete local postgres/i })
+		fireEvent.click(deleteButton)
+		expect(onDeleteConnection).not.toHaveBeenCalled()
+
+		fireEvent.pointerDown(deleteButton)
+		fireEvent.pointerUp(deleteButton)
+		fireCompletedFillTransition(deleteButton)
+		expect(onDeleteConnection).not.toHaveBeenCalled()
+	})
 })
+
+function completeHold(button: HTMLElement) {
+	fireEvent.pointerDown(button)
+	fireCompletedFillTransition(button)
+}
+
+function fireCompletedFillTransition(button: HTMLElement) {
+	const fill = button.querySelector('span')
+	if (!fill) throw new Error('hold-to-confirm fill overlay not found')
+	const transitionEnd = new Event('transitionend', { bubbles: true })
+	Object.assign(transitionEnd, { propertyName: 'clip-path' })
+	fireEvent(fill, transitionEnd)
+}

--- a/packages/studio/src/features/ai-assistant/ai-assistant-panel.tsx
+++ b/packages/studio/src/features/ai-assistant/ai-assistant-panel.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAdapter, useIsTauri } from '@studio/core/data-provider'
 import type { DatabaseSchema } from '@studio/lib/bindings'
 import { Button } from '@studio/shared/ui/button'
+import { usePresence } from '@studio/shared/hooks/use-presence'
 import { cn } from '@studio/shared/utils/cn'
 import { getTableRefId } from '@studio/shared/utils/table-ref'
 import { formatAiStatusBadge, useAiStatus } from './use-ai-status'
@@ -190,7 +191,9 @@ export function AiAssistantPanel({
 		[handleSend, isStreaming, abort, setOpen]
 	)
 
-	if (!open) return null
+	const { present, state } = usePresence(open, 200)
+
+	if (!present) return null
 
 	const keysAvailable = aiStatus?.ready ?? false
 	const keyLabel = formatAiStatusBadge(aiStatus, isMock)
@@ -207,8 +210,10 @@ export function AiAssistantPanel({
 
 	return (
 		<aside
+			data-state={state}
 			className={cn(
-				'fixed right-0 top-9 z-40 flex h-[calc(100%-2.25rem)] w-[420px] max-w-[90vw] flex-col border-l border-sidebar-border bg-sidebar shadow-2xl'
+				'fixed right-0 top-9 z-40 flex h-[calc(100%-2.25rem)] w-[420px] max-w-[90vw] flex-col border-l border-sidebar-border bg-sidebar shadow-2xl',
+				'transition-[transform,opacity] duration-200 data-[state=open]:duration-[240ms] ease-[var(--ease-out)] data-[state=closed]:translate-x-full motion-reduce:data-[state=closed]:translate-x-0 motion-reduce:data-[state=closed]:opacity-0 motion-reduce:duration-150'
 			)}
 		>
 			<header className='flex items-center gap-2 border-b border-sidebar-border px-3 py-2'>

--- a/packages/studio/src/features/connection-tab-bar/connection-tab-bar.tsx
+++ b/packages/studio/src/features/connection-tab-bar/connection-tab-bar.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Eye, Pencil, Plus, X, Trash2 } from 'lucide-react'
 import { cn } from '@studio/shared/utils/cn'
 import type { Connection } from '@studio/features/connections/types'
@@ -54,6 +54,37 @@ function statusLabel(status: Connection['status']): string {
   }
 }
 
+function StatusDot({ status }: { status: Connection['status'] }) {
+  const prevStatusRef = useRef(status)
+  const [flash, setFlash] = useState<'success' | 'error' | null>(null)
+
+  useEffect(
+    function flashOnTransition() {
+      if (prevStatusRef.current === status) return
+      prevStatusRef.current = status
+      if (status === 'connected') setFlash('success')
+      else if (status === 'error') setFlash('error')
+      else setFlash(null)
+    },
+    [status]
+  )
+
+  return (
+    <span
+      aria-hidden="true"
+      onAnimationEnd={function clearFlash() {
+        setFlash(null)
+      }}
+      className={cn(
+        'h-2 w-2 shrink-0 rounded-full transition-colors duration-300 ease-[var(--ease-out)]',
+        statusColor(status),
+        flash === 'success' && 'connection-status-success',
+        flash === 'error' && 'connection-status-error'
+      )}
+    />
+  )
+}
+
 export function ConnectionTabBar({
   connections,
   activeConnectionId,
@@ -99,10 +130,7 @@ export function ConnectionTabBar({
                     aria-current={isActive ? 'page' : undefined}
                     aria-label={`${connection.name}, ${statusLabel(connection.status)}`}
                   >
-                    <span
-                      aria-hidden="true"
-                      className={cn('h-2 w-2 shrink-0 rounded-full', statusColor(connection.status))}
-                    />
+                    <StatusDot status={connection.status} />
                     <span className="max-w-[140px] truncate">{connection.name}</span>
                   </button>
                   <button

--- a/packages/studio/src/features/connections/components/connection-switcher.tsx
+++ b/packages/studio/src/features/connections/components/connection-switcher.tsx
@@ -114,6 +114,8 @@ const ConnectionMenuRow = forwardRef<HTMLDivElement, ConnectionMenuRowProps>(
 		},
 		ref
 	) {
+		const [isHolding, setIsHolding] = useState(false)
+
 		return (
 			<div
 				ref={ref}
@@ -209,29 +211,77 @@ const ConnectionMenuRow = forwardRef<HTMLDivElement, ConnectionMenuRowProps>(
 								data-connection-action
 								type='button'
 								className={cn(
-									'flex h-6 w-6 items-center justify-center rounded-sm',
+									'relative overflow-hidden flex h-6 w-6 items-center justify-center rounded-sm',
 									'text-muted-foreground',
 									'opacity-0 -translate-x-1 pointer-events-none',
 									'group-hover/row:opacity-100 group-hover/row:translate-x-0 group-hover/row:pointer-events-auto',
 									'group-data-[highlighted]/row:opacity-100 group-data-[highlighted]/row:translate-x-0 group-data-[highlighted]/row:pointer-events-auto',
 									'transition-[opacity,transform,color] duration-150 ease-[var(--ease-out)]',
 									'hover:text-destructive hover:bg-background/60',
+									isHolding && 'text-destructive-foreground',
 									'focus-visible:outline-hidden focus-visible:opacity-100 focus-visible:translate-x-0 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-destructive/40'
 								)}
 								onPointerDown={function (e) {
 									onKeepOpenAfterDelete()
 									e.preventDefault()
 									e.stopPropagation()
+									/*
+									 * jsdom's synthetic pointer events fall back to MouseEvent with
+									 * no pointerId, and its setPointerCapture throws on it — capture
+									 * only when the event carries a real pointer.
+									 */
+									if (
+										e.pointerId != null &&
+										typeof e.currentTarget.setPointerCapture === 'function'
+									) {
+										e.currentTarget.setPointerCapture(e.pointerId)
+									}
+									setIsHolding(true)
+								}}
+								onPointerUp={function () {
+									setIsHolding(false)
+								}}
+								onPointerCancel={function () {
+									setIsHolding(false)
+								}}
+								onKeyDown={function (e) {
+									if (e.key !== 'Enter' && e.key !== ' ') return
+									e.preventDefault()
+									e.stopPropagation()
+									if (!isHolding) {
+										onKeepOpenAfterDelete()
+										setIsHolding(true)
+									}
+								}}
+								onKeyUp={function (e) {
+									if (e.key === 'Enter' || e.key === ' ') setIsHolding(false)
+								}}
+								onBlur={function () {
+									setIsHolding(false)
 								}}
 								onClick={function (e) {
 									e.preventDefault()
 									e.stopPropagation()
-									onConfirmDelete(connection.id)
 								}}
-								title={`Delete ${connection.name}`}
-								aria-label={`Delete ${connection.name}`}
+								title={`Hold to delete ${connection.name}`}
+								aria-label={`Hold to delete ${connection.name}`}
 							>
-								<Trash2 className='h-3 w-3' />
+								<span
+									aria-hidden='true'
+									className={cn(
+										'pointer-events-none absolute inset-0 bg-destructive',
+										isHolding
+											? '[clip-path:inset(0_0_0_0)] transition-[clip-path] duration-[2000ms] ease-linear'
+											: '[clip-path:inset(0_100%_0_0)] transition-[clip-path] duration-200 ease-[var(--ease-out)]'
+									)}
+									onTransitionEnd={function (e) {
+										if (e.propertyName !== 'clip-path') return
+										if (!isHolding) return
+										setIsHolding(false)
+										onConfirmDelete(connection.id)
+									}}
+								/>
+								<Trash2 className='relative h-3 w-3' />
 							</button>
 						)}
 					</div>

--- a/packages/studio/src/features/database-studio/components/cell-context-menu.tsx
+++ b/packages/studio/src/features/database-studio/components/cell-context-menu.tsx
@@ -21,6 +21,8 @@ type Props = {
 	row?: Record<string, unknown>
 	selectedRows?: Set<number>
 	hasFilter?: boolean
+	/** Hides the mutating items (edit cell, set to NULL) for readonly sources. */
+	canEdit?: boolean
 	onAction?: (
 		action: CellAction,
 		value: unknown,
@@ -47,6 +49,7 @@ export function CellContextMenuItems({
 	row,
 	selectedRows,
 	hasFilter = false,
+	canEdit = true,
 	onAction,
 	onBlobAction
 }: Props) {
@@ -96,11 +99,15 @@ export function CellContextMenuItems({
 
 	return (
 		<>
-			<ContextMenuItem onClick={handleEdit}>
-				<Pencil />
-				<span>Edit cell</span>
-			</ContextMenuItem>
-			<ContextMenuSeparator />
+			{canEdit && (
+				<>
+					<ContextMenuItem onClick={handleEdit}>
+						<Pencil />
+						<span>Edit cell</span>
+					</ContextMenuItem>
+					<ContextMenuSeparator />
+				</>
+			)}
 			<ContextMenuItem onClick={handleCopy}>
 				<Copy />
 				<span>Copy value</span>
@@ -145,13 +152,19 @@ export function CellContextMenuItems({
 				<Filter />
 				<span>Filter by this value</span>
 			</ContextMenuItem>
-			<ContextMenuSeparator />
-			<ContextMenuItem onClick={handleSetNull} variant='destructive'>
-				<Trash2 />
-				<span>
-					{hasSelectedRows ? `Set to NULL (${selectedRows!.size} rows)` : 'Set to NULL'}
-				</span>
-			</ContextMenuItem>
+			{canEdit && (
+				<>
+					<ContextMenuSeparator />
+					<ContextMenuItem onClick={handleSetNull} variant='destructive'>
+						<Trash2 />
+						<span>
+							{hasSelectedRows
+								? `Set to NULL (${selectedRows!.size} rows)`
+								: 'Set to NULL'}
+						</span>
+					</ContextMenuItem>
+				</>
+			)}
 		</>
 	)
 }

--- a/packages/studio/src/features/database-studio/components/data-file-help-panel.tsx
+++ b/packages/studio/src/features/database-studio/components/data-file-help-panel.tsx
@@ -35,8 +35,8 @@ export function DataFileHelpPanel({ className, defaultOpen = false }: Props) {
 					aria-hidden
 				/>
 			</CollapsibleTrigger>
-			<CollapsibleContent className='pt-2'>
-				<ul className='space-y-1.5 text-xs leading-relaxed text-muted-foreground'>
+			<CollapsibleContent>
+				<ul className='pt-2 space-y-1.5 text-xs leading-relaxed text-muted-foreground'>
 					{DATA_FILE_HELP_ITEMS.map(function (item) {
 						return (
 							<li key={item} className='flex gap-2'>

--- a/packages/studio/src/features/database-studio/components/data-grid.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid.tsx
@@ -57,6 +57,8 @@ type Props = {
 		rowIndex: number,
 		batchIndexes?: number[]
 	) => void
+	/** Whether the source allows mutating rows; hides edit/delete menu items when false. */
+	canEditRows?: boolean
 	tableName?: string
 	selectedCells?: Set<string>
 	onCellSelectionChange?: (cells: Set<string>) => void
@@ -95,6 +97,7 @@ export function DataGrid({
 	onDeleteSelectedRows,
 	onBatchCellEdit,
 	onRowAction,
+	canEditRows = true,
 	tableName,
 	selectedCells: externalSelectedCells,
 	onCellSelectionChange,
@@ -392,6 +395,7 @@ export function DataGrid({
 					startCellEdit={handleCellDoubleClick}
 					onBlobAction={onBlobAction}
 					onRowAction={onRowAction}
+					canEditRows={canEditRows}
 				>
 					<table
 						ref={gridRef}

--- a/packages/studio/src/features/database-studio/components/data-grid/grid-context-menu.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid/grid-context-menu.tsx
@@ -106,6 +106,7 @@ type Props = {
 		rowIndex: number,
 		batchIndexes?: number[]
 	) => void
+	canEditRows?: boolean
 	children: React.ReactNode
 }
 
@@ -129,6 +130,7 @@ export function GridContextMenu({
 	startCellEdit,
 	onBlobAction,
 	onRowAction,
+	canEditRows = true,
 	children
 }: Props) {
 	const targetRow = target ? rows[target.rowIndex] : undefined
@@ -157,6 +159,7 @@ export function GridContextMenu({
 						row={targetRow}
 						selectedRows={menuSelectedRows}
 						hasFilter={!!onFilterAdd}
+						canEdit={canEditRows}
 						onBlobAction={onBlobAction}
 						onAction={function (action, value, column, batchAction) {
 							if (action === 'filter-by-value' && onFilterAdd) {
@@ -183,6 +186,7 @@ export function GridContextMenu({
 						tableName={tableName}
 						allRows={rows}
 						selectedRows={menuSelectedRows}
+						canEdit={canEditRows}
 						onAction={onRowAction}
 					/>
 				) : null}

--- a/packages/studio/src/features/database-studio/components/data-grid/use-cell-editing.ts
+++ b/packages/studio/src/features/database-studio/components/data-grid/use-cell-editing.ts
@@ -59,36 +59,35 @@ export function useCellEditing({
 		[gridRef]
 	)
 
-	const handleCellDoubleClick = useCallback(function (
-		rowIndex: number,
-		columnName: string,
-		currentValue: unknown
-	) {
-		const nextEditingCell = { rowIndex, columnName }
-		editingCellRef.current = nextEditingCell
-		editSelectModeRef.current = 'all'
-		setEditingCell(nextEditingCell)
-		const originalValue = valueToEditString(currentValue)
-		originalEditValueRef.current = originalValue
-		setEditValue(originalValue)
-	}, [])
+	const handleCellDoubleClick = useCallback(
+		function (rowIndex: number, columnName: string, currentValue: unknown) {
+			if (!onCellEdit) return
+			const nextEditingCell = { rowIndex, columnName }
+			editingCellRef.current = nextEditingCell
+			editSelectModeRef.current = 'all'
+			setEditingCell(nextEditingCell)
+			const originalValue = valueToEditString(currentValue)
+			originalEditValueRef.current = originalValue
+			setEditValue(originalValue)
+		},
+		[onCellEdit]
+	)
 
 	// Start editing by typing a character into a focused cell. The typed char
 	// seeds the editor and the caret sits after it, so nothing is dropped and
 	// further typing appends (vs. select-all which would overwrite the seed).
-	const startTypeEdit = useCallback(function (
-		rowIndex: number,
-		columnName: string,
-		currentValue: unknown,
-		char: string
-	) {
-		const nextEditingCell = { rowIndex, columnName }
-		editingCellRef.current = nextEditingCell
-		editSelectModeRef.current = 'end'
-		originalEditValueRef.current = valueToEditString(currentValue)
-		setEditingCell(nextEditingCell)
-		setEditValue(char)
-	}, [])
+	const startTypeEdit = useCallback(
+		function (rowIndex: number, columnName: string, currentValue: unknown, char: string) {
+			if (!onCellEdit) return
+			const nextEditingCell = { rowIndex, columnName }
+			editingCellRef.current = nextEditingCell
+			editSelectModeRef.current = 'end'
+			originalEditValueRef.current = valueToEditString(currentValue)
+			setEditingCell(nextEditingCell)
+			setEditValue(char)
+		},
+		[onCellEdit]
+	)
 
 	const commitEdit = useCallback(
 		function ({ clear, refocus }: { clear: boolean; refocus: boolean }) {

--- a/packages/studio/src/features/database-studio/components/pending-changes-bar.tsx
+++ b/packages/studio/src/features/database-studio/components/pending-changes-bar.tsx
@@ -1,6 +1,8 @@
+import { useRef } from 'react'
 import { Check, X, Edit3 } from 'lucide-react'
 import { Spinner } from '@studio/shared/ui/spinner'
 import { Button } from '@studio/shared/ui/button'
+import { usePresence } from '@studio/shared/hooks/use-presence'
 import { cn } from '@studio/shared/utils/cn'
 
 type Props = {
@@ -12,43 +14,58 @@ type Props = {
 }
 
 export function PendingChangesBar({ editCount, isApplying, onApply, onCancel, className }: Props) {
-	if (editCount === 0) return null
+	const open = editCount > 0
+	const { present, state } = usePresence(open, 200)
+	const lastCountRef = useRef(editCount)
+	if (editCount > 0) {
+		lastCountRef.current = editCount
+	}
+	const displayCount = editCount > 0 ? editCount : lastCountRef.current
+
+	if (!present) return null
 
 	return (
 		<div
-			className={cn(
-				'flex items-center justify-between gap-4 px-4 py-2 bg-primary/10 border-t border-primary/20',
-				className
-			)}
+			data-state={state}
+			className='grid grid-rows-[0fr] opacity-0 data-[state=open]:grid-rows-[1fr] data-[state=open]:opacity-100 transition-[grid-template-rows,opacity] duration-200 ease-[var(--ease-out)] motion-reduce:transition-[opacity]'
 		>
-			<div className='flex items-center gap-2 text-sm'>
-				<Edit3 className='h-4 w-4 text-primary' />
-				<span className='font-medium'>
-					Edited <span className='text-primary'>{editCount}</span>{' '}
-					{editCount === 1 ? 'cell' : 'cells'}
-				</span>
-				<span className='text-muted-foreground'>(changes not saved)</span>
-			</div>
-
-			<div className='flex items-center gap-2'>
-				<Button
-					variant='ghost'
-					size='sm'
-					onClick={onCancel}
-					disabled={isApplying}
-					className='gap-1.5'
-				>
-					<X className='h-4 w-4' />
-					Discard
-				</Button>
-				<Button size='sm' onClick={onApply} disabled={isApplying} className='gap-1.5'>
-					{isApplying ? (
-						<Spinner className='h-4 w-4' />
-					) : (
-						<Check className='h-4 w-4' />
+			<div className='overflow-hidden'>
+				<div
+					className={cn(
+						'flex items-center justify-between gap-4 px-4 py-2 bg-primary/10 border-t border-primary/20',
+						className
 					)}
-					Apply Changes
-				</Button>
+				>
+					<div className='flex items-center gap-2 text-sm'>
+						<Edit3 className='h-4 w-4 text-primary' />
+						<span className='font-medium'>
+							Edited <span className='text-primary'>{displayCount}</span>{' '}
+							{displayCount === 1 ? 'cell' : 'cells'}
+						</span>
+						<span className='text-muted-foreground'>(changes not saved)</span>
+					</div>
+
+					<div className='flex items-center gap-2'>
+						<Button
+							variant='ghost'
+							size='sm'
+							onClick={onCancel}
+							disabled={isApplying}
+							className='gap-1.5'
+						>
+							<X className='h-4 w-4' />
+							Discard
+						</Button>
+						<Button size='sm' onClick={onApply} disabled={isApplying} className='gap-1.5'>
+							{isApplying ? (
+								<Spinner className='h-4 w-4' />
+							) : (
+								<Check className='h-4 w-4' />
+							)}
+							Apply Changes
+						</Button>
+					</div>
+				</div>
 			</div>
 		</div>
 	)

--- a/packages/studio/src/features/database-studio/components/row-context-menu.tsx
+++ b/packages/studio/src/features/database-studio/components/row-context-menu.tsx
@@ -23,6 +23,8 @@ type Props = {
 		batchIndexes?: number[]
 	) => void
 	selectedRows?: Set<number>
+	/** Hides the mutating items (edit, duplicate, delete) for readonly sources. */
+	canEdit?: boolean
 }
 
 /**
@@ -36,7 +38,8 @@ export function RowContextMenuItems({
 	tableName,
 	allRows,
 	onAction,
-	selectedRows
+	selectedRows,
+	canEdit = true
 }: Props) {
 	const isSelected = selectedRows?.has(rowIndex)
 	const batchCount = isSelected && selectedRows ? selectedRows.size : 0
@@ -109,22 +112,26 @@ export function RowContextMenuItems({
 				<Eye />
 				<span>View details</span>
 			</ContextMenuItem>
-			<ContextMenuItem
-				onClick={function () {
-					handleAction('edit')
-				}}
-			>
-				<Pencil />
-				<span>Edit row</span>
-			</ContextMenuItem>
-			<ContextMenuItem
-				onClick={function () {
-					handleAction('duplicate')
-				}}
-			>
-				<CopyPlus />
-				<span>{isBatch ? `Duplicate ${batchCount} rows` : 'Duplicate below'}</span>
-			</ContextMenuItem>
+			{canEdit && (
+				<>
+					<ContextMenuItem
+						onClick={function () {
+							handleAction('edit')
+						}}
+					>
+						<Pencil />
+						<span>Edit row</span>
+					</ContextMenuItem>
+					<ContextMenuItem
+						onClick={function () {
+							handleAction('duplicate')
+						}}
+					>
+						<CopyPlus />
+						<span>{isBatch ? `Duplicate ${batchCount} rows` : 'Duplicate below'}</span>
+					</ContextMenuItem>
+				</>
+			)}
 
 			<ContextMenuSeparator />
 
@@ -147,17 +154,21 @@ export function RowContextMenuItems({
 				</ContextMenuSubContent>
 			</ContextMenuSub>
 
-			<ContextMenuSeparator />
+			{canEdit && (
+				<>
+					<ContextMenuSeparator />
 
-			<ContextMenuItem
-				onClick={function () {
-					handleAction('delete')
-				}}
-				variant='destructive'
-			>
-				<Trash2 />
-				<span>{isBatch ? `Delete ${batchCount} rows` : 'Delete row'}</span>
-			</ContextMenuItem>
+					<ContextMenuItem
+						onClick={function () {
+							handleAction('delete')
+						}}
+						variant='destructive'
+					>
+						<Trash2 />
+						<span>{isBatch ? `Delete ${batchCount} rows` : 'Delete row'}</span>
+					</ContextMenuItem>
+				</>
+			)}
 		</>
 	)
 }

--- a/packages/studio/src/features/database-studio/components/row-detail-panel.tsx
+++ b/packages/studio/src/features/database-studio/components/row-detail-panel.tsx
@@ -1,3 +1,4 @@
+import { usePresence } from '@studio/shared/hooks/use-presence'
 import type { ColumnDefinition } from '../types'
 
 type Props = {
@@ -9,10 +10,14 @@ type Props = {
 }
 
 export function RowDetailPanel({ open, onClose, row, columns, tableName }: Props) {
-	if (!open) return null
+	const { present, state } = usePresence(open, 200)
+	if (!present) return null
 
 	return (
-		<div className='fixed inset-y-0 right-0 w-96 bg-card border-l border-sidebar-border shadow-xl z-50 flex flex-col'>
+		<div
+			data-state={state}
+			className='fixed inset-y-0 right-0 w-96 bg-card border-l border-sidebar-border shadow-xl z-50 flex flex-col transition-[transform,opacity] duration-200 data-[state=open]:duration-[240ms] ease-[var(--ease-out)] data-[state=closed]:translate-x-full motion-reduce:data-[state=closed]:translate-x-0 motion-reduce:data-[state=closed]:opacity-0 motion-reduce:duration-150'
+		>
 			<div className='flex items-center justify-between h-12 px-4 border-b border-sidebar-border shrink-0'>
 				<h2 className='text-sm font-semibold text-foreground'>Row Details</h2>
 				<button

--- a/packages/studio/src/features/database-studio/components/selection-action-bar.tsx
+++ b/packages/studio/src/features/database-studio/components/selection-action-bar.tsx
@@ -12,7 +12,7 @@ import {
 	ChevronRight,
 	Save
 } from 'lucide-react'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { Button } from '@studio/shared/ui/button'
 import {
 	DropdownMenu,
@@ -63,6 +63,8 @@ const LAYOUT_SPRING = {
 	damping: 36,
 	mass: 0.7
 } as const
+
+const EASE_OUT = [0.23, 1, 0.32, 1] as const
 
 function createToolbarKeyHandler(onEscapeToGrid?: () => void) {
 	return function handleToolbarKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
@@ -274,17 +276,17 @@ export const SelectionActionBar = forwardRef<HTMLDivElement, Props>(function Sel
 		})
 	}
 
+	const reduceMotion = useReducedMotion()
+
 	const floatingClasses = [
 		'absolute bottom-10 inset-x-0 mx-auto w-fit max-w-[calc(100%-2rem)] z-[100]',
 		'flex items-center gap-1 pl-3 pr-2 py-1.5',
 		'bg-popover/90 backdrop-blur-xl border border-border/60 rounded-2xl',
-		'shadow-[0_8px_30px_rgba(0,0,0,0.12)]',
-		'animate-in slide-in-from-bottom-4 fade-in duration-300 ease-out'
+		'shadow-[0_8px_30px_rgba(0,0,0,0.12)]'
 	]
 
 	const staticClasses = [
-		'flex items-center gap-2 h-11 px-3 bg-sidebar/80 backdrop-blur-sm border-t border-sidebar-border shrink-0',
-		'animate-in slide-in-from-bottom-2 duration-200'
+		'flex items-center gap-2 h-11 px-3 bg-sidebar/80 backdrop-blur-sm border-t border-sidebar-border shrink-0'
 	]
 
 	const isFloating = mode === 'floating'
@@ -359,7 +361,18 @@ export const SelectionActionBar = forwardRef<HTMLDivElement, Props>(function Sel
 	return (
 		<motion.div
 			layout
-			transition={LAYOUT_SPRING}
+			initial={{ opacity: 0, y: reduceMotion ? 0 : isFloating ? 16 : 8 }}
+			animate={{ opacity: 1, y: 0 }}
+			exit={{
+				opacity: 0,
+				y: reduceMotion ? 0 : 8,
+				transition: { duration: 0.15, ease: EASE_OUT }
+			}}
+			transition={{
+				duration: isFloating ? 0.3 : 0.2,
+				ease: EASE_OUT,
+				layout: LAYOUT_SPRING
+			}}
 			ref={function mergeRefs(node: HTMLDivElement | null) {
 				; (containerRef as React.MutableRefObject<HTMLDivElement | null>).current = node
 				if (typeof ref === 'function') {

--- a/packages/studio/src/features/database-studio/database-studio.tsx
+++ b/packages/studio/src/features/database-studio/database-studio.tsx
@@ -8,7 +8,10 @@ import { useEffectiveShortcuts, useShortcut, useActiveScope } from '@studio/core
 import { useUndo } from '@studio/core/undo'
 import type { Mutation } from '@studio/core/undo'
 import { getTableRefParts } from '@studio/shared/utils/table-ref'
-import { getSourceCaps } from '@studio/features/connections/source-caps'
+import {
+	getSourceCaps,
+	isDataFileSessionConnection
+} from '@studio/features/connections/source-caps'
 import { isUiActionVisible } from '@studio/features/connections/ui-actions'
 import { DataFileSessionChrome } from './components/data-file-session-chrome'
 import { ImportFilesIntoDuckDbButton } from './components/import-files-into-duckdb-button'
@@ -520,7 +523,8 @@ export function DatabaseStudio({
 		setSelectedRowForDetail,
 		setShowRowDetail,
 		setFilters: handleSetFiltersFromSync,
-		displayTableName
+		isReadonlySource: sourceCaps?.isReadonly ?? false,
+		isDataFileSession: activeConnection ? isDataFileSessionConnection(activeConnection) : false
 	})
 
 	// Re-fetch the original bytes of a blob cell (the grid only has the rendered
@@ -1139,7 +1143,8 @@ export function DatabaseStudio({
 							onCellEdit={canEditRows ? handleCellEdit : undefined}
 							onDeleteSelectedRows={canEditRows ? handleBulkDelete : undefined}
 							onBatchCellEdit={canEditRows ? handleBatchCellEdit : undefined}
-							onRowAction={canEditRows ? handleRowAction : undefined}
+							onRowAction={handleRowAction}
+							canEditRows={canEditRows}
 							tableName={displayTableName}
 							selectedCells={selectedCells}
 							onCellSelectionChange={setSelectedCells}

--- a/packages/studio/src/features/database-studio/database-studio.tsx
+++ b/packages/studio/src/features/database-studio/database-studio.tsx
@@ -46,6 +46,7 @@ import {
 	DatabaseStudioNoTablesFound
 } from './components/database-studio-empty-states'
 import { DatabaseStudioStructureView } from './components/database-studio-structure-view'
+import { AnimatePresence } from 'framer-motion'
 import { PendingChangesBar } from './components/pending-changes-bar'
 import { RowDetailPanel } from './components/row-detail-panel'
 import { SelectionActionBar } from './components/selection-action-bar'
@@ -1184,26 +1185,28 @@ export function DatabaseStudio({
 				)}
 			</div>
 
-			{tableData &&
-				(settings.selectionBarStyle === 'static' || !settings.selectionBarStyle) &&
-				rowsForActions.size > 0 && (
-					<SelectionActionBar
-						ref={toolbarRef}
-						selectedCount={rowsForActions.size}
-						onDelete={canEditRows ? handleBulkDelete : undefined}
-						onCopy={privacyMaskData ? undefined : handleBulkCopy}
-						onSetNull={canEditRows ? handleOpenSetNull : undefined}
-						onDuplicate={canEditRows ? handleBulkDuplicate : undefined}
-						onExportJson={canExportFile ? handleExportJson : undefined}
-						onExportCsv={canExportFile ? handleExportCsv : undefined}
-						onBulkEdit={canEditRows ? handleOpenBulkEdit : undefined}
-						onSave={canEditRows ? handleApplyPendingEdits : undefined}
-						pendingEditCount={tableId ? getEditCount(tableId) : 0}
-						onClearSelection={handleClearSelection}
-						onEscapeToGrid={handleEscapeToGrid}
-						mode='static'
-					/>
-				)}
+			<AnimatePresence>
+				{tableData &&
+					(settings.selectionBarStyle === 'static' || !settings.selectionBarStyle) &&
+					rowsForActions.size > 0 && (
+						<SelectionActionBar
+							ref={toolbarRef}
+							selectedCount={rowsForActions.size}
+							onDelete={canEditRows ? handleBulkDelete : undefined}
+							onCopy={privacyMaskData ? undefined : handleBulkCopy}
+							onSetNull={canEditRows ? handleOpenSetNull : undefined}
+							onDuplicate={canEditRows ? handleBulkDuplicate : undefined}
+							onExportJson={canExportFile ? handleExportJson : undefined}
+							onExportCsv={canExportFile ? handleExportCsv : undefined}
+							onBulkEdit={canEditRows ? handleOpenBulkEdit : undefined}
+							onSave={canEditRows ? handleApplyPendingEdits : undefined}
+							pendingEditCount={tableId ? getEditCount(tableId) : 0}
+							onClearSelection={handleClearSelection}
+							onEscapeToGrid={handleEscapeToGrid}
+							mode='static'
+						/>
+					)}
+			</AnimatePresence>
 
 			{tableData && (
 				<BottomStatusBar
@@ -1221,26 +1224,28 @@ export function DatabaseStudio({
 			)}
 
 			{/* Render floating bar if mode is floating */}
-			{tableData && settings.selectionBarStyle === 'floating' && rowsForActions.size > 0 && (
-				<SelectionActionBar
-					ref={toolbarRef}
-					selectedCount={rowsForActions.size}
-					onDelete={canEditRows ? handleBulkDelete : undefined}
-					onCopy={privacyMaskData ? undefined : handleBulkCopy}
-					onDuplicate={canEditRows ? handleBulkDuplicate : undefined}
-					onExportJson={canExportFile ? handleExportJson : undefined}
-					onExportCsv={canExportFile ? handleExportCsv : undefined}
-					onSetNull={canEditRows ? handleOpenSetNull : undefined}
-					onBulkEdit={canEditRows ? handleOpenBulkEdit : undefined}
-					onSave={canEditRows ? handleApplyPendingEdits : undefined}
-					pendingEditCount={tableId ? getEditCount(tableId) : 0}
-					onClearSelection={handleClearSelection}
-					onEscapeToGrid={handleEscapeToGrid}
-					mode='floating'
-				/>
-			)}
+			<AnimatePresence>
+				{tableData && settings.selectionBarStyle === 'floating' && rowsForActions.size > 0 && (
+					<SelectionActionBar
+						ref={toolbarRef}
+						selectedCount={rowsForActions.size}
+						onDelete={canEditRows ? handleBulkDelete : undefined}
+						onCopy={privacyMaskData ? undefined : handleBulkCopy}
+						onDuplicate={canEditRows ? handleBulkDuplicate : undefined}
+						onExportJson={canExportFile ? handleExportJson : undefined}
+						onExportCsv={canExportFile ? handleExportCsv : undefined}
+						onSetNull={canEditRows ? handleOpenSetNull : undefined}
+						onBulkEdit={canEditRows ? handleOpenBulkEdit : undefined}
+						onSave={canEditRows ? handleApplyPendingEdits : undefined}
+						pendingEditCount={tableId ? getEditCount(tableId) : 0}
+						onClearSelection={handleClearSelection}
+						onEscapeToGrid={handleEscapeToGrid}
+						mode='floating'
+					/>
+				)}
+			</AnimatePresence>
 
-			{tableId && canEditRows && hasEdits(tableId) && (
+			{tableId && canEditRows && (
 				<PendingChangesBar
 					editCount={getEditCount(tableId)}
 					isApplying={isApplyingEdits}

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-actions.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-actions.ts
@@ -50,7 +50,8 @@ type Args = {
 	setSelectedRowForDetail: React.Dispatch<React.SetStateAction<Record<string, unknown> | null>>
 	setShowRowDetail: React.Dispatch<React.SetStateAction<boolean>>
 	setFilters: React.Dispatch<React.SetStateAction<FilterDescriptor[]>>
-	displayTableName: string | null
+	isReadonlySource?: boolean
+	isDataFileSession?: boolean
 }
 
 export function useDatabaseStudioActions(args: Args) {
@@ -87,7 +88,8 @@ export function useDatabaseStudioActions(args: Args) {
 		setSelectedRowForDetail,
 		setShowRowDetail,
 		setFilters,
-		displayTableName
+		isReadonlySource = false,
+		isDataFileSession = false
 	} = args
 
 	const notifyActionFailure = useCallback(function (title: string, error: unknown) {
@@ -99,20 +101,31 @@ export function useDatabaseStudioActions(args: Args) {
 	}, [toast])
 
 	const notifyMissingPrimaryKey = useCallback(function (actionLabel: string) {
+		if (isReadonlySource) {
+			toast({
+				title: `Cannot ${actionLabel}`,
+				description: isDataFileSession
+					? 'Data files open as readonly views. Save as DuckDB to edit rows.'
+					: 'This connection is read-only.',
+				variant: 'destructive'
+			})
+			return
+		}
+
 		toast({
 			title: `Cannot ${actionLabel}`,
-			description: `Table "${displayTableName ?? tableRefName}" has no primary key, so this action cannot be saved safely.`,
+			description: 'This table has no primary key, so changes cannot be saved safely.',
 			variant: 'destructive'
 		})
-	}, [displayTableName, tableRefName, toast])
+	}, [isDataFileSession, isReadonlySource, toast])
 
 	const notifyPrimaryKeyNotGenerated = useCallback(function (actionLabel: string) {
 		toast({
 			title: `Cannot ${actionLabel}`,
-			description: `Table "${displayTableName ?? tableRefName}" has a primary key the database does not generate. Duplicate one row at a time and enter a new key.`,
+			description: 'This table has a primary key the database does not generate. Duplicate one row at a time and enter a new key.',
 			variant: 'destructive'
 		})
-	}, [displayTableName, tableRefName, toast])
+	}, [toast])
 
 	const { highlightedRowIndexes, markRowsAdded } = useRecentlyAddedRows(
 		tableData,

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-row-actions.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-row-actions.ts
@@ -165,6 +165,12 @@ export function useDatabaseStudioRowActions(args: Args) {
 	) {
 		if (!tableId || !activeConnectionId || !tableData) return
 
+		if (action === 'view') {
+			setSelectedRowForDetail(row)
+			setShowRowDetail(true)
+			return
+		}
+
 		const primaryKeyColumn = tableData.columns.find((c) => c.primaryKey)
 		if (!primaryKeyColumn) {
 			notifyMissingPrimaryKey('perform this row action')
@@ -194,10 +200,6 @@ export function useDatabaseStudioRowActions(args: Args) {
 				}
 
 				deleteRowIndexes(effectiveRowIndexes)
-				break
-			case 'view':
-				setSelectedRowForDetail(row)
-				setShowRowDetail(true)
 				break
 			case 'edit':
 				setDuplicateInitialData(row)

--- a/packages/studio/src/features/docker-manager/components/create-container-dialog.tsx
+++ b/packages/studio/src/features/docker-manager/components/create-container-dialog.tsx
@@ -486,8 +486,8 @@ export function CreateContainerDialog({
                 Advanced Options
               </Button>
             </CollapsibleTrigger>
-            <CollapsibleContent className="space-y-4 pt-2">
-              <div className="grid grid-cols-2 gap-4">
+            <CollapsibleContent>
+              <div className="grid grid-cols-2 gap-4 pt-2">
                 <div className="space-y-2">
                   <Label htmlFor="cpu">CPU Limit (cores)</Label>
                   <Input

--- a/packages/studio/src/features/onboarding/onboarding-tour.tsx
+++ b/packages/studio/src/features/onboarding/onboarding-tour.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '@studio/shared/ui/button'
+import { usePresence } from '@studio/shared/hooks/use-presence'
 import { cn } from '@studio/shared/utils/cn'
 import { markTourCompleted, recordLaunch, shouldShowTour } from './launch-state'
 
@@ -102,14 +103,17 @@ export function OnboardingTour() {
 		setOpen(false)
 	}
 
-	if (!open || !step) return null
+	const { present, state } = usePresence(open, 150)
+
+	if (!present || !step) return null
 
 	return (
 		<>
 			{spotlight && (
 				<div
 					aria-hidden='true'
-					className='pointer-events-none fixed z-[90] rounded-lg ring-2 ring-primary ring-offset-2 ring-offset-background transition-all duration-200'
+					data-state={state}
+					className='pointer-events-none fixed z-[90] rounded-lg ring-2 ring-primary ring-offset-2 ring-offset-background transition-all duration-200 opacity-100 data-[state=closed]:opacity-0'
 					style={{
 						top: spotlight.top,
 						left: spotlight.left,
@@ -119,19 +123,29 @@ export function OnboardingTour() {
 				/>
 			)}
 			<div
-				role='dialog'
-				aria-label='Onboarding tour'
-				className={cn(
-					'fixed bottom-6 left-1/2 z-[91] w-[min(380px,calc(100vw-2rem))] -translate-x-1/2',
-					'rounded-lg border border-border bg-popover p-4 shadow-xl'
-				)}
+				data-state={state}
+				className='fixed bottom-6 left-1/2 z-[91] w-[min(380px,calc(100vw-2rem))] -translate-x-1/2 transition-opacity duration-150 ease-[var(--ease-out)] data-[state=closed]:opacity-0'
 			>
-				<div className='mb-1 flex items-center justify-between'>
-					<div className='text-sm font-medium text-popover-foreground'>{step.title}</div>
-					<div className='text-xs text-muted-foreground'>{progressLabel}</div>
-				</div>
-				<p className='mb-3 text-xs leading-relaxed text-muted-foreground'>{step.description}</p>
-				<div className='flex items-center justify-between'>
+				<div
+					role='dialog'
+					aria-label='Onboarding tour'
+					className={cn(
+						'rounded-lg border border-border bg-popover p-4 shadow-xl',
+						'animate-in fade-in zoom-in-95 slide-in-from-bottom-2 duration-200',
+						'motion-reduce:zoom-in-100 motion-reduce:slide-in-from-bottom-0'
+					)}
+				>
+					<div
+						key={stepIndex}
+						className='animate-in fade-in slide-in-from-bottom-1 duration-150 motion-reduce:slide-in-from-bottom-0'
+					>
+						<div className='mb-1 flex items-center justify-between'>
+							<div className='text-sm font-medium text-popover-foreground'>{step.title}</div>
+							<div className='text-xs text-muted-foreground'>{progressLabel}</div>
+						</div>
+						<p className='mb-3 text-xs leading-relaxed text-muted-foreground'>{step.description}</p>
+					</div>
+					<div className='flex items-center justify-between'>
 					<Button variant='ghost' size='sm' className='h-7 text-xs' onClick={finish}>
 						Skip tour
 					</Button>
@@ -162,6 +176,7 @@ export function OnboardingTour() {
 							{isLastStep ? 'Done' : 'Next'}
 						</Button>
 					</div>
+				</div>
 				</div>
 			</div>
 		</>

--- a/packages/studio/src/pages/workspace/ai-assistant-host.tsx
+++ b/packages/studio/src/pages/workspace/ai-assistant-host.tsx
@@ -10,6 +10,7 @@ import { useAiEditorContext } from '@studio/features/ai-assistant/editor-context
 import { scheduleSqlConsoleCommand } from '@studio/features/command-palette/events'
 import { Button } from '@studio/shared/ui/button'
 import { Skeleton } from '@studio/shared/ui/skeleton'
+import { usePresence } from '@studio/shared/hooks/use-presence'
 import { Sparkles } from 'lucide-react'
 
 const AiAssistantPanel = lazy(function () {
@@ -32,7 +33,7 @@ export function AiAssistantToggle() {
 			size='icon'
 			onClick={toggleOpen}
 			title='Open AI assistant'
-			className='fixed bottom-4 right-4 z-[70] h-10 w-10 rounded-full shadow-lg'
+			className='fixed bottom-4 right-4 z-[70] h-10 w-10 rounded-full shadow-lg animate-in fade-in duration-150'
 		>
 			<Sparkles className='h-4 w-4' />
 		</Button>
@@ -49,6 +50,7 @@ export function AiAssistantPanelHost() {
 	const open = useAiAssistantStore(function (s) {
 		return s.open
 	})
+	const { present } = usePresence(open, 200)
 	const activeConnectionId = useActiveConnectionId()
 	const activeNavId = useActiveNavId()
 	const activeTab = useActiveTab()
@@ -72,7 +74,7 @@ export function AiAssistantPanelHost() {
 		)
 	}, [])
 
-	if (!open) return null
+	if (!present) return null
 
 	return (
 		<Suspense

--- a/packages/studio/src/shared/hooks/use-presence.ts
+++ b/packages/studio/src/shared/hooks/use-presence.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Presence controller for enter/exit transitions on conditionally-rendered UI.
+ * `present` keeps the element mounted for `exitMs` after `open` flips false.
+ * `state` is 'closed' on the first mounted frame and flips to 'open' a frame
+ * later, so a CSS transition has a from-state to animate away from.
+ */
+export function usePresence(open: boolean, exitMs: number) {
+	const [present, setPresent] = useState(open)
+	const [state, setState] = useState<'open' | 'closed'>('closed')
+	const timeoutRef = useRef<number | undefined>(undefined)
+
+	useEffect(
+		function syncPresence() {
+			if (open) {
+				window.clearTimeout(timeoutRef.current)
+				setPresent(true)
+				/*
+				 * Double rAF: the first frame can batch into the same paint as the
+				 * mount, which would skip the transition. The second guarantees the
+				 * 'closed' styles have been painted before flipping to 'open'.
+				 */
+				let inner: number | undefined
+				const outer = window.requestAnimationFrame(function () {
+					inner = window.requestAnimationFrame(function () {
+						setState('open')
+					})
+				})
+				return function () {
+					window.cancelAnimationFrame(outer)
+					if (inner !== undefined) window.cancelAnimationFrame(inner)
+				}
+			}
+			setState('closed')
+			timeoutRef.current = window.setTimeout(function () {
+				setPresent(false)
+			}, exitMs)
+			return function () {
+				window.clearTimeout(timeoutRef.current)
+			}
+		},
+		[open, exitMs]
+	)
+
+	return { present, state }
+}

--- a/packages/studio/src/shared/ui/collapsible.tsx
+++ b/packages/studio/src/shared/ui/collapsible.tsx
@@ -1,9 +1,25 @@
+import * as React from 'react'
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible'
+import { cn } from '@studio/shared/utils/cn'
 
 const Collapsible = CollapsiblePrimitive.Root
 
 const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
 
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+const CollapsibleContent = React.forwardRef<
+	React.ElementRef<typeof CollapsiblePrimitive.CollapsibleContent>,
+	React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.CollapsibleContent>
+>(function CollapsibleContent({ className, ...props }, ref) {
+	return (
+		<CollapsiblePrimitive.CollapsibleContent
+			ref={ref}
+			className={cn(
+				'overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none',
+				className
+			)}
+			{...props}
+		/>
+	)
+})
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/packages/studio/src/styles.css
+++ b/packages/studio/src/styles.css
@@ -100,22 +100,22 @@
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-sm: calc(var(--radius) - 4px);
 
-	--animate-accordion-down: accordion-down 0.2s ease-out;
-	--animate-accordion-up: accordion-up 0.2s ease-out;
+	--animate-collapsible-down: collapsible-down 0.2s ease-out;
+	--animate-collapsible-up: collapsible-up 0.2s ease-out;
 
-	@keyframes accordion-down {
+	@keyframes collapsible-down {
 		from {
 			height: 0;
 		}
 
 		to {
-			height: var(--radix-accordion-content-height);
+			height: var(--radix-collapsible-content-height);
 		}
 	}
 
-	@keyframes accordion-up {
+	@keyframes collapsible-up {
 		from {
-			height: var(--radix-accordion-content-height);
+			height: var(--radix-collapsible-content-height);
 		}
 
 		to {
@@ -2074,5 +2074,33 @@
 		max-width: 40%;
 		overflow-wrap: anywhere;
 		text-align: right;
+	}
+}
+
+/*
+ * Reduced-motion baseline. Movement and infinite decorative animation is
+ * suppressed; opacity/color feedback (shimmers, pulses, fades) is kept on
+ * purpose — reduced motion means gentler, not zero.
+ */
+@media (prefers-reduced-motion: reduce) {
+	.db-type-icon-glint {
+		animation: none;
+		-webkit-mask-position: 150% center;
+		mask-position: 150% center;
+	}
+
+	.desktop-only-notice__shimmer::after,
+	.cockpit-skeleton::after {
+		animation: none;
+	}
+
+	.sv-edge-flow,
+	.sv-edge-flow--match,
+	.sv-edge-flow--active {
+		animation: none;
+	}
+
+	.connection-status-error {
+		animation: none;
 	}
 }


### PR DESCRIPTION
## Summary

Executes all eight plans from the Studio motion sweep. The plans themselves live on the `docs/animation-plans` branch for reference; this PR is the implementation only.

- **Reduced-motion baseline** (`styles.css`): one `@media (prefers-reduced-motion: reduce)` block suppressing infinite decorative sheens (icon glint, notice shimmer, cockpit skeleton), the schema visualizer's marching-ants edges, and the status shake. Loading shimmers and pulse feedback are kept on purpose.
- **Right-edge drawers slide** (Row Details, AI Assistant): both 384/420px panels now enter at 240ms and exit at 200ms on `var(--ease-out)` via a new `usePresence` hook (`shared/hooks/use-presence.ts`) that delays unmount for the exit and keeps the mounted-only-while-open perf design intact. The AI toggle FAB fades back in.
- **Hold-to-confirm connection delete**: the trash button in the connection switcher now requires a 2s hold (linear clip-path fill; 200ms ease-out snap-back on early release; keyboard hold supported; pointer capture so dragging off cancels). A plain click no longer deletes anything — this also closes the no-confirmation data-loss gap on that button.
- **Collapsibles animate**: the dead `accordion-down/up` keyframes are renamed `collapsible-down/up`, retargeted to `--radix-collapsible-content-height`, and wired into the shared `CollapsibleContent` (padding moved off the animated elements to avoid the height jump).
- **Pending-changes bar**: grows in / folds away over 200ms via a `grid-template-rows 0fr↔1fr` transition, holding its last non-zero count during exit so "Edited 0 cells" never flashes.
- **Selection action bar**: wrapped in `AnimatePresence`; enter/exit moved from tw-animate classes into framer with a faster exit (0.15s) along the entry path, `useReducedMotion`-aware; the layout spring is unchanged.
- **Status dot**: the connection tab-bar dot eases color over 300ms and plays the previously dead `statusPulse`/`statusShake` one-shot only on real status transitions (never on initial render or re-renders).
- **Onboarding tour**: the card enters with fade/zoom-95/rise (centering moved to a wrapper to dodge the tw-animate transform collision), step text crossfades in 150ms alongside the gliding spotlight ring, and both fade out together on Skip/Done. Focus stays on Next across steps.

## Verification

- `bun run typecheck` (packages/studio): clean
- `bun run test` (packages/studio): 1066/1066 — the connection-switcher test now exercises the hold interaction, plus a new regression test that a plain click and an aborted hold never delete
- Feel checks per plan (slow-motion, rapid-toggle interruption, reduced-motion emulation) are listed in each plan on the `docs/animation-plans` branch

## Note on the base

This branch stacks on the three not-yet-pushed `feature/data-viewer` commits (`0a8e6eda`, `d58f8e49`, `d39cca69`) that the animation work builds on — the remote `feature/data-viewer` is stale/diverged, so those commits appear in this PR. If you'd rather land them separately first, merge order is: push/land those, then rebase this branch.

## Also in this PR: readonly-source gating (`d1083a63`)

Row mutations are now gated behind source capabilities in the data grid: readonly sources (data-file sessions, read-only connections) no longer show edit/duplicate/delete in the row and cell context menus, double-click/type-to-edit is inert without a wired cell editor, and the action toasts explain the block (including the save-as-DuckDB hint for data files) instead of the misleading missing-primary-key message. Verified with the same gates: typecheck clean, 1066/1066 tests.

## Summary by Sourcery

Polish Studio motion interactions and enforce safe mutation behavior for readonly data sources.

New Features:
- Add polished motion and transition behavior across Studio panels, controls, status indicators, pending changes, selection actions, collapsibles, and onboarding.
- Require a completed hold gesture to confirm connection deletion, preventing accidental deletes from clicks or aborted holds.
- Gate row and cell mutation actions for readonly sources and provide source-specific feedback when edits are unavailable.

Bug Fixes:
- Prevent readonly data sources from exposing or initiating unsupported row and cell mutations.
- Prevent status animations from triggering on initial render or unrelated re-renders.
- Prevent pending-change exit animations from displaying an incorrect zero-edit count.

Enhancements:
- Add shared presence handling for delayed unmounting of exiting UI while preserving reduced-motion behavior.
- Establish a reduced-motion baseline for decorative and movement-based animations.

Tests:
- Update connection switcher coverage for hold-to-delete confirmation and verify plain clicks and aborted holds do not delete connections.
- Verify Studio type checking and the full test suite pass.