### PR TITLE
feat: CSV delimiter auto-detection and BOM handling

### DIFF
--- a/__tests__/apps/desktop/unit/csv-parser.test.ts
+++ b/__tests__/apps/desktop/unit/csv-parser.test.ts
@@ -39,4 +39,41 @@ describe('parseCSV', () => {
     expect(result.rows).toHaveLength(0)
     expect(result.error).toBeUndefined()
   })
+
+  it('strips a leading UTF-8 BOM from the first header', () => {
+    const result = parseCSV('\uFEFFname,age\nAlice,30')
+    expect(result.headers).toEqual(['name', 'age'])
+  })
+
+  it('detects semicolon delimiter and keeps commas inside fields', () => {
+    const result = parseCSV(
+      '\uFEFFTitel;URL;Robots;Inleidende inhoud;Inhoud\r\n' +
+        'Abarth 595;/aanbod/abarth/595;Index, follow;<p>compact, sportief</p>;"<h2>Kenmerken</h2><p>zegt ""hallo"", met komma</p>"'
+    )
+    expect(result.headers).toEqual(['Titel', 'URL', 'Robots', 'Inleidende inhoud', 'Inhoud'])
+    expect(result.rows[0]).toEqual([
+      'Abarth 595',
+      '/aanbod/abarth/595',
+      'Index, follow',
+      '<p>compact, sportief</p>',
+      '<h2>Kenmerken</h2><p>zegt "hallo", met komma</p>'
+    ])
+  })
+
+  it('detects tab delimiter', () => {
+    const result = parseCSV('name\tage\nAlice\t30')
+    expect(result.headers).toEqual(['name', 'age'])
+    expect(result.rows[0]).toEqual(['Alice', '30'])
+  })
+
+  it('ignores delimiter candidates inside quoted headers', () => {
+    const result = parseCSV('"a;b",c,d\n1,2,3')
+    expect(result.headers).toEqual(['a;b', 'c', 'd'])
+    expect(result.rows[0]).toEqual(['1', '2', '3'])
+  })
+
+  it('prefers comma when delimiter counts tie', () => {
+    const result = parseCSV('a,b;c\n1,2')
+    expect(result.headers).toEqual(['a', 'b;c'])
+  })
 })

--- a/packages/studio/src/features/database-studio/utils/csv-parser.ts
+++ b/packages/studio/src/features/database-studio/utils/csv-parser.ts
@@ -5,21 +5,56 @@ export type ParseCSVResult = {
 }
 
 export function parseCSV(text: string): ParseCSVResult {
-  if (!text.trim()) return { headers: [], rows: [], error: 'File is empty' }
+  const content = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text
+  if (!content.trim()) return { headers: [], rows: [], error: 'File is empty' }
 
-  const lines = splitLines(text)
+  const lines = splitLines(content)
   if (lines.length === 0) return { headers: [], rows: [], error: 'File is empty' }
 
-  const headers = parseRow(lines[0])
+  const delimiter = detectDelimiter(lines[0])
+  const headers = parseRow(lines[0], delimiter)
   const rows: string[][] = []
 
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i]
     if (line.trim() === '') continue
-    rows.push(parseRow(line))
+    rows.push(parseRow(line, delimiter))
   }
 
   return { headers, rows }
+}
+
+const DELIMITER_CANDIDATES = [',', ';', '\t']
+
+function detectDelimiter(headerLine: string): string {
+  let best = ','
+  let bestCount = 0
+
+  for (const candidate of DELIMITER_CANDIDATES) {
+    const count = countOutsideQuotes(headerLine, candidate)
+    if (count > bestCount) {
+      best = candidate
+      bestCount = count
+    }
+  }
+
+  return best
+}
+
+function countOutsideQuotes(line: string, delimiter: string): number {
+  let count = 0
+  let inQuotes = false
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if (ch === '"') {
+      inQuotes = !inQuotes
+    } else if (ch === delimiter && !inQuotes) {
+      count++
+    }
+  }
+
+  return count
 }
 
 function splitLines(text: string): string[] {
@@ -54,7 +89,7 @@ function splitLines(text: string): string[] {
   return lines
 }
 
-function parseRow(line: string): string[] {
+function parseRow(line: string, delimiter: string): string[] {
   const fields: string[] = []
   let current = ''
   let inQuotes = false
@@ -85,7 +120,7 @@ function parseRow(line: string): string[] {
         }
       }
     }
-    if (ch === ',' && !inQuotes) {
+    if (ch === delimiter && !inQuotes) {
       fields.push(current)
       current = ''
       i++


### PR DESCRIPTION
## Summary

`parseCSV` (used by the data-file import path) previously assumed comma-delimited input and choked on two common real-world cases:

- **Semicolon/tab-delimited files** — e.g. exports from European-locale Excel — parsed as a single mangled column. The parser now sniffs the delimiter from the header line among `,` `;` and tab, counting candidates **outside quoted fields**, with comma winning ties.
- **UTF-8 BOM** — a leading BOM ended up glued to the first header name. It is now stripped before parsing.

Two files: `packages/studio/src/features/database-studio/utils/csv-parser.ts` and its unit test.

## Verification

- `bunx vitest run __tests__/apps/desktop/unit/csv-parser.test.ts`: 12/12 (5 new cases: BOM strip, semicolon detection with embedded commas, tab detection, quoted-header candidates ignored, comma tie-break)
- `bun run typecheck` (packages/studio): clean

Standalone against `master` — independent of the animation PR #231 and the rest of the data-viewer WIP (readonly-source gating, regenerated bindings), which remain uncommitted.

## Summary by Sourcery

Improve CSV imports by supporting common delimiters and UTF-8 BOM-prefixed files.

New Features:
- Add automatic detection of comma, semicolon, and tab delimiters while respecting quoted header fields.
- Strip a leading UTF-8 BOM before parsing CSV content.

Bug Fixes:
- Correctly parse semicolon- and tab-delimited imports and prevent BOM characters from contaminating the first header.

Tests:
- Add coverage for BOM removal, delimiter detection, quoted-header handling, embedded commas, and comma tie-breaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV imports now automatically detect comma, semicolon, and tab delimiters.
  * UTF-8 byte-order marks are removed during CSV parsing.
  * Quoted fields preserve embedded commas and escaped quotation marks.

* **Bug Fixes**
  * Improved parsing for delimiter characters inside quoted headers and fields.
  * Comma separators are preferred when delimiter counts are tied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->