### PR TITLE
feat(grid): keyboard sort, context-menu key, rectangle-only shift selection

### DIFF
--- a/.agents/skills/dora-data-grid/SKILL.md
+++ b/.agents/skills/dora-data-grid/SKILL.md
@@ -120,9 +120,10 @@ a second normalization between the editor and the mutation.
 **"Default" in the grid is never the database's declared DEFAULT.** The grid has
 no access to it. `getColumnDefault` infers one from column type and name — a
 timestamp for date-ish and audit columns, null when nullable, the empty string
-otherwise — and that inferred value is what Backspace writes into the focused
-cell, skipping primary keys. Do not label it as the column default in UI copy,
-and do not use it to decide whether a column was set.
+otherwise — and that inferred value is what Backspace writes into the selected
+cells, falling back to the focused cell and skipping primary keys. Do not label
+it as the column default in UI copy, and do not use it to decide whether a
+column was set.
 
 **The draft row is a separate editor with its own rules.** It shows `auto` in
 every primary-key cell and never edits one, uses `NULL` as the placeholder for a
@@ -165,11 +166,11 @@ A new teardown path sets those flags rather than tearing the editor down on the
 first blur it sees.
 
 **Bare printable keys are commands, not text.** With a cell focused, `e` and
-`F2` and `Enter` open the editor, `d` deletes, `c` copies, `v` pastes, Space
-toggles the row, Backspace clears to the inferred default, and the default branch
-swallows every other lone printable key so it neither types nor escapes to a
-document-level shortcut. Editing is only ever entered explicitly. Adding a new
-bare-letter command means checking it against that list first.
+`F2` and `Enter` open the editor, `d` deletes, `c` copies, `v` pastes, `s` sorts,
+Space toggles the row, Backspace clears to the inferred default, and the default
+branch swallows every other lone printable key so it neither types nor escapes
+to a document-level shortcut. Editing is only ever entered explicitly. Adding a
+new bare-letter command means checking it against that list first.
 
 **The grid is one tab stop with roving focus.** The `<table>` is the only
 tabbable node; the row checkboxes and the FK icon carry `tabIndex={-1}`, and

--- a/.agents/skills/dora-data-grid/reference.md
+++ b/.agents/skills/dora-data-grid/reference.md
@@ -97,13 +97,15 @@ With a cell focused, from `use-grid-keyboard.ts`:
 | --- | --- |
 | First arrow, Tab or Enter with no focus | Focus lands on the top-left cell |
 | Arrows | Move one cell; with ctrl or cmd, jump to the edge |
-| Shift plus arrows | Left and right extend the cell rectangle from the anchor; up and down extend the *row* selection instead and clear the cell selection |
+| Shift plus arrows | Extend a rectangular cell selection from the anchor |
 | Tab and shift+Tab | Move one cell, wrapping across rows; Tab escapes the grid at the last cell |
 | Enter, F2, `e` | Open the editor on the focused cell |
 | Delete, `d` | Delete the selected rows, falling back to the focused row |
-| Backspace | Write `getColumnDefault` into the focused cell; skipped on a primary key |
+| Backspace | Write `getColumnDefault` into every selected cell, falling back to the focused cell; primary keys are skipped |
 | Escape | Progressive: collapse a multi-cell selection, then drop the row selection, then clear focus |
 | Space | Toggle the focused row; with shift, select the range from the last clicked row |
+| `s` | Cycle the focused column's sort state |
+| Shift+F10 or Context Menu | Open the focused cell's action menu |
 | `c`, mod+c | Copy the selection, or the focused cell, as TSV |
 | `v`, mod+v | Paste TSV from the focused cell, clipped to the existing row and column count |
 | mod+a | Toggle select all |

--- a/__tests__/apps/desktop/src/features/database-studio/components/data-grid/use-grid-keyboard.test.ts
+++ b/__tests__/apps/desktop/src/features/database-studio/components/data-grid/use-grid-keyboard.test.ts
@@ -1,7 +1,10 @@
 import { renderHook, act } from '@testing-library/react'
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { useGridKeyboard } from '@/features/database-studio/components/data-grid/use-grid-keyboard'
-import type { CellPosition, EditingCell } from '@/features/database-studio/components/data-grid/types'
+import type {
+	CellPosition,
+	EditingCell
+} from '@/features/database-studio/components/data-grid/types'
 import type { ColumnDefinition } from '@/features/database-studio/types'
 
 function createColumns(): ColumnDefinition[] {
@@ -24,7 +27,7 @@ describe('useGridKeyboard', function () {
 		vi.unstubAllGlobals()
 	})
 
-	it('extends the selected row range with shift plus arrow up', function () {
+	it('extends the selected cell rectangle with shift plus arrow up', function () {
 		const focusedCell: CellPosition = { row: 2, col: 1 }
 		const anchorCell: CellPosition = { row: 2, col: 1 }
 		const lastClickedRowRef = { current: null as number | null }
@@ -75,9 +78,9 @@ describe('useGridKeyboard', function () {
 		})
 
 		expect(setFocusedCell).toHaveBeenCalledWith({ row: 1, col: 1 })
-		expect(onSelectAll).toHaveBeenCalledWith(false)
-		expect(onRowsSelect).toHaveBeenCalledWith([1, 2], true)
-		expect(updateCellSelection).toHaveBeenCalledWith(new Set())
-		expect(lastClickedRowRef.current).toBe(2)
+		expect(onSelectAll).not.toHaveBeenCalled()
+		expect(onRowsSelect).not.toHaveBeenCalled()
+		expect(updateCellSelection).toHaveBeenCalledWith(new Set(['1:1', '2:1']))
+		expect(lastClickedRowRef.current).toBeNull()
 	})
 })

--- a/packages/studio/src/features/database-studio/components/data-grid.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid.tsx
@@ -1,4 +1,12 @@
-import React, { useState, useRef, useEffect, useLayoutEffect, useMemo, useCallback } from 'react'
+import React, {
+	useState,
+	useRef,
+	useEffect,
+	useId,
+	useLayoutEffect,
+	useMemo,
+	useCallback
+} from 'react'
 import { useShortcut, useEffectiveShortcuts } from '@studio/core/shortcuts'
 import { useSettings } from '@studio/core/settings'
 import {
@@ -11,7 +19,7 @@ import { NoColumnsState } from './data-grid/empty-states'
 import { GridBody } from './data-grid/grid-body'
 import { GridContextMenu, useGridContextMenu } from './data-grid/grid-context-menu'
 import { GridHeader } from './data-grid/grid-header'
-import { getCellsInRectangle } from './data-grid/selection'
+import { getCellId, getCellsInRectangle } from './data-grid/selection'
 import { CellPosition, ContextMenuState } from './data-grid/types'
 import { useCellEditing } from './data-grid/use-cell-editing'
 import { useCellSelection } from './data-grid/use-cell-selection'
@@ -115,6 +123,8 @@ export function DataGrid({
 	workspaceStateKey = 'data-grid'
 }: Props) {
 	const lastClickedRowRef = useRef<number | null>(null)
+	const gridId = `data-grid-${useId().replace(/:/g, '')}`
+	const instructionsId = `${gridId}-instructions`
 
 	// The studio recreates these handlers on every render; pinning them here is
 	// what lets the memoized rows skip re-rendering when only the shell moved.
@@ -330,6 +340,8 @@ export function DataGrid({
 		masked,
 		onCellEdit,
 		onDeleteSelectedRows,
+		onOpenCellMenu: contextMenu.armCell,
+		onSortColumn: handleSort,
 		onRowsSelect,
 		onRowSelect,
 		onSelectAll,
@@ -346,8 +358,19 @@ export function DataGrid({
 		return <NoColumnsState />
 	}
 
+	const activeCellId =
+		focusedCell && rows[focusedCell.row] && columns[focusedCell.col]
+			? getCellId(gridId, focusedCell.row, focusedCell.col)
+			: undefined
+
 	return (
 		<div className='relative h-full min-h-0 w-full overflow-hidden'>
+			<div id={instructionsId} className='sr-only'>
+				Use arrow keys to move between cells. Hold Shift with an arrow key to select a
+				rectangle. Press Enter, F2, or E to edit, Backspace to clear selected cells, Delete
+				to delete selected rows, Space to select a row, S to sort the focused column, and
+				Shift+F10 to open cell actions.
+			</div>
 			<div
 				ref={scrollContainerRef}
 				className={cn(
@@ -403,8 +426,12 @@ export function DataGrid({
 						style={{ tableLayout: 'auto', minWidth: '100%' }}
 						role='grid'
 						aria-label={tableName ? `Data grid for ${tableName}` : 'Data grid'}
-						aria-rowcount={rows.length}
+						aria-describedby={instructionsId}
+						aria-activedescendant={activeCellId}
+						aria-rowcount={rows.length + 1}
 						aria-colcount={columns.length + 1}
+						aria-multiselectable='true'
+						aria-readonly={masked || !onCellEdit}
 						tabIndex={0}
 						onKeyDown={handleGridKeyDown}
 					>
@@ -436,6 +463,7 @@ export function DataGrid({
 							sort={sort}
 						/>
 						<GridBody
+							gridId={gridId}
 							columns={columns}
 							draftInsertIndex={draftInsertIndex}
 							draftRow={draftRow}

--- a/packages/studio/src/features/database-studio/components/data-grid/grid-body.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid/grid-body.tsx
@@ -7,9 +7,11 @@ import { formatCellValue } from './cell-value'
 import { DraftRow } from './draft-row'
 import { NoRowsState } from './empty-states'
 import { FKNavigateIcon } from './fk-icon'
+import { getCellId } from './selection'
 import { EditingCell } from './types'
 
 type GridRowProps = {
+	gridId: string
 	row: Record<string, unknown>
 	rowIndex: number
 	columns: ColumnDefinition[]
@@ -49,6 +51,7 @@ type GridRowProps = {
  * grid's shared menu from `onContextMenu`.
  */
 const GridRow = memo(function GridRow({
+	gridId,
 	row,
 	rowIndex,
 	columns,
@@ -119,6 +122,7 @@ const GridRow = memo(function GridRow({
 					stickyCellAccentClasses
 				)}
 				role='gridcell'
+				aria-colindex={1}
 				onContextMenu={function () {
 					onRowContextMenu(rowIndex)
 				}}
@@ -148,6 +152,7 @@ const GridRow = memo(function GridRow({
 
 				return (
 					<td
+						id={getCellId(gridId, rowIndex, colIndex)}
 						key={col.name}
 						className={cn(
 							'border-b border-r border-sidebar-border last:border-r-0 font-mono text-sm overflow-hidden cursor-cell px-3 py-1.5 relative whitespace-nowrap text-ellipsis max-w-[300px] group/cell',
@@ -159,6 +164,9 @@ const GridRow = memo(function GridRow({
 						)}
 						style={width ? { maxWidth: width } : undefined}
 						data-cell-key={`${rowIndex}:${colIndex}`}
+						role='gridcell'
+						aria-colindex={colIndex + 2}
+						aria-selected={isSelected}
 						onContextMenu={function () {
 							onCellContextMenu(rowIndex, colIndex)
 						}}
@@ -183,6 +191,7 @@ const GridRow = memo(function GridRow({
 								onBlur={handleEditBlur}
 								onKeyDown={handleEditKeyDown}
 								data-no-shortcuts='true'
+								aria-label={`Edit ${col.name} in row ${rowIndex + 1}`}
 								className='w-full h-full bg-focus-strong font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
 							>
 								{!col.allowedValues.includes(editValue) && (
@@ -209,6 +218,7 @@ const GridRow = memo(function GridRow({
 								onBlur={handleEditBlur}
 								onKeyDown={handleEditKeyDown}
 								data-no-shortcuts='true'
+								aria-label={`Edit ${col.name} in row ${rowIndex + 1}`}
 								className='w-full h-full bg-focus-strong font-mono text-sm -mx-3 -my-1.5 px-3 py-1.5 box-content'
 							/>
 						) : (
@@ -236,6 +246,7 @@ const GridRow = memo(function GridRow({
 })
 
 type GridBodyProps = {
+	gridId: string
 	columns: ColumnDefinition[]
 	draftInsertIndex?: number | null
 	draftRow?: Record<string, unknown> | null
@@ -276,6 +287,7 @@ type GridBodyProps = {
 }
 
 export function GridBody({
+	gridId,
 	columns,
 	draftInsertIndex,
 	draftRow,
@@ -343,8 +355,8 @@ export function GridBody({
 				)}
 
 			{topPad > 0 && (
-				<tr style={{ height: topPad }}>
-					<td colSpan={columns.length + 1} />
+				<tr style={{ height: topPad }} role='presentation' aria-hidden='true'>
+					<td colSpan={columns.length + 1} role='presentation' />
 				</tr>
 			)}
 
@@ -354,6 +366,7 @@ export function GridBody({
 				return (
 					<React.Fragment key={rowIndex}>
 						<GridRow
+							gridId={gridId}
 							row={rows[rowIndex]}
 							rowIndex={rowIndex}
 							columns={columns}
@@ -397,8 +410,8 @@ export function GridBody({
 				)
 			})}
 			{bottomPad > 0 && (
-				<tr style={{ height: bottomPad }}>
-					<td colSpan={columns.length + 1} />
+				<tr style={{ height: bottomPad }} role='presentation' aria-hidden='true'>
+					<td colSpan={columns.length + 1} role='presentation' />
 				</tr>
 			)}
 

--- a/packages/studio/src/features/database-studio/components/data-grid/grid-header.tsx
+++ b/packages/studio/src/features/database-studio/components/data-grid/grid-header.tsx
@@ -84,10 +84,11 @@ export function GridHeader({
 }: GridHeaderProps) {
 	return (
 		<thead className='sticky top-0 bg-sidebar z-10' role='rowgroup'>
-			<tr role='row'>
+			<tr role='row' aria-rowindex={1}>
 				<th
 					className='w-[30px] min-w-[30px] p-0 text-center align-middle border-b border-l border-r border-sidebar-border bg-background sticky left-0 z-30'
 					role='columnheader'
+					aria-colindex={1}
 					aria-label='Select all rows'
 				>
 					<Checkbox
@@ -102,7 +103,7 @@ export function GridHeader({
 						tabIndex={-1}
 					/>
 				</th>
-				{columns.map(function (col) {
+				{columns.map(function (col, colIndex) {
 					const isSorted = sort?.column === col.name
 					const width = getColumnWidth(col.name)
 
@@ -115,6 +116,15 @@ export function GridHeader({
 								resizingColumn === col.name && 'bg-sidebar-accent'
 							)}
 							style={width ? { width } : undefined}
+							role='columnheader'
+							aria-colindex={colIndex + 2}
+							aria-sort={
+								isSorted
+									? sort?.direction === 'asc'
+										? 'ascending'
+										: 'descending'
+									: 'none'
+							}
 							onClick={function () {
 								onSort(col.name)
 							}}

--- a/packages/studio/src/features/database-studio/components/data-grid/selection.ts
+++ b/packages/studio/src/features/database-studio/components/data-grid/selection.ts
@@ -4,6 +4,10 @@ export function getCellKey(row: number, col: number): string {
 	return `${row}:${col}`
 }
 
+export function getCellId(gridId: string, row: number, col: number): string {
+	return `${gridId}-cell-${row}-${col}`
+}
+
 export function getCellsInRectangle(start: CellPosition, end: CellPosition): Set<string> {
 	const minRow = Math.min(start.row, end.row)
 	const maxRow = Math.max(start.row, end.row)

--- a/packages/studio/src/features/database-studio/components/data-grid/use-grid-keyboard.test.ts
+++ b/packages/studio/src/features/database-studio/components/data-grid/use-grid-keyboard.test.ts
@@ -1,5 +1,78 @@
-import { describe, expect, it } from 'vitest'
-import { parseClipboardGrid } from './use-grid-keyboard'
+import React from 'react'
+import { act, render, renderHook, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DataGrid } from '../data-grid'
+import { getCellsToClear, parseClipboardGrid, useGridKeyboard } from './use-grid-keyboard'
+
+vi.mock('@studio/core/settings', function () {
+	return {
+		useSettings: function () {
+			return { settings: { privacyMaskData: false } }
+		}
+	}
+})
+
+vi.mock('@studio/core/shortcuts', async function (importOriginal) {
+	const actual = await importOriginal<typeof import('@studio/core/shortcuts')>()
+	const chain = {
+		in: function () {
+			return chain
+		},
+		except: function () {
+			return chain
+		},
+		on: function () {
+			return chain
+		}
+	}
+	return {
+		...actual,
+		useEffectiveShortcuts: function () {
+			return {
+				selectAll: { combo: 'mod+a', description: 'Select all' },
+				deselect: { combo: 'mod+d', description: 'Deselect' }
+			}
+		},
+		useShortcut: function () {
+			return {
+				bind: function () {
+					return chain
+				}
+			}
+		}
+	}
+})
+
+beforeEach(function () {
+	vi.stubGlobal('requestAnimationFrame', function (callback: FrameRequestCallback) {
+		callback(0)
+		return 1
+	})
+	vi.stubGlobal('cancelAnimationFrame', vi.fn())
+})
+
+afterEach(function () {
+	vi.unstubAllGlobals()
+})
+
+function createKeyboardEvent(key: string, shiftKey = false): React.KeyboardEvent {
+	return {
+		key,
+		shiftKey,
+		ctrlKey: false,
+		metaKey: false,
+		altKey: false,
+		preventDefault: vi.fn()
+	} as unknown as React.KeyboardEvent
+}
+
+function createColumns() {
+	return [
+		{ name: 'id', type: 'integer', nullable: false, primaryKey: true },
+		{ name: 'name', type: 'text', nullable: false, primaryKey: false },
+		{ name: 'email', type: 'text', nullable: true, primaryKey: false }
+	]
+}
 
 describe('parseClipboardGrid', () => {
 	it('splits LF-delimited TSV into rows and cells', () => {
@@ -34,5 +107,192 @@ describe('parseClipboardGrid', () => {
 
 	it('keeps a deliberate empty trailing cell', () => {
 		expect(parseClipboardGrid('a\t')).toEqual([['a', '']])
+	})
+})
+
+describe('useGridKeyboard', function () {
+	it('extends a rectangular cell selection with vertical Shift+Arrow navigation', function () {
+		const updateCellSelection = vi.fn()
+		const onRowsSelect = vi.fn()
+		const setFocusedCell = vi.fn()
+		const columns = createColumns()
+		const rows = [
+			{ id: 1, name: 'Ada', email: 'ada@example.com' },
+			{ id: 2, name: 'Grace', email: 'grace@example.com' },
+			{ id: 3, name: 'Linus', email: 'linus@example.com' }
+		]
+		const { result } = renderHook(function () {
+			return useGridKeyboard({
+				anchorCell: { row: 0, col: 1 },
+				allSelected: false,
+				columns,
+				editingCell: null,
+				focusedCell: { row: 0, col: 1 },
+				lastClickedRowRef: { current: 0 },
+				onRowsSelect,
+				onRowSelect: vi.fn(),
+				onSelectAll: vi.fn(),
+				rows,
+				selectedCellsSet: new Set(['0:1']),
+				selectedRows: new Set(),
+				setAnchorCell: vi.fn(),
+				setFocusedCell,
+				startCellEdit: vi.fn(),
+				updateCellSelection
+			})
+		})
+
+		act(function () {
+			result.current(createKeyboardEvent('ArrowDown', true))
+		})
+
+		expect(setFocusedCell).toHaveBeenCalledWith({ row: 1, col: 1 })
+		expect(updateCellSelection).toHaveBeenCalledWith(new Set(['0:1', '1:1']))
+		expect(onRowsSelect).not.toHaveBeenCalled()
+	})
+
+	it('clears every selected editable cell while preserving primary keys', function () {
+		const onCellEdit = vi.fn()
+		const columns = createColumns()
+		const rows = [
+			{ id: 1, name: 'Ada', email: 'ada@example.com' },
+			{ id: 2, name: 'Grace', email: 'grace@example.com' }
+		]
+		const { result } = renderHook(function () {
+			return useGridKeyboard({
+				anchorCell: { row: 0, col: 0 },
+				allSelected: false,
+				columns,
+				editingCell: null,
+				focusedCell: { row: 0, col: 0 },
+				lastClickedRowRef: { current: 0 },
+				onCellEdit,
+				onRowSelect: vi.fn(),
+				onSelectAll: vi.fn(),
+				rows,
+				selectedCellsSet: new Set(['0:0', '0:1', '1:2']),
+				selectedRows: new Set(),
+				setAnchorCell: vi.fn(),
+				setFocusedCell: vi.fn(),
+				startCellEdit: vi.fn(),
+				updateCellSelection: vi.fn()
+			})
+		})
+
+		act(function () {
+			result.current(createKeyboardEvent('Backspace'))
+		})
+
+		expect(onCellEdit).toHaveBeenCalledTimes(2)
+		expect(onCellEdit).toHaveBeenCalledWith(0, 'name', '')
+		expect(onCellEdit).toHaveBeenCalledWith(1, 'email', null)
+	})
+
+	it('sorts the focused column with S', function () {
+		const onSortColumn = vi.fn()
+		const columns = createColumns()
+		const { result } = renderHook(function () {
+			return useGridKeyboard({
+				anchorCell: { row: 0, col: 1 },
+				allSelected: false,
+				columns,
+				editingCell: null,
+				focusedCell: { row: 0, col: 1 },
+				lastClickedRowRef: { current: 0 },
+				onSortColumn,
+				onRowSelect: vi.fn(),
+				onSelectAll: vi.fn(),
+				rows: [{ id: 1, name: 'Ada', email: 'ada@example.com' }],
+				selectedCellsSet: new Set(['0:1']),
+				selectedRows: new Set(),
+				setAnchorCell: vi.fn(),
+				setFocusedCell: vi.fn(),
+				startCellEdit: vi.fn(),
+				updateCellSelection: vi.fn()
+			})
+		})
+
+		act(function () {
+			result.current(createKeyboardEvent('s'))
+		})
+
+		expect(onSortColumn).toHaveBeenCalledWith('name')
+	})
+
+	it('opens the focused cell menu with Shift+F10', function () {
+		const onOpenCellMenu = vi.fn()
+		const columns = createColumns()
+		const { result } = renderHook(function () {
+			return useGridKeyboard({
+				anchorCell: { row: 0, col: 2 },
+				allSelected: false,
+				columns,
+				editingCell: null,
+				focusedCell: { row: 0, col: 2 },
+				lastClickedRowRef: { current: 0 },
+				onOpenCellMenu,
+				onRowSelect: vi.fn(),
+				onSelectAll: vi.fn(),
+				rows: [{ id: 1, name: 'Ada', email: 'ada@example.com' }],
+				selectedCellsSet: new Set(['0:2']),
+				selectedRows: new Set(),
+				setAnchorCell: vi.fn(),
+				setFocusedCell: vi.fn(),
+				startCellEdit: vi.fn(),
+				updateCellSelection: vi.fn()
+			})
+		})
+
+		act(function () {
+			result.current(createKeyboardEvent('F10', true))
+		})
+
+		expect(onOpenCellMenu).toHaveBeenCalledWith(0, 2)
+	})
+})
+
+describe('DataGrid accessibility', function () {
+	it('exposes the active cell, selection, dimensions, and sort state', function () {
+		render(
+			React.createElement(DataGrid, {
+				columns: createColumns(),
+				rows: [
+					{ id: 1, name: 'Ada', email: 'ada@example.com' },
+					{ id: 2, name: 'Grace', email: 'grace@example.com' }
+				],
+				selectedRows: new Set<number>(),
+				onRowSelect: vi.fn(),
+				onSelectAll: vi.fn(),
+				onCellEdit: vi.fn(),
+				onSortChange: vi.fn(),
+				sort: { column: 'name', direction: 'asc' },
+				selectedCells: new Set(['0:1']),
+				initialFocusedCell: { row: 0, col: 1 },
+				tableName: 'people',
+				workspaceStateKey: 'accessibility-test-grid'
+			})
+		)
+
+		const grid = screen.getByRole('grid', { name: 'Data grid for people' })
+		const activeCellId = grid.getAttribute('aria-activedescendant')
+		const activeCell = activeCellId ? document.getElementById(activeCellId) : null
+
+		expect(grid).toHaveAttribute('aria-rowcount', '3')
+		expect(grid).toHaveAttribute('aria-colcount', '4')
+		expect(grid).toHaveAttribute('aria-multiselectable', 'true')
+		expect(grid).toHaveAttribute('aria-readonly', 'false')
+		expect(activeCell).toHaveAttribute('role', 'gridcell')
+		expect(activeCell).toHaveAttribute('aria-colindex', '3')
+		expect(activeCell).toHaveAttribute('aria-selected', 'true')
+		expect(screen.getByRole('columnheader', { name: /name text/i })).toHaveAttribute(
+			'aria-sort',
+			'ascending'
+		)
+	})
+})
+
+describe('getCellsToClear', function () {
+	it('falls back to the focused cell when there is no selection', function () {
+		expect(getCellsToClear(new Set(), { row: 2, col: 3 })).toEqual([{ row: 2, col: 3 }])
 	})
 })

--- a/packages/studio/src/features/database-studio/components/data-grid/use-grid-keyboard.ts
+++ b/packages/studio/src/features/database-studio/components/data-grid/use-grid-keyboard.ts
@@ -16,6 +16,8 @@ type UseGridKeyboardArgs = {
 	masked?: boolean
 	onCellEdit?: (rowIndex: number, columnName: string, newValue: unknown) => void
 	onDeleteSelectedRows?: () => void
+	onOpenCellMenu?: (rowIndex: number, colIndex: number) => void
+	onSortColumn?: (columnName: string) => void
 	onRowsSelect?: (rowIndices: number[], checked: boolean) => void
 	onRowSelect: (rowIndex: number, checked: boolean) => void
 	onSelectAll: (checked: boolean) => void
@@ -38,6 +40,8 @@ export function useGridKeyboard({
 	masked,
 	onCellEdit,
 	onDeleteSelectedRows,
+	onOpenCellMenu,
+	onSortColumn,
 	onRowsSelect,
 	onRowSelect,
 	onSelectAll,
@@ -89,30 +93,6 @@ export function useGridKeyboard({
 			const { row, col } = focusedCell
 			const maxRow = rows.length - 1
 			const maxCol = columns.length - 1
-			const rowShiftSelectionKey =
-				e.shiftKey && (e.key === 'ArrowUp' || e.key === 'ArrowDown')
-
-			function getShiftRowAnchor() {
-				return lastClickedRowRef.current ?? row
-			}
-
-			function applyRowSelection(newRow: number) {
-				if (!onRowsSelect) return false
-
-				const anchorRow = getShiftRowAnchor()
-				const start = Math.min(anchorRow, newRow)
-				const end = Math.max(anchorRow, newRow)
-				const range: number[] = []
-				for (let i = start; i <= end; i++) {
-					range.push(i)
-				}
-
-				onSelectAll(false)
-				onRowsSelect(range, true)
-				lastClickedRowRef.current = anchorRow
-				return true
-			}
-
 			function moveAndMaybeSelect(newRow: number, newCol: number) {
 				const newPos: CellPosition = { row: newRow, col: newCol }
 				if (pendingNavFrameRef.current !== null) {
@@ -120,10 +100,7 @@ export function useGridKeyboard({
 				}
 				pendingNavFrameRef.current = requestAnimationFrame(function () {
 					setFocusedCell(newPos)
-					if (rowShiftSelectionKey && applyRowSelection(newRow)) {
-						setAnchorCell({ row: newRow, col: newCol })
-						updateCellSelection(new Set())
-					} else if (e.shiftKey && anchorCell) {
+					if (e.shiftKey && anchorCell) {
 						updateCellSelection(getCellsInRectangle(anchorCell, newPos))
 					} else if (!e.shiftKey) {
 						setAnchorCell(newPos)
@@ -191,6 +168,12 @@ export function useGridKeyboard({
 						startCellEdit(row, columns[col].name, rows[row][columns[col].name])
 					}
 					break
+				case 'F10':
+				case 'ContextMenu':
+					if (e.key === 'ContextMenu' || e.shiftKey) {
+						onOpenCellMenu?.(row, col)
+					}
+					break
 				// Delete removes the active row(s). onDeleteSelectedRows resolves
 				// the target via rowsForActions, which falls back to the focused
 				// row when nothing is explicitly selected — matching the "Del"
@@ -211,8 +194,12 @@ export function useGridKeyboard({
 					if (e.ctrlKey || e.metaKey || e.shiftKey) break
 					e.preventDefault()
 					if (masked) break
-					if (onCellEdit && !columns[col].primaryKey) {
-						onCellEdit(row, columns[col].name, getColumnDefault(columns[col]))
+					if (onCellEdit) {
+						for (const cell of getCellsToClear(selectedCellsSet, focusedCell)) {
+							const column = columns[cell.col]
+							if (!column || column.primaryKey || !rows[cell.row]) continue
+							onCellEdit(cell.row, column.name, getColumnDefault(column))
+						}
 					}
 					break
 				case 'Escape':
@@ -268,6 +255,12 @@ export function useGridKeyboard({
 						}
 					}
 					break
+				case 's':
+					if (!e.ctrlKey && !e.metaKey && !e.altKey) {
+						e.preventDefault()
+						onSortColumn?.(columns[col].name)
+					}
+					break
 				case 'a':
 					if (e.ctrlKey || e.metaKey) {
 						e.preventDefault()
@@ -316,6 +309,8 @@ export function useGridKeyboard({
 			masked,
 			onCellEdit,
 			onDeleteSelectedRows,
+			onOpenCellMenu,
+			onSortColumn,
 			onRowsSelect,
 			onRowSelect,
 			onSelectAll,
@@ -328,6 +323,20 @@ export function useGridKeyboard({
 			updateCellSelection
 		]
 	)
+}
+
+export function getCellsToClear(
+	selectedCellsSet: Set<string>,
+	focusedCell: CellPosition
+): CellPosition[] {
+	const keys =
+		selectedCellsSet.size > 0
+			? selectedCellsSet
+			: new Set([getCellKey(focusedCell.row, focusedCell.col)])
+	return Array.from(keys, function (key) {
+		const [row, col] = key.split(':').map(Number)
+		return { row, col }
+	})
 }
 
 function copySelectionToClipboard(


### PR DESCRIPTION
## What

Keyboard follow-ups in the data grid:

- `s` on a focused cell toggles that column's sort.
- Shift+F10 / the ContextMenu key opens the cell context menu at the focused cell.
- Shift+Arrow always extends the cell selection rectangle; the special shift-row-range branch is removed.
- Backspace clears every selected cell, falling back to the focused cell, still skipping primary keys.
- `dora-data-grid` skill docs updated to match the new behavior.

## Verification

- vitest: full suite passes (978 in `__tests__` plus the 12-test grid keyboard suite in `packages/studio`)
- `tsc --noEmit` clean for packages/studio and apps/desktop
- `bun run lint`: clean

## Summary by Sourcery

Improve data-grid keyboard interaction by adding sorting and context-menu commands, making Shift+Arrow selection consistently rectangular, and supporting multi-cell clearing.

New Features:
- Add keyboard controls to sort the focused column and open the focused cell’s context menu.
- Expose grid focus, selection, dimensions, sort state, and keyboard guidance through accessibility attributes.

Bug Fixes:
- Make Backspace clear all selected editable cells, falling back to the focused cell while preserving primary keys.

Enhancements:
- Standardize Shift+Arrow navigation on rectangular cell selection instead of row-range selection.

Documentation:
- Update data-grid skill documentation for the expanded keyboard commands and selection behavior.

Tests:
- Expand grid keyboard and accessibility coverage for rectangular selection, multi-cell clearing, sorting, context menus, and ARIA state.