### PR TITLE
feat: focus and press states as a background tint across the Studio

### DIFF
--- a/packages/studio/src/features/ai-assistant/ai-assistant-panel.tsx
+++ b/packages/studio/src/features/ai-assistant/ai-assistant-panel.tsx
@@ -337,7 +337,7 @@ export function AiAssistantPanel({
 						disabled={isStreaming || !keysAvailable}
 						placeholder='Ask anything about your database…'
 						rows={3}
-						className='w-full resize-none rounded-md border border-sidebar-border bg-background px-3 py-2 pr-10 text-sm outline-none focus:border-primary disabled:opacity-50'
+						className='w-full resize-none rounded-md border border-sidebar-border bg-background px-3 py-2 pr-10 text-sm transition-colors duration-150 focus-visible:bg-focus disabled:opacity-50'
 					/>
 					<div className='absolute bottom-1.5 right-1.5'>
 						{isStreaming ? (

--- a/packages/studio/src/features/app-sidebar/nav-item.tsx
+++ b/packages/studio/src/features/app-sidebar/nav-item.tsx
@@ -6,8 +6,7 @@ import type { NavItem } from './types'
 
 const navItemVariants = cva(
 	[
-		'relative flex items-center justify-center transition-colors',
-		'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring/30 focus-visible:ring-offset-1 focus-visible:ring-offset-sidebar',
+		'relative flex items-center justify-center transition-colors duration-150',
 		'disabled:pointer-events-none disabled:opacity-40'
 	],
 	{
@@ -23,9 +22,8 @@ const navItemVariants = cva(
 			},
 			state: {
 				default:
-					'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-				active:
-					'bg-sidebar-accent/80 text-sidebar-accent-foreground ring-1 ring-sidebar-border/70 shadow-sm',
+					'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:bg-focus focus-visible:text-sidebar-accent-foreground',
+				active: 'bg-sidebar-accent text-sidebar-accent-foreground focus-visible:bg-focus-strong',
 				disabled: 'cursor-not-allowed opacity-40'
 			}
 		},

--- a/packages/studio/src/features/app-sidebar/navigation-sidebar.tsx
+++ b/packages/studio/src/features/app-sidebar/navigation-sidebar.tsx
@@ -136,7 +136,7 @@ function SidebarContent({
 						<button
 							type='button'
 							onClick={() => onNavSelect?.('database-studio')}
-							className='cursor-pointer hover:opacity-80 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar rounded-md'
+							className='cursor-pointer hover:opacity-80 transition-opacity focus-visible:opacity-80 focus-visible:bg-focus rounded-md'
 							aria-label='Go to home'
 							title='Dora AI Home'
 						>

--- a/packages/studio/src/features/connections/components/connection-dialog/database-type-selector.tsx
+++ b/packages/studio/src/features/connections/components/connection-dialog/database-type-selector.tsx
@@ -286,20 +286,18 @@ export function DatabaseTypeSelector({
 						style={
 							{
 								'--db-accent': theme.accent,
-								background: isActive ? theme.wash : undefined,
-								borderColor: isActive ? theme.accent : undefined,
-								boxShadow: isActive
-									? `0 14px 34px -28px ${theme.accent}`
-									: undefined
+								'--db-wash': theme.wash,
+								borderColor: isActive ? theme.accent : undefined
 							} as React.CSSProperties
 						}
 						className={cn(
 							'db-type-btn group relative overflow-hidden border p-3 text-left',
-							'bg-card/55 transition-[border-color,background-color,box-shadow,transform] duration-200 ease-out',
+							'bg-card/55 transition-[border-color,background-color,transform] duration-200 ease-out',
 							'hover:border-border/90 hover:bg-card active:scale-[0.985]',
-							'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35',
 							compact && 'p-2',
-							isActive ? 'ring-1 ring-inset ring-white/10' : 'border-border/55',
+							isActive
+								? 'bg-[var(--db-wash)] hover:bg-[var(--db-wash)] focus-visible:bg-focus-strong'
+								: 'border-border/55 focus-visible:bg-focus',
 							disabled && 'opacity-50 cursor-not-allowed'
 						)}
 					>

--- a/packages/studio/src/features/connections/components/connection-switcher.tsx
+++ b/packages/studio/src/features/connections/components/connection-switcher.tsx
@@ -189,7 +189,7 @@ const ConnectionMenuRow = forwardRef<HTMLDivElement, ConnectionMenuRowProps>(
 									'group-data-[highlighted]/row:opacity-100 group-data-[highlighted]/row:translate-x-0 group-data-[highlighted]/row:pointer-events-auto',
 									'transition-[opacity,transform,color] duration-150 ease-[var(--ease-out)]',
 									'hover:text-foreground hover:bg-background/60',
-									'focus-visible:outline-hidden focus-visible:opacity-100 focus-visible:translate-x-0 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-primary/40'
+									'focus-visible:opacity-100 focus-visible:translate-x-0 focus-visible:pointer-events-auto focus-visible:text-foreground focus-visible:bg-focus-strong'
 								)}
 								onPointerDown={function (e) {
 									e.preventDefault()
@@ -219,7 +219,7 @@ const ConnectionMenuRow = forwardRef<HTMLDivElement, ConnectionMenuRowProps>(
 									'transition-[opacity,transform,color] duration-150 ease-[var(--ease-out)]',
 									'hover:text-destructive hover:bg-background/60',
 									isHolding && 'text-destructive-foreground',
-									'focus-visible:outline-hidden focus-visible:opacity-100 focus-visible:translate-x-0 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-destructive/40'
+									'focus-visible:opacity-100 focus-visible:translate-x-0 focus-visible:pointer-events-auto focus-visible:text-destructive focus-visible:bg-destructive/20'
 								)}
 								onPointerDown={function (e) {
 									onKeepOpenAfterDelete()
@@ -507,7 +507,7 @@ export function ConnectionSwitcher({
 							'transition-[background-color,color] duration-150 ease-[var(--ease-out)]',
 							'hover:bg-sidebar-accent',
 							'data-[state=open]:bg-sidebar-accent',
-							'focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-primary/40'
+							'focus-visible:bg-focus-strong'
 						)}
 					>
 						<div

--- a/packages/studio/src/features/database-studio/components/add-record-dialog.tsx
+++ b/packages/studio/src/features/database-studio/components/add-record-dialog.tsx
@@ -160,7 +160,7 @@ export function AddRecordDialog({
 										}}
 										placeholder={col.nullable ? 'NULL' : `Enter ${col.type}`}
 										required={!col.nullable}
-										className='w-full h-9 px-3 rounded-md border border-sidebar-border bg-sidebar text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-secondary/50'
+										className='w-full h-9 px-3 rounded-md border border-sidebar-border bg-sidebar text-sm text-foreground placeholder:text-muted-foreground transition-colors duration-150 focus-visible:bg-focus'
 									/>
 									<span className='text-xs text-muted-foreground mt-1'>
 										{col.type}

--- a/packages/studio/src/features/database-studio/components/data-grid/draft-row.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid/draft-row.tsx
@@ -125,7 +125,7 @@ function DraftInput({
 			}}
 			data-draft-col={col.name}
 			data-no-shortcuts='true'
-			className='w-full h-full bg-transparent px-3 py-1.5 outline-none focus:bg-sidebar-accent/35 focus:shadow-[inset_0_0_0_1px_hsl(var(--sidebar-foreground)/0.18)] font-mono text-sm'
+			className='w-full h-full bg-transparent px-3 py-1.5 transition-colors duration-150 focus:bg-focus-strong font-mono text-sm'
 			placeholder={col.nullable ? 'NULL' : ''}
 		/>
 	)

--- a/packages/studio/src/features/database-studio/components/data-grid/grid-body.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid/grid-body.tsx
@@ -183,7 +183,7 @@ const GridRow = memo(function GridRow({
 								onBlur={handleEditBlur}
 								onKeyDown={handleEditKeyDown}
 								data-no-shortcuts='true'
-								className='w-full h-full bg-sidebar-accent/35 outline outline-1 outline-offset-[-1px] outline-sidebar-foreground/25 font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
+								className='w-full h-full bg-focus-strong font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
 							>
 								{!col.allowedValues.includes(editValue) && (
 									<option value={editValue}>
@@ -209,7 +209,7 @@ const GridRow = memo(function GridRow({
 								onBlur={handleEditBlur}
 								onKeyDown={handleEditKeyDown}
 								data-no-shortcuts='true'
-								className='w-full h-full bg-sidebar-accent/35 outline outline-1 outline-offset-[-1px] outline-sidebar-foreground/25 font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
+								className='w-full h-full bg-focus-strong font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
 							/>
 						) : (
 							<div className='flex items-center min-w-0 relative'>

--- a/packages/studio/src/features/database-studio/components/filter-bar.tsx
+++ b/packages/studio/src/features/database-studio/components/filter-bar.tsx
@@ -67,7 +67,7 @@ function OperatorSelect({
 	return (
 		<div className='relative'>
 			<select
-				className='h-6 text-xs bg-background border border-sidebar-border rounded px-2 w-[120px] appearance-none focus:ring-1 focus:ring-secondary focus:border-primary outline-none cursor-pointer'
+				className='h-6 text-xs bg-background border border-sidebar-border rounded px-2 w-[120px] appearance-none transition-colors duration-150 focus-visible:bg-focus cursor-pointer'
 				value={value}
 				onChange={(e) => onChange(e.target.value as FilterOperator)}
 			>
@@ -96,7 +96,7 @@ function ColumnSelect({
 	return (
 		<div className='relative'>
 			<select
-				className='h-6 text-xs bg-background border border-sidebar-border rounded px-2 min-w-[120px] appearance-none focus:ring-1 focus:ring-secondary focus:border-primary outline-none cursor-pointer'
+				className='h-6 text-xs bg-background border border-sidebar-border rounded px-2 min-w-[120px] appearance-none transition-colors duration-150 focus-visible:bg-focus cursor-pointer'
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
 			>

--- a/packages/studio/src/features/database-studio/components/selection-action-bar.tsx
+++ b/packages/studio/src/features/database-studio/components/selection-action-bar.tsx
@@ -386,7 +386,7 @@ export const SelectionActionBar = forwardRef<HTMLDivElement, Props>(function Sel
 			tabIndex={-1}
 			className={cn(
 				mode === 'floating' ? floatingClasses : staticClasses,
-				'outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+				'transition-colors duration-150 focus-visible:bg-focus'
 			)}
 			onKeyDown={createToolbarKeyHandler(onEscapeToGrid)}
 		>

--- a/packages/studio/src/features/database-studio/components/studio-toolbar.tsx
+++ b/packages/studio/src/features/database-studio/components/studio-toolbar.tsx
@@ -220,7 +220,7 @@ export function StudioToolbar({
 							<div className='px-2 py-1.5 border-b border-sidebar-border/50 sticky top-0 bg-popover z-10'>
 								<Input
 									placeholder='Search columns...'
-									className='h-7 text-xs bg-transparent border-none shadow-none focus-visible:ring-0 px-0'
+									className='h-7 text-xs bg-transparent border-none shadow-none px-0'
 								/>
 							</div>
 							{columns.map((col) => (

--- a/packages/studio/src/features/docker-manager/components/container-card.tsx
+++ b/packages/studio/src/features/docker-manager/components/container-card.tsx
@@ -111,10 +111,9 @@ export function ContainerCard({
 					onContextMenu={handleContextMenu}
 					className={cn(
 						'group relative p-3 rounded-lg border transition-all cursor-pointer',
-						'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 						isSelected
-							? 'border-emerald-500/50 bg-emerald-500/5'
-							: 'border-border/50 hover:border-border hover:bg-accent/50'
+							? 'border-emerald-500/50 bg-emerald-500/5 focus-visible:bg-emerald-500/15'
+							: 'border-border/50 hover:border-border hover:bg-accent/50 focus-visible:bg-focus'
 					)}
 				>
 					<div className='flex items-start justify-between gap-2'>
@@ -290,7 +289,7 @@ function QuickActionButton({
 			className={cn(
 				'inline-flex items-center justify-center h-6 w-6 rounded-md text-muted-foreground transition-colors',
 				'hover:text-foreground hover:bg-muted',
-				'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+				'focus-visible:text-foreground focus-visible:bg-focus-strong',
 				'disabled:opacity-30 disabled:pointer-events-none',
 				className
 			)}

--- a/packages/studio/src/features/docker-manager/components/docker-view.tsx
+++ b/packages/studio/src/features/docker-manager/components/docker-view.tsx
@@ -696,10 +696,9 @@ export function DockerView({ onOpenInDataViewer, windowControls }: Props) {
                 }}
                 className={cn(
                   "inline-flex h-7 items-center rounded px-2.5 text-xs font-medium transition-colors",
-                  "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
                   isActive
-                    ? "bg-primary text-primary-foreground shadow-sm"
-                    : "text-muted-foreground hover:bg-accent hover:text-foreground",
+                    ? "bg-primary text-primary-foreground shadow-sm focus-visible:bg-primary/78"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:bg-focus focus-visible:text-foreground",
                 )}
               >
                 {option.label}

--- a/packages/studio/src/features/sidebar/components/appearance-panel.tsx
+++ b/packages/studio/src/features/sidebar/components/appearance-panel.tsx
@@ -144,8 +144,8 @@ export function AppearanceControls({ className }: { className?: string }) {
 								className={cn(
 									'flex flex-col items-start p-3 rounded-lg border transition-all text-left',
 									isSelected
-										? 'border-primary bg-primary/10 ring-1 ring-secondary/30'
-										: 'border-border hover:border-muted-foreground/50 hover:bg-muted/50'
+										? 'border-primary bg-primary/10 focus-visible:bg-primary/20'
+										: 'border-border hover:border-muted-foreground/50 hover:bg-muted/50 focus-visible:bg-focus'
 								)}
 							>
 								<span className='text-sm font-medium text-foreground'>{option.name}</span>

--- a/packages/studio/src/features/sidebar/components/changelog-panel.tsx
+++ b/packages/studio/src/features/sidebar/components/changelog-panel.tsx
@@ -107,7 +107,7 @@ export function ChangelogPanel({
 											toggleVersion(entry.version)
 										}
 									}}
-									className='p-3 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-md transition-all'
+									className='p-3 cursor-pointer focus-visible:bg-focus rounded-md transition-all'
 									aria-expanded={isExpanded}
 									aria-controls={`changelog-details-${entry.version}`}
 								>
@@ -169,7 +169,7 @@ export function ChangelogPanel({
 													rel='noopener noreferrer'
 													onClick={(e) => e.stopPropagation()}
 													onKeyDown={(e) => e.stopPropagation()}
-													className='font-mono bg-muted/50 px-1.5 py-0.5 rounded focus-visible:ring-1 focus-visible:ring-ring hover:bg-muted hover:text-primary transition-colors inline-flex items-center gap-1 group/link'
+													className='font-mono bg-muted/50 px-1.5 py-0.5 rounded focus-visible:bg-focus-strong hover:bg-muted hover:text-primary transition-colors inline-flex items-center gap-1 group/link'
 												>
 													{entry.commit}
 													<ExternalLink

--- a/packages/studio/src/features/sidebar/components/settings-panel.tsx
+++ b/packages/studio/src/features/sidebar/components/settings-panel.tsx
@@ -540,7 +540,7 @@ function SettingsSearchField({
 					onKeyDown={onKeyDown}
 					placeholder='Search settings'
 					aria-label='Search settings'
-					className='relative z-10 h-8 border-sidebar-border/60 bg-sidebar/90 pl-9 pr-16 text-sm text-sidebar-foreground placeholder:text-muted-foreground/70 focus-visible:border-sidebar-border focus-visible:ring-1 focus-visible:ring-sidebar-ring'
+					className='relative z-10 h-8 border-sidebar-border/60 bg-sidebar/90 pl-9 pr-16 text-sm text-sidebar-foreground placeholder:text-muted-foreground/70 focus-visible:bg-focus'
 				/>
 				{hasQuery ? (
 					<div className='absolute inset-y-0 right-1 flex items-center gap-0.5'>
@@ -1305,7 +1305,7 @@ export function SettingsView({ windowControls, initialSection, highlightSection 
 																	className={cn(
 																		'flex items-center justify-between gap-4 rounded-sm px-2 py-1.5 transition-colors',
 																		isActive
-																			? 'bg-sidebar-accent/60 ring-1 ring-sidebar-primary/30'
+																			? 'bg-sidebar-accent'
 																			: 'hover:bg-sidebar-accent/30'
 																	)}
 																>

--- a/packages/studio/src/features/sidebar/components/table-list.tsx
+++ b/packages/studio/src/features/sidebar/components/table-list.tsx
@@ -225,7 +225,7 @@ const TableItemRow = memo(function TableItemRow({
 		<div>
 			<div
 				className={cn(
-					'group flex items-center gap-2 px-2 py-1.5 cursor-pointer transition-colors outline-hidden focus-visible:bg-sidebar-accent focus-visible:ring-1 focus-visible:ring-sidebar-ring',
+					'group flex items-center gap-2 px-2 py-1.5 cursor-pointer transition-colors focus-visible:bg-focus-strong',
 					isActive && 'bg-sidebar-accent',
 					!isActive && 'hover:bg-sidebar-accent/60'
 				)}

--- a/packages/studio/src/features/sidebar/components/table-search.tsx
+++ b/packages/studio/src/features/sidebar/components/table-search.tsx
@@ -39,7 +39,7 @@ export function TableSearch({
 					placeholder='Search...'
 					value={searchValue}
 					onChange={(e) => onSearchChange(e.target.value)}
-					className='h-8 bg-transparent border-sidebar-border/60 text-sm pl-3 pr-3 text-sidebar-foreground placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-sidebar-ring focus-visible:border-sidebar-border'
+					className='h-8 bg-transparent border-sidebar-border/60 text-sm pl-3 pr-3 text-sidebar-foreground placeholder:text-muted-foreground/70 focus-visible:bg-focus'
 				/>
 			</div>
 

--- a/packages/studio/src/features/sidebar/components/theme-preview-card.tsx
+++ b/packages/studio/src/features/sidebar/components/theme-preview-card.tsx
@@ -25,7 +25,7 @@ export function ThemePreviewCard({ name, isSelected, onClick, variant, accentCol
 			onClick={onClick}
 			className={cn(
 				'flex-shrink-0 flex flex-col rounded-lg transition-all cursor-pointer overflow-hidden w-full',
-				'hover:opacity-90',
+				'hover:opacity-90 focus-visible:opacity-75',
 				isSelected && 'ring-1 ring-border/60 ring-offset-1 ring-offset-sidebar  relative '
 			)}
 		>

--- a/packages/studio/src/features/sql-console/components/ai-cmd-k.tsx
+++ b/packages/studio/src/features/sql-console/components/ai-cmd-k.tsx
@@ -287,7 +287,7 @@ export function AiCmdK({ open, onClose, onApplySql, activeConnectionId, isTauri 
 						onKeyDown={handleKeyDown}
 						disabled={isGenerating}
 						placeholder="e.g. users who signed up last week but haven't logged in"
-						className='w-full resize-none rounded-md border border-sidebar-border bg-background px-3 py-2 text-sm outline-none focus:border-primary disabled:opacity-50'
+						className='w-full resize-none rounded-md border border-sidebar-border bg-background px-3 py-2 text-sm transition-colors duration-150 focus-visible:bg-focus disabled:opacity-50'
 						rows={2}
 					/>
 					<div className='mt-1 flex items-center justify-between text-[10px] text-muted-foreground'>

--- a/packages/studio/src/features/sql-console/components/unified-sidebar.tsx
+++ b/packages/studio/src/features/sql-console/components/unified-sidebar.tsx
@@ -180,7 +180,7 @@ export function UnifiedSidebar({
 										if (e.key === 'Enter') handleRenameSubmit()
 										if (e.key === 'Escape') setEditingId(null)
 									}}
-									className='h-6 py-0 px-1 text-xs bg-sidebar-accent border-sidebar-border/60 focus-visible:ring-0 focus-visible:border-muted-foreground/40'
+									className='h-6 py-0 px-1 text-xs bg-sidebar-accent border-sidebar-border/60 focus-visible:bg-focus-strong'
 								/>
 							</div>
 						) : (

--- a/packages/studio/src/shared/ui/alert-dialog.tsx
+++ b/packages/studio/src/shared/ui/alert-dialog.tsx
@@ -96,7 +96,7 @@ const AlertDialogAction = React.forwardRef<
 		<AlertDialogPrimitive.Action
 			ref={ref}
 			className={cn(
-				'inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground transition-[background-color,color,box-shadow] duration-150 ease-[var(--ease-out)] hover:bg-destructive/90 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-destructive-foreground/40 disabled:pointer-events-none disabled:opacity-50',
+				'inline-flex h-10 items-center justify-center rounded-md bg-destructive px-4 py-2 text-sm font-medium text-destructive-foreground transition-[background-color,color] duration-150 ease-[var(--ease-out)] hover:bg-destructive/90 focus-visible:bg-destructive/78 active:bg-destructive/70 disabled:pointer-events-none disabled:opacity-50',
 				className
 			)}
 			{...props}
@@ -112,7 +112,7 @@ const AlertDialogCancel = React.forwardRef<
 		<AlertDialogPrimitive.Cancel
 			ref={ref}
 			className={cn(
-				'inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-[background-color,color,box-shadow] duration-150 ease-[var(--ease-out)] hover:bg-accent hover:text-accent-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 sm:mt-0',
+				'inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-[background-color,color] duration-150 ease-[var(--ease-out)] hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground active:bg-focus-strong disabled:pointer-events-none disabled:opacity-50 sm:mt-0',
 				className
 			)}
 			{...props}

--- a/packages/studio/src/shared/ui/badge.tsx
+++ b/packages/studio/src/shared/ui/badge.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { cn } from '@studio/shared/utils/cn'
 
 const badgeVariants = cva(
-	'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+	'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors duration-150',
 	{
 		variants: {
 			variant: {

--- a/packages/studio/src/shared/ui/button.tsx
+++ b/packages/studio/src/shared/ui/button.tsx
@@ -4,21 +4,24 @@ import * as React from 'react'
 import { cn } from '@studio/shared/utils/cn'
 
 const buttonVariants = cva(
-	'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-[color,background-color,border-color,transform] duration-150 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 active:scale-[0.97] [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+	'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,transform] duration-150 disabled:pointer-events-none disabled:opacity-50 active:scale-[0.97] [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
 	{
 		variants: {
 			variant: {
-				default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-				destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+				default:
+					'bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:bg-primary/78 active:bg-primary/70',
+				destructive:
+					'bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:bg-destructive/78 active:bg-destructive/70',
 				outline:
-					'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-				secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-				ghost: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-				link: 'text-primary underline-offset-4 hover:underline',
+					'border border-input bg-background hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground active:bg-focus-strong',
+				secondary:
+					'bg-secondary text-secondary-foreground hover:bg-secondary/80 focus-visible:bg-secondary/60 active:bg-secondary/50',
+				ghost: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:bg-focus focus-visible:text-sidebar-accent-foreground active:bg-focus-strong',
+				link: 'text-primary underline-offset-4 hover:underline focus-visible:bg-focus focus-visible:underline',
 				sidebar:
-					'bg-sidebar-accent text-sidebar-foreground hover:bg-sidebar-accent/80 justify-start',
+					'bg-sidebar-accent text-sidebar-foreground hover:bg-sidebar-accent/80 focus-visible:bg-focus-strong justify-start',
 				'sidebar-ghost':
-					'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground justify-start'
+					'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:bg-focus focus-visible:text-sidebar-accent-foreground active:bg-focus-strong justify-start'
 			},
 			size: {
 				default: 'h-10 px-4 py-2',

--- a/packages/studio/src/shared/ui/checkbox.tsx
+++ b/packages/studio/src/shared/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
 		<CheckboxPrimitive.Root
 			ref={ref}
 			className={cn(
-				'peer h-4 w-4 shrink-0 rounded-sm border border-muted-foreground bg-background ring-offset-background transition-colors data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+				'peer h-4 w-4 shrink-0 rounded-sm border border-muted-foreground bg-background transition-colors duration-150 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary focus-visible:bg-focus-strong data-[state=checked]:focus-visible:bg-primary/75 disabled:cursor-not-allowed disabled:opacity-50',
 				className
 			)}
 			{...props}

--- a/packages/studio/src/shared/ui/dialog.tsx
+++ b/packages/studio/src/shared/ui/dialog.tsx
@@ -40,7 +40,7 @@ const DialogContent = React.forwardRef<
 				{...props}
 			>
 				{children}
-				<DialogPrimitive.Close className='absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground'>
+				<DialogPrimitive.Close className='absolute right-4 top-4 grid h-6 w-6 place-items-center rounded-sm opacity-70 transition-[opacity,background-color] duration-150 hover:opacity-100 hover:bg-focus focus-visible:opacity-100 focus-visible:bg-focus-strong disabled:pointer-events-none'>
 					<X className='h-4 w-4' />
 					<span className='sr-only'>Close</span>
 				</DialogPrimitive.Close>

--- a/packages/studio/src/shared/ui/input.tsx
+++ b/packages/studio/src/shared/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, Props>(function Input(
 		<input
 			type={type}
 			className={cn(
-				'flex h-8 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+				'flex h-8 w-full rounded-md border border-input bg-background px-3 py-1.5 text-sm transition-colors duration-150 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:bg-focus disabled:cursor-not-allowed disabled:opacity-50',
 				className
 			)}
 			ref={ref}

--- a/packages/studio/src/shared/ui/number-input.tsx
+++ b/packages/studio/src/shared/ui/number-input.tsx
@@ -77,7 +77,7 @@ export function NumberInput({
 				disabled={disabled}
 				title={title}
 				className={cn(
-					'flex h-full w-full rounded-md border border-input bg-background py-1 pl-2 pr-7 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none'
+					'flex h-full w-full rounded-md border border-input bg-background py-1 pl-2 pr-7 text-sm transition-colors duration-150 placeholder:text-muted-foreground focus-visible:bg-focus disabled:cursor-not-allowed disabled:opacity-50 text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none'
 				)}
 			/>
 			<div className='absolute right-0 top-0 flex flex-col h-full border-l border-input'>

--- a/packages/studio/src/shared/ui/select.tsx
+++ b/packages/studio/src/shared/ui/select.tsx
@@ -16,7 +16,7 @@ const SelectTrigger = React.forwardRef<
 	<SelectPrimitive.Trigger
 		ref={ref}
 		className={cn(
-			'flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+			'flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors duration-150 placeholder:text-muted-foreground focus-visible:bg-focus data-[state=open]:bg-focus disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
 			className
 		)}
 		{...props}

--- a/packages/studio/src/shared/ui/slider.tsx
+++ b/packages/studio/src/shared/ui/slider.tsx
@@ -9,13 +9,16 @@ const Slider = React.forwardRef<
 	return (
 		<SliderPrimitive.Root
 			ref={ref}
-			className={cn('relative flex w-full touch-none select-none items-center', className)}
+			className={cn(
+				'group relative flex w-full touch-none select-none items-center',
+				className
+			)}
 			{...props}
 		>
-			<SliderPrimitive.Track className='relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted'>
+			<SliderPrimitive.Track className='relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted transition-colors duration-150 group-has-[:focus-visible]:bg-focus-strong'>
 				<SliderPrimitive.Range className='absolute h-full bg-primary' />
 			</SliderPrimitive.Track>
-			<SliderPrimitive.Thumb className='block h-4 w-4 rounded-full border border-primary/50 bg-foreground shadow-sm transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50' />
+			<SliderPrimitive.Thumb className='block h-4 w-4 rounded-full border border-primary/50 bg-foreground shadow-sm transition-colors duration-150 focus-visible:bg-foreground/75 disabled:pointer-events-none disabled:opacity-50' />
 		</SliderPrimitive.Root>
 	)
 })

--- a/packages/studio/src/shared/ui/switch.tsx
+++ b/packages/studio/src/shared/ui/switch.tsx
@@ -9,7 +9,7 @@ const Switch = React.forwardRef<
 	return (
 		<SwitchPrimitives.Root
 			className={cn(
-				'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors data-[state=checked]:bg-white data-[state=unchecked]:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50',
+				'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-150 data-[state=checked]:bg-white data-[state=unchecked]:bg-muted data-[state=checked]:focus-visible:bg-white/75 data-[state=unchecked]:focus-visible:bg-focus-strong disabled:cursor-not-allowed disabled:opacity-50',
 				className
 			)}
 			{...props}

--- a/packages/studio/src/shared/ui/tabs.tsx
+++ b/packages/studio/src/shared/ui/tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
 		<TabsPrimitive.Trigger
 			ref={ref}
 			className={cn(
-				'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+				'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:bg-focus focus-visible:text-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm data-[state=active]:focus-visible:bg-focus-strong',
 				className
 			)}
 			{...props}
@@ -42,16 +42,7 @@ const TabsContent = React.forwardRef<
 	React.ElementRef<typeof TabsPrimitive.Content>,
 	React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(function TabsContent({ className, ...props }, ref) {
-	return (
-		<TabsPrimitive.Content
-			ref={ref}
-			className={cn(
-				'mt-2 ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-				className
-			)}
-			{...props}
-		/>
-	)
+	return <TabsPrimitive.Content ref={ref} className={cn('mt-2', className)} {...props} />
 })
 TabsContent.displayName = TabsPrimitive.Content.displayName
 

--- a/packages/studio/src/styles.css
+++ b/packages/studio/src/styles.css
@@ -96,6 +96,9 @@
 
 	--color-editor: hsl(var(--editor));
 
+	--color-focus: var(--focus-surface);
+	--color-focus-strong: var(--focus-surface-strong);
+
 	--radius-lg: var(--radius);
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-sm: calc(var(--radius) - 4px);
@@ -142,6 +145,60 @@
 	}
 }
 
+/*
+  App-wide focus contract.
+
+  1. Nothing ever draws a focus outline or ring. The UA's default outline and
+     any inherited `outline` are cleared unconditionally.
+  2. Keyboard focus and press states read as a background wash instead
+     (`bg-focus` / `bg-focus-strong`, or the tokens directly in plain CSS).
+
+  The fallback below is wrapped in `:where()` so it carries zero specificity:
+  any element that paints its own background (`bg-primary`, `bg-transparent`, a
+  `focus-visible:bg-*` utility, …) overrides it and owns its own focus look.
+  It exists so that a focusable element nobody styled still shows *something*
+  rather than disappearing from the keyboard-navigation story entirely.
+*/
+@layer base {
+	:focus,
+	:focus-visible {
+		outline: none;
+	}
+
+	:where(
+		a[href],
+		button,
+		summary,
+		input,
+		textarea,
+		select,
+		[contenteditable='true'],
+		[role='button'],
+		[role='link'],
+		[role='menuitem'],
+		[role='menuitemcheckbox'],
+		[role='menuitemradio'],
+		[role='option'],
+		[role='tab']
+	):focus-visible {
+		background-color: var(--focus-surface);
+	}
+
+	:where(
+		a[href],
+		button,
+		summary,
+		[role='button'],
+		[role='menuitem'],
+		[role='menuitemcheckbox'],
+		[role='menuitemradio'],
+		[role='option'],
+		[role='tab']
+	):not(:disabled, [data-disabled], [aria-disabled='true']):active {
+		background-color: var(--focus-surface-strong);
+	}
+}
+
 @utility scrollbar-thin {
 	scrollbar-width: thin;
 	scrollbar-color: hsl(var(--muted)) transparent;
@@ -181,6 +238,18 @@
 
 		--ease-out: cubic-bezier(0.23, 1, 0.32, 1);
 		--ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+
+		/*
+		 * Focus and press feedback is a translucent wash of the theme's own
+		 * foreground — never an outline, ring, glow or shadow. Because these are
+		 * alpha values they composite over whatever surface the element sits on,
+		 * and because `--foreground` is redefined by every theme class (applied to
+		 * the same <html> element as `:root`) they re-tune themselves per theme:
+		 * dark themes lighten, light themes darken.
+		 */
+		--focus-surface: hsl(var(--foreground) / 0.1);
+		--focus-surface-strong: hsl(var(--foreground) / 0.16);
+		--focus-duration: 130ms;
 
 		--background: 0 0% 6.7%;
 		--editor: 240 9% 6%;
@@ -1055,8 +1124,6 @@
 	--sv-accent-bg: hsl(var(--sidebar-foreground) / 0.08);
 	--sv-accent-bg-muted: hsl(var(--sidebar-foreground) / 0.05);
 	--sv-accent-text: hsl(var(--sidebar-foreground) / 0.86);
-	--sv-focus-border: hsl(var(--sidebar-foreground) / 0.18);
-	--sv-focus-ring: hsl(var(--sidebar-foreground) / 0.1);
 	--sv-canvas-base: hsl(var(--background));
 	--sv-canvas-panel: hsl(var(--card) / 0.18);
 	--sv-grid-line: hsl(var(--border) / 0.34);
@@ -1581,9 +1648,8 @@
 	border-color: hsl(var(--sidebar-foreground) / 0.12);
 }
 
-.sv-toolbar__search-input:focus {
-	border-color: var(--sv-focus-border);
-	box-shadow: 0 0 0 3px var(--sv-focus-ring);
+.sv-toolbar__search-input:focus-visible {
+	background: var(--focus-surface);
 }
 
 .sv-toolbar__toggle--active {


### PR DESCRIPTION
## What

Replaces ring/outline/shadow focus treatments with a single app-wide focus contract: keyboard focus and press states read as a background wash driven by two tokens (`bg-focus` / `bg-focus-strong`, i.e. `--focus-surface` / `--focus-surface-strong`).

- All UA outlines and rings are cleared unconditionally in the base layer.
- A zero-specificity `:where()` fallback paints `--focus-surface` on any focusable element nobody styled, so unstyled elements never vanish from keyboard navigation.
- ~30 components (shared UI primitives, sidebar, data grid chrome, dialogs, docker manager, SQL console) migrated from `focus-visible:ring-*` / `outline` utilities to the tokens.
- Destructive actions keep their own tint (`focus-visible:bg-destructive/20`); the hold-to-delete motion from #231 is preserved and composes with the new focus style.

## Verification

- `vitest`: 98 files, 978 tests pass
- `tsc --noEmit` clean for packages/studio and apps/desktop
- `bun run lint`: 0 errors
- oxfmt parity with master on the touched file set (pre-existing offenders only)

## Summary by Sourcery

Standardize Studio keyboard focus and press feedback as theme-aware background tints instead of outlines, rings, or shadows.

New Features:
- Introduce app-wide background tint tokens for keyboard focus and press feedback, including a fallback for otherwise unstyled focusable elements.

Enhancements:
- Replace ring, outline, border, shadow, and glow focus treatments across Studio UI components with consistent focus and pressed-state background washes.
- Preserve distinct visual treatment for destructive actions and selected or active controls while aligning them with the new focus contract.
- Add transition styling and theme-aware focus surfaces for shared controls, navigation, dialogs, data grids, sidebars, Docker management, and SQL console interfaces.

Chores:
- Remove obsolete sidebar-specific focus border and ring variables and update the toolbar search focus styling.