### PR TITLE
perf: overhaul the connection-open path on every engine

### DIFF
--- a/__tests__/poll-delay.test.ts
+++ b/__tests__/poll-delay.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import {
+	nextPollDelay,
+	QUERY_POLL_INITIAL_MS,
+	QUERY_POLL_INTERVAL_MS
+} from '@studio/core/data-provider/poll-delay'
+
+describe('nextPollDelay', () => {
+	it('backs off 20 → 40 → 80 → 100 and caps there', () => {
+		const delays: number[] = []
+		let current = QUERY_POLL_INITIAL_MS
+		for (let i = 0; i < 5; i++) {
+			delays.push(current)
+			current = nextPollDelay(current)
+		}
+		expect(delays).toEqual([20, 40, 80, 100, 100])
+	})
+
+	it('never exceeds the legacy interval', () => {
+		expect(nextPollDelay(QUERY_POLL_INTERVAL_MS)).toBe(QUERY_POLL_INTERVAL_MS)
+		expect(nextPollDelay(999)).toBe(QUERY_POLL_INTERVAL_MS)
+	})
+})

--- a/__tests__/schema-query.test.ts
+++ b/__tests__/schema-query.test.ts
@@ -1,0 +1,82 @@
+import { QueryClient } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { schemaQueryOptions } from '@studio/core/data-provider/schema-query'
+import type { DataAdapter } from '@studio/core/data-provider/types'
+import { readSchemaEntry, resetWorkspaceStore } from '@studio/core/workspace-store'
+import type { DatabaseSchema } from '@studio/lib/bindings'
+
+const SCHEMA: DatabaseSchema = {
+	tables: [],
+	schemas: [],
+	unique_columns: []
+}
+
+function stubAdapter() {
+	const connectToDatabase = vi.fn(async () => ({
+		ok: true as const,
+		data: { connected: true, fileSources: null }
+	}))
+	const getSchema = vi.fn(async () => ({ ok: true as const, data: SCHEMA }))
+	return { connectToDatabase, getSchema } as unknown as DataAdapter & {
+		connectToDatabase: typeof connectToDatabase
+		getSchema: typeof getSchema
+	}
+}
+
+describe('schemaQueryOptions', () => {
+	afterEach(() => {
+		resetWorkspaceStore()
+	})
+
+	it('single-flights concurrent fetches through the query client', async () => {
+		const adapter = stubAdapter()
+		const queryClient = new QueryClient()
+		const options = schemaQueryOptions(adapter, queryClient, 'conn-1')
+
+		const [a, b] = await Promise.all([
+			queryClient.fetchQuery(options),
+			queryClient.fetchQuery(options)
+		])
+
+		expect(a).toEqual(SCHEMA)
+		expect(b).toEqual(SCHEMA)
+		expect(adapter.connectToDatabase).toHaveBeenCalledTimes(1)
+		expect(adapter.getSchema).toHaveBeenCalledTimes(1)
+	})
+
+	it('serves a fresh cache entry without re-running connect', async () => {
+		const adapter = stubAdapter()
+		const queryClient = new QueryClient()
+		const options = schemaQueryOptions(adapter, queryClient, 'conn-1')
+
+		await queryClient.fetchQuery(options)
+		await queryClient.fetchQuery(options)
+
+		expect(adapter.connectToDatabase).toHaveBeenCalledTimes(1)
+	})
+
+	it('mirrors the schema into the workspace store with a real timestamp', async () => {
+		const adapter = stubAdapter()
+		const queryClient = new QueryClient()
+
+		await queryClient.fetchQuery(schemaQueryOptions(adapter, queryClient, 'conn-1'))
+
+		const entry = readSchemaEntry('conn-1')
+		expect(entry?.schema).toEqual(SCHEMA)
+		expect(entry?.fetchedAt).toBeGreaterThan(0)
+	})
+
+	it('surfaces a failed connect as a thrown error', async () => {
+		const adapter = stubAdapter()
+		adapter.connectToDatabase.mockResolvedValueOnce({
+			ok: true as const,
+			data: { connected: false, fileSources: null }
+		})
+		const queryClient = new QueryClient()
+
+		await expect(
+			queryClient.fetchQuery(schemaQueryOptions(adapter, queryClient, 'conn-1'))
+		).rejects.toThrow('Could not connect to this database')
+		expect(adapter.getSchema).not.toHaveBeenCalled()
+	})
+})

--- a/__tests__/snapshot-persistence.test.ts
+++ b/__tests__/snapshot-persistence.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+	configureTableSnapshotPersistence,
+	putTableSnapshot,
+	readTableSnapshot,
+	resetWorkspaceStore
+} from '@studio/core/workspace-store'
+import type { TableSnapshot } from '@studio/core/workspace-store'
+import {
+	DEFAULT_PAGE_LIMIT,
+	EMPTY_FILTER_GROUP
+} from '@studio/features/database-studio/utils/table-snapshot'
+
+const STORAGE_KEY = 'dora.table-snapshots.v1'
+
+function snapshot(overrides: Partial<TableSnapshot> = {}): TableSnapshot {
+	return {
+		connectionId: 'conn-1',
+		tableId: 'users',
+		columns: [{ name: 'id', data_type: 'INTEGER' } as TableSnapshot['columns'][number]],
+		rows: [{ id: 1 }],
+		totalCount: 1,
+		visibleColumns: ['id'],
+		offset: 0,
+		limit: DEFAULT_PAGE_LIMIT,
+		sort: undefined,
+		filters: [],
+		conjunction: 'AND',
+		filterGroup: EMPTY_FILTER_GROUP,
+		fetchedAt: 1000,
+		...overrides
+	}
+}
+
+describe('snapshot persistence', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		window.localStorage.clear()
+		resetWorkspaceStore()
+	})
+
+	afterEach(() => {
+		configureTableSnapshotPersistence(false)
+		window.localStorage.clear()
+		resetWorkspaceStore()
+		vi.useRealTimers()
+	})
+
+	it('mirrors default-page snapshots to localStorage', () => {
+		configureTableSnapshotPersistence(true)
+		putTableSnapshot(snapshot())
+		vi.advanceTimersByTime(600)
+
+		const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? '[]')
+		expect(stored).toHaveLength(1)
+		expect(stored[0].tableId).toBe('users')
+	})
+
+	it('does not mirror filtered or paged snapshots', () => {
+		configureTableSnapshotPersistence(true)
+		putTableSnapshot(snapshot({ tableId: 'paged', offset: 50 }))
+		putTableSnapshot(
+			snapshot({
+				tableId: 'sorted',
+				sort: { column: 'id', direction: 'asc' } as TableSnapshot['sort']
+			})
+		)
+		vi.advanceTimersByTime(600)
+
+		const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? 'null')
+		expect(stored).toEqual([])
+	})
+
+	it('hydrates persisted snapshots back into the store', () => {
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify([snapshot()]))
+		configureTableSnapshotPersistence(true)
+
+		const restored = readTableSnapshot('conn-1', 'users')
+		expect(restored?.rows).toEqual([{ id: 1 }])
+	})
+
+	it('caps the mirror at 20 entries, newest first', () => {
+		configureTableSnapshotPersistence(true)
+		for (let i = 0; i < 25; i++) {
+			putTableSnapshot(snapshot({ tableId: `table-${i}`, fetchedAt: i }))
+		}
+		vi.advanceTimersByTime(600)
+
+		const stored: TableSnapshot[] = JSON.parse(
+			window.localStorage.getItem(STORAGE_KEY) ?? '[]'
+		)
+		expect(stored).toHaveLength(20)
+		expect(stored[0].tableId).toBe('table-24')
+		expect(stored.map((s) => s.tableId)).not.toContain('table-0')
+	})
+
+	it('disabling clears the stored data and stops mirroring', () => {
+		configureTableSnapshotPersistence(true)
+		putTableSnapshot(snapshot())
+		vi.advanceTimersByTime(600)
+		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+
+		configureTableSnapshotPersistence(false)
+		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+
+		putTableSnapshot(snapshot({ tableId: 'after-disable' }))
+		vi.advanceTimersByTime(600)
+		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+	})
+
+	it('ignores malformed stored data', () => {
+		window.localStorage.setItem(STORAGE_KEY, '{not json')
+		configureTableSnapshotPersistence(true)
+		expect(readTableSnapshot('conn-1', 'users')).toBeUndefined()
+	})
+})

--- a/apps/desktop/src-tauri/src/database.rs
+++ b/apps/desktop/src-tauri/src/database.rs
@@ -8,8 +8,8 @@ pub mod duckdb_ipc;
 pub mod ident;
 pub mod libsql;
 pub mod mysql;
-pub mod posthog;
 pub mod postgres;
+pub mod posthog;
 pub mod sqlite;
 
 pub use postgres::tls::Certificates;
@@ -22,7 +22,10 @@ mod live_monitor;
 pub mod maintenance;
 pub mod metadata;
 pub mod parser;
+pub mod row_count_refresher;
+pub mod schema_cache;
 pub mod services;
+pub mod sqlite_introspection;
 pub mod ssh_tunnel;
 pub mod stmt_manager;
 pub mod types;
@@ -32,5 +35,6 @@ pub use live_monitor::{
     LiveMonitorChangeType, LiveMonitorManager, LiveMonitorSession, LiveMonitorUpdateEvent,
     LIVE_MONITOR_EVENT_NAME,
 };
+pub use row_count_refresher::RowCountRefresher;
 
 use crate::database::types::QueryExecEvent;

--- a/apps/desktop/src-tauri/src/database/commands/connections.rs
+++ b/apps/desktop/src-tauri/src/database/commands/connections.rs
@@ -38,13 +38,20 @@ pub async fn update_connection(
     clear_password: bool,
     color: Option<i32>,
     state: State<'_, AppState>,
+    refresher: State<'_, crate::database::RowCountRefresher>,
 ) -> Result<ConnectionInfo, Error> {
     let svc = ConnectionService {
         connections: &state.connections,
         storage: &state.storage,
     };
-    svc.update_connection(conn_id, name, database_info, clear_password, color)
-        .await
+    let info = svc
+        .update_connection(conn_id, name, database_info, clear_password, color)
+        .await?;
+    // A config change may point at a different database entirely; a cached
+    // schema from the old target must not survive the reconnect.
+    state.schemas.remove(&conn_id);
+    refresher.cancel(conn_id);
+    Ok(info)
 }
 
 #[tauri::command]
@@ -144,9 +151,11 @@ pub async fn disconnect_from_database(
     state: State<'_, AppState>,
     live_monitor: State<'_, crate::database::LiveMonitorManager>,
     monitor: State<'_, crate::database::ConnectionMonitor>,
+    refresher: State<'_, crate::database::RowCountRefresher>,
 ) -> Result<(), Error> {
     live_monitor.stop_monitors_for_connection(connection_id);
     state.stmt_manager.cancel_connection_queries(connection_id);
+    refresher.cancel(connection_id);
 
     let svc = ConnectionService {
         connections: &state.connections,
@@ -171,8 +180,11 @@ pub async fn remove_connection(
     connection_id: Uuid,
     state: State<'_, AppState>,
     monitor: State<'_, crate::database::ConnectionMonitor>,
+    refresher: State<'_, crate::database::RowCountRefresher>,
 ) -> Result<(), Error> {
     state.stmt_manager.cancel_connection_queries(connection_id);
+    refresher.cancel(connection_id);
+    state.schemas.remove(&connection_id);
     let svc = ConnectionService {
         connections: &state.connections,
         storage: &state.storage,

--- a/apps/desktop/src-tauri/src/database/commands/mutation.rs
+++ b/apps/desktop/src-tauri/src/database/commands/mutation.rs
@@ -236,7 +236,10 @@ pub async fn execute_batch(
     connection_id: Uuid,
     statements: Vec<String>,
     state: State<'_, AppState>,
+    refresher: State<'_, crate::database::RowCountRefresher>,
 ) -> Result<MutationResult, Error> {
     let svc = mutation_service(state.inner());
-    svc.execute_batch(connection_id, statements).await
+    let result = svc.execute_batch(connection_id, statements).await;
+    refresher.cancel(connection_id);
+    result
 }

--- a/apps/desktop/src-tauri/src/database/commands/query.rs
+++ b/apps/desktop/src-tauri/src/database/commands/query.rs
@@ -35,6 +35,7 @@ pub async fn start_query(
     connection_id: Uuid,
     query: &str,
     state: State<'_, AppState>,
+    refresher: State<'_, crate::database::RowCountRefresher>,
 ) -> Result<Vec<usize>, Error> {
     // SQL Console uses `start_query`; invalidate cached schema when query includes
     // non-read-only statements so schema fetches reflect DDL changes immediately.
@@ -48,6 +49,7 @@ pub async fn start_query(
 
     if invalidates_schema {
         state.schemas.remove(&connection_id);
+        refresher.cancel(connection_id);
     }
 
     Ok(query_ids)
@@ -60,6 +62,7 @@ pub async fn start_query_stream(
     query: &str,
     on_event: tauri::ipc::Channel<QueryEvent>,
     state: State<'_, AppState>,
+    refresher: State<'_, crate::database::RowCountRefresher>,
 ) -> Result<Vec<usize>, Error> {
     let invalidates_schema = query_invalidates_schema(state.inner(), connection_id, query);
     let svc = QueryService {
@@ -67,9 +70,12 @@ pub async fn start_query_stream(
         storage: &state.storage,
         stmt_manager: &state.stmt_manager,
     };
-    let query_ids = svc.start_query_stream(connection_id, query, on_event).await?;
+    let query_ids = svc
+        .start_query_stream(connection_id, query, on_event)
+        .await?;
     if invalidates_schema {
         state.schemas.remove(&connection_id);
+        refresher.cancel(connection_id);
     }
     Ok(query_ids)
 }

--- a/apps/desktop/src-tauri/src/database/commands/schema.rs
+++ b/apps/desktop/src-tauri/src/database/commands/schema.rs
@@ -3,7 +3,10 @@ use uuid::Uuid;
 
 use crate::{
     database::{
-        metadata::DatabaseMetadata, services::metadata::MetadataService, types::DatabaseSchema,
+        metadata::DatabaseMetadata,
+        row_count_refresher::{pending_counts, RowCountRefresher},
+        services::metadata::MetadataService,
+        types::DatabaseSchema,
     },
     error::Error,
     AppState,
@@ -14,14 +17,16 @@ use crate::{
 pub async fn get_database_schema(
     connection_id: Uuid,
     state: State<'_, AppState>,
+    refresher: State<'_, RowCountRefresher>,
 ) -> Result<DatabaseSchema, Error> {
     let svc = MetadataService {
         connections: &state.connections,
         schemas: &state.schemas,
+        schema_locks: &state.schema_locks,
     };
-    svc.get_database_schema(connection_id)
-        .await
-        .map(|s| (*s).clone())
+    let schema = svc.get_database_schema(connection_id).await?;
+    refresher.schedule(connection_id, pending_counts(&schema));
+    Ok((*schema).clone())
 }
 
 #[tauri::command]
@@ -33,6 +38,7 @@ pub async fn get_database_metadata(
     let svc = MetadataService {
         connections: &state.connections,
         schemas: &state.schemas,
+        schema_locks: &state.schema_locks,
     };
     svc.get_database_metadata(connection_id).await
 }

--- a/apps/desktop/src-tauri/src/database/connection_monitor.rs
+++ b/apps/desktop/src-tauri/src/database/connection_monitor.rs
@@ -119,6 +119,9 @@ impl ConnectionMonitor {
 
     fn notify_disconnect(&self, connection_id: Uuid) {
         self.persist_disconnect(connection_id);
+        if let Some(refresher) = self.app.try_state::<crate::database::RowCountRefresher>() {
+            refresher.cancel(connection_id);
+        }
         match self
             .app
             .emit_to(EventTarget::App, "end-of-connection", connection_id)

--- a/apps/desktop/src-tauri/src/database/d1/mod.rs
+++ b/apps/desktop/src-tauri/src/database/d1/mod.rs
@@ -47,7 +47,7 @@ pub struct D1Http {
 impl D1Http {
     pub fn new(account_id: String, database_id: String, token: String) -> Self {
         Self {
-            client: crate::http::query_client(),
+            client: crate::http::query_client().clone(),
             account_id,
             database_id,
             token,
@@ -82,7 +82,9 @@ impl D1Http {
             .json(&body)
             .send()
             .await
-            .map_err(|error| Error::Any(anyhow::anyhow!("Cloudflare D1 request failed: {error}")))?;
+            .map_err(|error| {
+                Error::Any(anyhow::anyhow!("Cloudflare D1 request failed: {error}"))
+            })?;
 
         let status = response.status();
         let text = read_body(response).await;
@@ -439,10 +441,7 @@ mod tests {
         assert_eq!(columns, vec!["id", "name", "note"]);
         let page = rows_to_page(&set.results, &columns);
         // NULL renders as the literal string "NULL", matching the SQLite writer.
-        assert_eq!(
-            page.get(),
-            r#"[[1,"Alice","NULL"],[2,"NULL","hi"]]"#
-        );
+        assert_eq!(page.get(), r#"[[1,"Alice","NULL"],[2,"NULL","hi"]]"#);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/database/d1/schema.rs
+++ b/apps/desktop/src-tauri/src/database/d1/schema.rs
@@ -1,19 +1,29 @@
 //! D1 schema introspection over HTTP.
 //!
-//! D1 is the SQLite dialect, so introspection uses the same `sqlite_master` /
-//! `PRAGMA` queries the local SQLite reader uses (see
-//! `crate::database::sqlite::schema`) — only the transport differs: each query
-//! is a REST call via `D1Http` instead of a local `rusqlite` prepare. PRAGMAs
-//! are sent as plain SQL (`PRAGMA table_info('users')`), which the D1 `/query`
-//! endpoint accepts.
+//! D1 is the SQLite dialect, but every statement is an HTTPS round trip, so
+//! the old per-table PRAGMA loop cost `1 + tables × (4 + indexes)` requests —
+//! seconds of pure latency on any real schema. The primary path batches the
+//! PRAGMAs into multi-statement scripts (the `/query` endpoint returns one
+//! result set per statement, positionally), bringing introspection down to a
+//! constant 2–3 requests. If the response arity ever disagrees with the script
+//! (a gateway change), the legacy per-table path runs instead. Row counts are
+//! filled in by the background row-count refresher.
 
 use std::collections::{HashMap, HashSet};
 
 use serde_json::Value;
 
-use crate::database::d1::{D1Http, D1Row};
+use crate::database::d1::{D1Http, D1ResultSet, D1Row};
+use crate::database::sqlite_introspection::{
+    assemble, RawColumn, RawForeignKey, RawIndexColumn, RawTable,
+};
 use crate::database::types::{ColumnInfo, DatabaseSchema, ForeignKeyInfo, IndexInfo, TableInfo};
 use crate::Error;
+
+/// Tables per multi-statement introspection request (3 statements per table).
+const TABLES_PER_REQUEST: usize = 40;
+/// Indexes per multi-statement `index_info` request.
+const INDEXES_PER_REQUEST: usize = 100;
 
 /// Reads a cell as a string, tolerating that D1 returns native JSON (a name may
 /// arrive as a JSON string, a number as a JSON number, etc.).
@@ -35,6 +45,11 @@ fn cell_int(row: &D1Row, column: &str) -> i64 {
     }
 }
 
+/// Escapes a name for interpolation inside a single-quoted PRAGMA argument.
+fn quote_pragma_arg(name: &str) -> String {
+    name.replace('\'', "''")
+}
+
 /// Runs a single statement and returns its rows (introspection statements never
 /// take params).
 async fn rows(http: &D1Http, sql: &str) -> Result<Vec<D1Row>, Error> {
@@ -46,10 +61,172 @@ async fn rows(http: &D1Http, sql: &str) -> Result<Vec<D1Row>, Error> {
         .unwrap_or_default())
 }
 
-/// Builds the full `DatabaseSchema` for a D1 database, mirroring the SQLite
-/// reader's shape (tables, columns, primary keys, foreign keys, indexes, row
-/// counts).
 pub async fn get_database_schema(http: &D1Http) -> Result<DatabaseSchema, Error> {
+    match batched_introspect(http).await {
+        Ok(schema) => Ok(schema),
+        Err(err) => {
+            log::warn!(
+                "Batched D1 introspection failed, falling back to per-table PRAGMAs: {}",
+                err
+            );
+            legacy_introspect(http).await
+        }
+    }
+}
+
+async fn batched_introspect(http: &D1Http) -> Result<DatabaseSchema, Error> {
+    let table_rows = rows(
+        http,
+        "SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    )
+    .await?;
+    let raw_tables: Vec<RawTable> = table_rows
+        .iter()
+        .filter_map(|row| {
+            Some(RawTable {
+                name: cell_string(row, "name")?,
+                create_sql: cell_string(row, "sql").unwrap_or_default(),
+            })
+        })
+        .collect();
+
+    let mut raw_columns = Vec::new();
+    let mut raw_foreign_keys = Vec::new();
+    // (table, index, unique), in response order, for the index_info pass.
+    let mut index_list: Vec<(String, String, bool)> = Vec::new();
+
+    for chunk in raw_tables.chunks(TABLES_PER_REQUEST) {
+        let script = chunk
+            .iter()
+            .map(|table| {
+                let name = quote_pragma_arg(&table.name);
+                format!(
+                    "PRAGMA table_info('{name}'); PRAGMA foreign_key_list('{name}'); PRAGMA index_list('{name}')"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        let result_sets = http.query(&script, Vec::new()).await?;
+        if result_sets.len() != chunk.len() * 3 {
+            return Err(Error::Any(anyhow::anyhow!(
+                "D1 multi-statement introspection returned {} result sets for {} statements",
+                result_sets.len(),
+                chunk.len() * 3
+            )));
+        }
+
+        for (table, sets) in chunk.iter().zip(result_sets.chunks(3)) {
+            collect_table_sets(
+                &table.name,
+                sets,
+                &mut raw_columns,
+                &mut raw_foreign_keys,
+                &mut index_list,
+            );
+        }
+    }
+
+    let mut raw_index_columns: Vec<RawIndexColumn> = Vec::new();
+    for chunk in index_list.chunks(INDEXES_PER_REQUEST) {
+        let script = chunk
+            .iter()
+            .map(|(_, index, _)| format!("PRAGMA index_info('{}')", quote_pragma_arg(index)))
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        let result_sets = http.query(&script, Vec::new()).await?;
+        if result_sets.len() != chunk.len() {
+            return Err(Error::Any(anyhow::anyhow!(
+                "D1 index_info returned {} result sets for {} statements",
+                result_sets.len(),
+                chunk.len()
+            )));
+        }
+
+        for ((table, index, is_unique), set) in chunk.iter().zip(result_sets) {
+            if set.results.is_empty() {
+                raw_index_columns.push(RawIndexColumn {
+                    table: table.clone(),
+                    index: index.clone(),
+                    is_unique: *is_unique,
+                    column: None,
+                });
+                continue;
+            }
+            for row in &set.results {
+                raw_index_columns.push(RawIndexColumn {
+                    table: table.clone(),
+                    index: index.clone(),
+                    is_unique: *is_unique,
+                    column: cell_string(row, "name"),
+                });
+            }
+        }
+    }
+
+    Ok(assemble(
+        raw_tables,
+        raw_columns,
+        raw_foreign_keys,
+        raw_index_columns,
+    ))
+}
+
+/// Decodes one table's `[table_info, foreign_key_list, index_list]` result-set
+/// triple into the shared raw shapes.
+fn collect_table_sets(
+    table: &str,
+    sets: &[D1ResultSet],
+    raw_columns: &mut Vec<RawColumn>,
+    raw_foreign_keys: &mut Vec<RawForeignKey>,
+    index_list: &mut Vec<(String, String, bool)>,
+) {
+    if let Some(columns_set) = sets.first() {
+        for row in &columns_set.results {
+            let Some(name) = cell_string(row, "name") else {
+                continue;
+            };
+            raw_columns.push(RawColumn {
+                table: table.to_string(),
+                name,
+                data_type: cell_string(row, "type").unwrap_or_default(),
+                not_null: cell_int(row, "notnull") != 0,
+                default_value: cell_string(row, "dflt_value"),
+                is_primary_key: cell_int(row, "pk") > 0,
+            });
+        }
+    }
+    if let Some(fk_set) = sets.get(1) {
+        for row in &fk_set.results {
+            let (Some(from), Some(ref_table), Some(ref_column)) = (
+                cell_string(row, "from"),
+                cell_string(row, "table"),
+                cell_string(row, "to"),
+            ) else {
+                continue;
+            };
+            raw_foreign_keys.push(RawForeignKey {
+                table: table.to_string(),
+                from_column: from,
+                referenced_table: ref_table,
+                referenced_column: ref_column,
+            });
+        }
+    }
+    if let Some(index_set) = sets.get(2) {
+        for row in &index_set.results {
+            let Some(name) = cell_string(row, "name") else {
+                continue;
+            };
+            index_list.push((table.to_string(), name, cell_int(row, "unique") != 0));
+        }
+    }
+}
+
+/// The pre-batching per-table introspection, kept as the fallback when the
+/// multi-statement response shape is unexpected.
+async fn legacy_introspect(http: &D1Http) -> Result<DatabaseSchema, Error> {
     let table_rows = rows(
         http,
         "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
@@ -64,11 +241,12 @@ pub async fn get_database_schema(http: &D1Http) -> Result<DatabaseSchema, Error>
     let mut unique_columns_set = HashSet::new();
 
     for table_name in table_names {
+        let arg = quote_pragma_arg(&table_name);
         // PRAGMA table_info: cid, name, type, notnull, dflt_value, pk
-        let col_rows = rows(http, &format!("PRAGMA table_info('{table_name}')")).await?;
+        let col_rows = rows(http, &format!("PRAGMA table_info('{arg}')")).await?;
 
         // PRAGMA foreign_key_list: id, seq, table, from, to, on_update, on_delete, match
-        let fk_rows = rows(http, &format!("PRAGMA foreign_key_list('{table_name}')")).await?;
+        let fk_rows = rows(http, &format!("PRAGMA foreign_key_list('{arg}')")).await?;
         let fk_map: HashMap<String, ForeignKeyInfo> = fk_rows
             .iter()
             .filter_map(|row| {
@@ -86,21 +264,19 @@ pub async fn get_database_schema(http: &D1Http) -> Result<DatabaseSchema, Error>
             })
             .collect();
 
-        // Row-count estimate. A failed count (e.g. large table cap) is non-fatal.
-        let row_count = rows(http, &format!("SELECT COUNT(*) AS c FROM \"{table_name}\""))
-            .await
-            .ok()
-            .and_then(|count_rows| count_rows.first().map(|row| cell_int(row, "c") as u64));
-
         // Indexes: index_list (seq, name, unique, origin, partial) → index_info.
         let mut indexes = Vec::new();
-        let index_rows = rows(http, &format!("PRAGMA index_list('{table_name}')")).await?;
+        let index_rows = rows(http, &format!("PRAGMA index_list('{arg}')")).await?;
         for index_row in &index_rows {
             let Some(name) = cell_string(index_row, "name") else {
                 continue;
             };
             let is_unique = cell_int(index_row, "unique") != 0;
-            let info_rows = rows(http, &format!("PRAGMA index_info('{name}')")).await?;
+            let info_rows = rows(
+                http,
+                &format!("PRAGMA index_info('{}')", quote_pragma_arg(&name)),
+            )
+            .await?;
             let column_names: Vec<String> = info_rows
                 .iter()
                 .filter_map(|row| cell_string(row, "name"))
@@ -117,7 +293,7 @@ pub async fn get_database_schema(http: &D1Http) -> Result<DatabaseSchema, Error>
         // table's CREATE SQL, like the SQLite reader.
         let create_sql = rows(
             http,
-            &format!("SELECT sql FROM sqlite_master WHERE type='table' AND name='{table_name}'"),
+            &format!("SELECT sql FROM sqlite_master WHERE type='table' AND name='{arg}'"),
         )
         .await?
         .first()
@@ -163,7 +339,7 @@ pub async fn get_database_schema(http: &D1Http) -> Result<DatabaseSchema, Error>
             schema: String::new(),
             columns,
             primary_key_columns,
-            row_count_estimate: row_count,
+            row_count_estimate: None,
             indexes,
         });
     }
@@ -178,7 +354,6 @@ pub async fn get_database_schema(http: &D1Http) -> Result<DatabaseSchema, Error>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database::d1::D1ResultSet;
 
     fn result_set(json: &str) -> D1ResultSet {
         serde_json::from_str(json).expect("result set should deserialize")
@@ -220,12 +395,55 @@ mod tests {
 
     #[test]
     fn cell_int_tolerates_string_and_bool() {
-        let set = result_set(
-            r#"{ "results": [ { "a": "5", "b": true, "c": 9 } ], "meta": {} }"#,
-        );
+        let set = result_set(r#"{ "results": [ { "a": "5", "b": true, "c": 9 } ], "meta": {} }"#);
         let row = &set.results[0];
         assert_eq!(cell_int(row, "a"), 5);
         assert_eq!(cell_int(row, "b"), 1);
         assert_eq!(cell_int(row, "c"), 9);
+    }
+
+    #[test]
+    fn collect_table_sets_maps_the_positional_triple() {
+        let columns = result_set(
+            r#"{ "results": [
+                { "cid": 0, "name": "id", "type": "INTEGER", "notnull": 1, "dflt_value": null, "pk": 1 },
+                { "cid": 1, "name": "user_id", "type": "INTEGER", "notnull": 0, "dflt_value": null, "pk": 0 }
+            ], "meta": {} }"#,
+        );
+        let fks = result_set(
+            r#"{ "results": [
+                { "id": 0, "seq": 0, "table": "users", "from": "user_id", "to": "id" }
+            ], "meta": {} }"#,
+        );
+        let indexes = result_set(
+            r#"{ "results": [
+                { "seq": 0, "name": "posts_user", "unique": 1, "origin": "c", "partial": 0 }
+            ], "meta": {} }"#,
+        );
+
+        let mut raw_columns = Vec::new();
+        let mut raw_fks = Vec::new();
+        let mut index_list = Vec::new();
+        collect_table_sets(
+            "posts",
+            &[columns, fks, indexes],
+            &mut raw_columns,
+            &mut raw_fks,
+            &mut index_list,
+        );
+
+        assert_eq!(raw_columns.len(), 2);
+        assert!(raw_columns[0].is_primary_key);
+        assert_eq!(raw_fks.len(), 1);
+        assert_eq!(raw_fks[0].referenced_table, "users");
+        assert_eq!(
+            index_list,
+            vec![("posts".to_string(), "posts_user".to_string(), true)]
+        );
+    }
+
+    #[test]
+    fn quote_pragma_arg_escapes_single_quotes() {
+        assert_eq!(quote_pragma_arg("we'ird"), "we''ird");
     }
 }

--- a/apps/desktop/src-tauri/src/database/dialect.rs
+++ b/apps/desktop/src-tauri/src/database/dialect.rs
@@ -109,13 +109,13 @@ impl PgIntrospection {
         // only emits a direction for non-default ordering), but that is stripped
         // in the shared parser, so the query itself needs no override.
         indexes: VANILLA_INDEXES,
-        // Row counts: CockroachDB's `pg_stat_user_tables` is a stub that returns
-        // ZERO rows, so the vanilla query yields no estimates at all. Pull the
-        // estimate from `crdb_internal.table_row_statistics` instead, joined to
+        // Row counts: CockroachDB's `pg_class.reltuples` is a stub, so the
+        // vanilla query yields no usable estimates. Pull the estimate from
+        // `crdb_internal.table_row_statistics` instead, joined to
         // pg_class/pg_namespace for schema+table names (table_id == pg_class.oid
         // on CockroachDB). When the estimate is stale/0 (stats collection lags),
-        // postgres/schema.rs already falls back to an exact COUNT(*) per table —
-        // the same safety net vanilla relies on — so correctness is guaranteed.
+        // the background row-count refresher fills in an exact COUNT(*) — the
+        // same safety net vanilla relies on — so correctness is guaranteed.
         row_counts: COCKROACH_ROW_COUNTS,
         // Enum labels and CHECK constraint expressions live in the same
         // pg_catalog views CockroachDB implements (`pg_enum`, `pg_constraint`),
@@ -219,14 +219,24 @@ const VANILLA_INDEXES: &str = r#"
             schemaname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
     "#;
 
-/// Vanilla: row-count estimates via `pg_stat_user_tables`.
+/// Vanilla: row-count estimates via `pg_class.reltuples`.
+///
+/// `pg_stat_user_tables.n_live_tup` is runtime statistics-collector state and
+/// is wiped whenever the server restarts — which on scale-to-zero providers
+/// (Neon) happens on every compute wake, turning every estimate into 0.
+/// `reltuples` is on-disk catalog data from the last VACUUM/ANALYZE and
+/// survives restarts. It is `-1` for never-analyzed tables (PG >= 14), which
+/// the shared parser maps to "unknown" so the background exact count fills it
+/// in.
 const VANILLA_ROW_COUNTS: &str = r#"
-        SELECT 
-            schemaname,
-            relname,
-            n_live_tup
-        FROM 
-            pg_stat_user_tables
+        SELECT
+            n.nspname AS schemaname,
+            c.relname AS relname,
+            c.reltuples::bigint AS n_live_tup
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind IN ('r', 'p', 'm')
+          AND n.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
     "#;
 
 /// Vanilla: closed value sets per column.
@@ -356,8 +366,9 @@ impl MySqlDialect {
 /// fields whose vanilla query fails or returns wrong/empty results against that
 /// engine. Same shape as [`PgIntrospection`].
 ///
-/// Every query is parameterised by the current database name (`?`), matching
-/// the `conn.exec(query, (&current_db,))` call sites in `mysql/schema.rs`.
+/// Every query scopes itself to the connection's default schema via
+/// `DATABASE()`, so no bind parameter (and no prior `SELECT DATABASE()` round
+/// trip) is needed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MySqlIntrospection {
     /// Columns + primary-key flag + auto-increment detection per table.
@@ -411,8 +422,8 @@ impl MySqlIntrospection {
 //
 // The `VANILLA_MYSQL_*` constants are the EXACT queries that previously lived
 // inline in `mysql/schema.rs`. They are the single source of truth for the
-// vanilla path; moving them here is byte-for-byte behaviour-preserving. Each
-// query takes the current database name as its single `?` bind parameter.
+// vanilla path. Each query scopes itself to the connection's default schema
+// inline via `DATABASE()` instead of a bind parameter.
 // ---------------------------------------------------------------------------
 
 /// Vanilla: columns + primary-key flag + auto-increment detection.
@@ -434,7 +445,7 @@ const VANILLA_MYSQL_COLUMNS: &str = r#"
             AND c.TABLE_SCHEMA = t.TABLE_SCHEMA
         WHERE
             t.TABLE_TYPE = 'BASE TABLE'
-            AND c.TABLE_SCHEMA = ?
+            AND c.TABLE_SCHEMA = DATABASE()
         ORDER BY
             c.TABLE_SCHEMA, c.TABLE_NAME, c.ORDINAL_POSITION
     "#;
@@ -452,7 +463,7 @@ const VANILLA_MYSQL_FOREIGN_KEYS: &str = r#"
             information_schema.KEY_COLUMN_USAGE kcu
         WHERE
             kcu.REFERENCED_TABLE_NAME IS NOT NULL
-            AND kcu.TABLE_SCHEMA = ?
+            AND kcu.TABLE_SCHEMA = DATABASE()
     "#;
 
 /// Vanilla: index columns via `information_schema.STATISTICS`.
@@ -466,7 +477,7 @@ const VANILLA_MYSQL_INDEXES: &str = r#"
         FROM
             information_schema.STATISTICS
         WHERE
-            TABLE_SCHEMA = ?
+            TABLE_SCHEMA = DATABASE()
         ORDER BY
             TABLE_SCHEMA, TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX
     "#;
@@ -481,7 +492,7 @@ const VANILLA_MYSQL_ROW_COUNTS: &str = r#"
             information_schema.TABLES
         WHERE
             TABLE_TYPE = 'BASE TABLE'
-            AND TABLE_SCHEMA = ?
+            AND TABLE_SCHEMA = DATABASE()
     "#;
 
 /// A unified, runtime-detected dialect tag stored on a connection.
@@ -618,7 +629,10 @@ mod tests {
 
     #[test]
     fn detects_cockroachdb_case_insensitively() {
-        assert_eq!(detect_pg_dialect("cockroachdb v22.2"), PgDialect::CockroachDb);
+        assert_eq!(
+            detect_pg_dialect("cockroachdb v22.2"),
+            PgDialect::CockroachDb
+        );
     }
 
     #[test]
@@ -634,7 +648,32 @@ mod tests {
 
     #[test]
     fn detects_mariadb_case_insensitively() {
-        assert_eq!(detect_mysql_dialect("10.11.8-mariadb"), MySqlDialect::MariaDb);
+        assert_eq!(
+            detect_mysql_dialect("10.11.8-mariadb"),
+            MySqlDialect::MariaDb
+        );
+    }
+
+    #[test]
+    fn mysql_introspection_queries_are_self_scoped() {
+        for queries in [MySqlIntrospection::VANILLA, MySqlIntrospection::MARIADB] {
+            for query in [
+                queries.columns,
+                queries.foreign_keys,
+                queries.indexes,
+                queries.row_counts,
+            ] {
+                assert!(query.contains("DATABASE()"));
+                assert!(!query.contains('?'));
+            }
+        }
+    }
+
+    #[test]
+    fn vanilla_pg_row_counts_survive_restarts() {
+        let queries = PgDialect::Postgres.introspection();
+        assert!(queries.row_counts.contains("reltuples"));
+        assert!(!queries.row_counts.contains("pg_stat_user_tables"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/database/duckdb/schema.rs
+++ b/apps/desktop/src-tauri/src/database/duckdb/schema.rs
@@ -43,6 +43,12 @@ pub async fn get_database_schema(conn: Arc<Mutex<Connection>>) -> Result<Databas
             })?
             .collect::<Result<Vec<_>, _>>()?;
 
+        // One pass each over duckdb_constraints()/duckdb_indexes(), grouped in
+        // Rust — a per-table WHERE-filtered query would rescan the catalog for
+        // every table.
+        let mut fk_by_table = all_foreign_keys(&conn).unwrap_or_default();
+        let mut indexes_by_table = all_indexes(&conn).unwrap_or_default();
+
         let mut tables = Vec::new();
         let mut unique_columns_set = HashSet::new();
 
@@ -70,10 +76,13 @@ pub async fn get_database_schema(conn: Arc<Mutex<Connection>>) -> Result<Databas
                 })?
                 .collect::<Result<Vec<_>, _>>()?;
 
-            let fk_map =
-                foreign_keys_for_table(&conn, &schema_name, &table_name).unwrap_or_default();
+            let fk_map = fk_by_table
+                .remove(&(schema_name.clone(), table_name.clone()))
+                .unwrap_or_default();
 
-            let indexes = indexes_for_table(&conn, &schema_name, &table_name).unwrap_or_default();
+            let indexes = indexes_by_table
+                .remove(&(schema_name.clone(), table_name.clone()))
+                .unwrap_or_default();
 
             let mut columns = Vec::new();
             let mut primary_key_columns = Vec::new();
@@ -187,25 +196,26 @@ pub async fn get_database_schema(conn: Arc<Mutex<Connection>>) -> Result<Databas
 /// DuckDB only exposes foreign-key details through `duckdb_constraints()`'s
 /// `constraint_text` (e.g. `FOREIGN KEY (a) REFERENCES other(b)`), so we parse
 /// the text. Composite keys map column-by-column.
-fn foreign_keys_for_table(
+fn all_foreign_keys(
     conn: &Connection,
-    schema_name: &str,
-    table_name: &str,
-) -> Result<HashMap<String, ForeignKeyInfo>, Error> {
+) -> Result<HashMap<(String, String), HashMap<String, ForeignKeyInfo>>, Error> {
     let mut stmt = conn.prepare(
-        "SELECT constraint_text FROM duckdb_constraints() \
-         WHERE schema_name = ? AND table_name = ? AND constraint_type = 'FOREIGN KEY'",
+        "SELECT schema_name, table_name, constraint_text FROM duckdb_constraints() \
+         WHERE constraint_type = 'FOREIGN KEY'",
     )?;
 
-    let texts: Vec<String> = stmt
-        .query_map([schema_name, table_name], |row| row.get::<_, String>(0))?
+    let rows: Vec<(String, String, String)> = stmt
+        .query_map([], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get::<_, String>(2)?))
+        })?
         .collect::<Result<Vec<_>, _>>()?;
 
-    let mut map = HashMap::new();
-    for text in texts {
+    let mut map: HashMap<(String, String), HashMap<String, ForeignKeyInfo>> = HashMap::new();
+    for (schema_name, table_name, text) in rows {
         if let Some((from_columns, referenced_table, to_columns)) = parse_fk_constraint(&text) {
+            let table_map = map.entry((schema_name, table_name)).or_default();
             for (from, to) in from_columns.into_iter().zip(to_columns) {
-                map.insert(
+                table_map.insert(
                     from,
                     ForeignKeyInfo {
                         referenced_table: referenced_table.clone(),
@@ -246,44 +256,46 @@ fn read_parenthesized(s: &str) -> Option<(String, &str)> {
     Some((s[..close].to_string(), &s[close + 1..]))
 }
 
-fn indexes_for_table(
-    conn: &Connection,
-    schema_name: &str,
-    table_name: &str,
-) -> Result<Vec<IndexInfo>, Error> {
+fn all_indexes(conn: &Connection) -> Result<HashMap<(String, String), Vec<IndexInfo>>, Error> {
     let mut stmt = conn.prepare(
-        "SELECT index_name, is_unique, is_primary, expressions FROM duckdb_indexes() \
-         WHERE schema_name = ? AND table_name = ?",
+        "SELECT schema_name, table_name, index_name, is_unique, is_primary, expressions \
+         FROM duckdb_indexes()",
     )?;
 
-    let rows: Vec<(String, bool, bool, Option<String>)> = stmt
-        .query_map([schema_name, table_name], |row| {
+    let rows: Vec<(String, String, String, bool, bool, Option<String>)> = stmt
+        .query_map([], |row| {
             Ok((
                 row.get(0)?,
                 row.get(1)?,
                 row.get(2)?,
-                row.get::<_, Option<String>>(3)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get::<_, Option<String>>(5)?,
             ))
         })?
         .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(rows
-        .into_iter()
-        .map(|(name, is_unique, is_primary, expressions)| IndexInfo {
-            name,
-            column_names: expressions
-                .map(|e| {
-                    e.trim_matches(['[', ']'])
-                        .split(',')
-                        .map(|c| c.trim().trim_matches(['\'', '"']).to_string())
-                        .filter(|c| !c.is_empty())
-                        .collect()
-                })
-                .unwrap_or_default(),
-            is_unique,
-            is_primary,
-        })
-        .collect())
+    let mut map: HashMap<(String, String), Vec<IndexInfo>> = HashMap::new();
+    for (schema_name, table_name, name, is_unique, is_primary, expressions) in rows {
+        map.entry((schema_name, table_name))
+            .or_default()
+            .push(IndexInfo {
+                name,
+                column_names: expressions
+                    .map(|e| {
+                        e.trim_matches(['[', ']'])
+                            .split(',')
+                            .map(|c| c.trim().trim_matches(['\'', '"']).to_string())
+                            .filter(|c| !c.is_empty())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                is_unique,
+                is_primary,
+            });
+    }
+
+    Ok(map)
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/database/libsql/schema.rs
+++ b/apps/desktop/src-tauri/src/database/libsql/schema.rs
@@ -1,36 +1,134 @@
-//! Schema introspection for libSQL databases
+//! Schema introspection for libSQL databases.
 //!
-//! LibSQL is SQLite-compatible, so we use similar PRAGMA queries.
+//! libSQL is SQLite-compatible, so the primary path runs the four collapsed
+//! introspection queries (pragma table-valued functions embedded in plain
+//! SELECTs — a constant number of round trips, which matters against remote
+//! Turso where the old per-table PRAGMA loop cost ~4 network RTTs per table).
+//! sqld's statement parser has historically been picky about PRAGMAs, so if
+//! the collapsed queries are rejected the legacy per-table path runs instead.
+//! Row counts are filled in by the background row-count refresher.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::database::sqlite_introspection::{
+    assemble, CollapsedQueries, RawColumn, RawForeignKey, RawIndexColumn, RawTable,
+};
 use crate::database::types::{ColumnInfo, DatabaseSchema, ForeignKeyInfo, IndexInfo, TableInfo};
 use crate::Error;
 
-/// Get the database schema from a libSQL connection
 pub async fn get_database_schema(conn: Arc<libsql::Connection>) -> Result<DatabaseSchema, Error> {
-    let mut tables = Vec::new();
-    let mut unique_columns: HashMap<String, HashSet<String>> = HashMap::new();
+    match collapsed_introspect(&conn).await {
+        Ok(schema) => Ok(schema),
+        Err(err) => {
+            log::warn!(
+                "Collapsed libSQL introspection failed, falling back to per-table PRAGMAs: {}",
+                err
+            );
+            legacy_introspect(&conn).await
+        }
+    }
+}
 
-    // Get all tables
-    let table_names = get_table_names(&conn).await?;
+async fn query_rows(conn: &libsql::Connection, sql: &str) -> Result<Vec<libsql::Row>, Error> {
+    let mut rows = conn
+        .query(sql, ())
+        .await
+        .map_err(|e| Error::Any(anyhow::anyhow!("libSQL introspection query failed: {}", e)))?;
+    let mut collected = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::Any(anyhow::anyhow!("libSQL introspection row failed: {}", e)))?
+    {
+        collected.push(row);
+    }
+    Ok(collected)
+}
+
+/// Public so the live sqld test can call the collapsed path directly and fail
+/// loudly if the server rejects it (the production entry silently falls back).
+pub async fn collapsed_introspect(conn: &libsql::Connection) -> Result<DatabaseSchema, Error> {
+    let raw_tables: Vec<RawTable> = query_rows(conn, CollapsedQueries::TABLES)
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            Some(RawTable {
+                name: row.get::<String>(0).ok()?,
+                create_sql: row
+                    .get::<Option<String>>(1)
+                    .ok()
+                    .flatten()
+                    .unwrap_or_default(),
+            })
+        })
+        .collect();
+
+    let raw_columns: Vec<RawColumn> = query_rows(conn, CollapsedQueries::COLUMNS)
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            Some(RawColumn {
+                table: row.get::<String>(0).ok()?,
+                name: row.get::<String>(1).ok()?,
+                data_type: row.get::<String>(2).unwrap_or_else(|_| "TEXT".to_string()),
+                not_null: row.get::<i64>(3).unwrap_or(0) != 0,
+                default_value: row.get::<Option<String>>(4).ok().flatten(),
+                is_primary_key: row.get::<i64>(5).unwrap_or(0) > 0,
+            })
+        })
+        .collect();
+
+    let raw_foreign_keys: Vec<RawForeignKey> = query_rows(conn, CollapsedQueries::FOREIGN_KEYS)
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            Some(RawForeignKey {
+                table: row.get::<String>(0).ok()?,
+                referenced_table: row.get::<String>(1).ok()?,
+                from_column: row.get::<String>(2).ok()?,
+                referenced_column: row.get::<String>(3).ok()?,
+            })
+        })
+        .collect();
+
+    let raw_index_columns: Vec<RawIndexColumn> = query_rows(conn, CollapsedQueries::INDEXES)
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            Some(RawIndexColumn {
+                table: row.get::<String>(0).ok()?,
+                index: row.get::<String>(1).ok()?,
+                is_unique: row.get::<i64>(2).unwrap_or(0) != 0,
+                column: row.get::<Option<String>>(3).ok().flatten(),
+            })
+        })
+        .collect();
+
+    Ok(assemble(
+        raw_tables,
+        raw_columns,
+        raw_foreign_keys,
+        raw_index_columns,
+    ))
+}
+
+/// The pre-collapse per-table introspection, kept as the fallback for sqld
+/// deployments that reject the pragma table-valued functions.
+async fn legacy_introspect(conn: &Arc<libsql::Connection>) -> Result<DatabaseSchema, Error> {
+    let mut tables = Vec::new();
+    let mut unique_columns = std::collections::HashSet::new();
+
+    let table_names = get_table_names(conn).await?;
 
     for table_name in table_names {
-        let (columns, pk_columns) = get_table_columns(&conn, &table_name).await?;
-        let row_count = get_row_count(&conn, &table_name).await.unwrap_or(None);
-        let indexes = get_table_indexes(&conn, &table_name)
+        let (columns, pk_columns) = get_table_columns(conn, &table_name).await?;
+        let indexes = get_table_indexes(conn, &table_name)
             .await
             .unwrap_or_default();
 
-        let mut unique_cols = HashSet::new();
         for col in &columns {
-            if col.is_primary_key {
-                unique_cols.insert(col.name.clone());
-            }
-        }
-        if !unique_cols.is_empty() {
-            unique_columns.insert(table_name.clone(), unique_cols);
+            unique_columns.insert(col.name.clone());
         }
 
         tables.push(TableInfo {
@@ -39,44 +137,29 @@ pub async fn get_database_schema(conn: Arc<libsql::Connection>) -> Result<Databa
             columns,
             primary_key_columns: pk_columns,
             indexes,
-            row_count_estimate: row_count.map(|c| c as u64),
+            row_count_estimate: None,
         });
     }
 
     Ok(DatabaseSchema {
         tables,
-        schemas: vec![String::new()],
-        unique_columns: unique_columns.into_keys().collect(),
+        schemas: vec![],
+        unique_columns: unique_columns.into_iter().collect(),
     })
 }
 
-/// Get list of table names from the database
 async fn get_table_names(conn: &Arc<libsql::Connection>) -> Result<Vec<String>, Error> {
-    let mut tables = Vec::new();
-
-    let mut rows = conn
-        .query(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
-            (),
-        )
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to query tables: {}", e)))?;
-
-    while let Some(row) = rows
-        .next()
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to fetch table row: {}", e)))?
-    {
-        let name: String = row
-            .get(0)
-            .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get table name: {}", e)))?;
-        tables.push(name);
-    }
-
-    Ok(tables)
+    let rows = query_rows(
+        conn,
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    )
+    .await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| row.get::<String>(0).ok())
+        .collect())
 }
 
-/// Get column information for a table
 async fn get_table_columns(
     conn: &Arc<libsql::Connection>,
     table_name: &str,
@@ -84,21 +167,11 @@ async fn get_table_columns(
     let mut columns = Vec::new();
     let mut pk_columns = Vec::new();
 
-    // Get table info using PRAGMA
-    let query = format!("PRAGMA table_info(\"{}\")", table_name);
-    let mut rows = conn
-        .query(&query, ())
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get table info: {}", e)))?;
-
-    while let Some(row) = rows
-        .next()
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to fetch column row: {}", e)))?
-    {
-        let name: String = row
-            .get(1)
-            .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get column name: {}", e)))?;
+    let query = format!("PRAGMA table_info(\"{}\")", table_name.replace('"', "\"\""));
+    for row in query_rows(conn, &query).await? {
+        let Ok(name) = row.get::<String>(1) else {
+            continue;
+        };
         let data_type: String = row.get(2).unwrap_or("TEXT".to_string());
         let not_null: i64 = row.get(3).unwrap_or(0);
         let default_value: Option<String> = row.get(4).ok();
@@ -109,7 +182,6 @@ async fn get_table_columns(
             pk_columns.push(name.clone());
         }
 
-        // Check for auto-increment (INTEGER PRIMARY KEY is auto-increment in SQLite)
         let is_auto_increment =
             is_primary_key && data_type.to_uppercase() == "INTEGER" && pk_columns.len() == 1;
 
@@ -120,12 +192,11 @@ async fn get_table_columns(
             default_value,
             is_primary_key,
             is_auto_increment,
-            foreign_key: None, // We'll fill this separately
+            foreign_key: None,
             allowed_values: None,
         });
     }
 
-    // Get foreign key information
     let fk_map = get_foreign_keys(conn, table_name).await?;
     for column in &mut columns {
         if let Some(fk) = fk_map.get(&column.name) {
@@ -136,35 +207,24 @@ async fn get_table_columns(
     Ok((columns, pk_columns))
 }
 
-/// Get foreign key relationships for a table
 async fn get_foreign_keys(
     conn: &Arc<libsql::Connection>,
     table_name: &str,
 ) -> Result<HashMap<String, ForeignKeyInfo>, Error> {
     let mut fk_map = HashMap::new();
 
-    let query = format!("PRAGMA foreign_key_list(\"{}\")", table_name);
-    let mut rows = conn
-        .query(&query, ())
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get foreign keys: {}", e)))?;
-
-    while let Some(row) = rows
-        .next()
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to fetch FK row: {}", e)))?
-    {
-        // PRAGMA foreign_key_list returns: id, seq, table, from, to, on_update, on_delete, match
-        let referenced_table: String = row
-            .get(2)
-            .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get referenced table: {}", e)))?;
-        let from_column: String = row
-            .get(3)
-            .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get from column: {}", e)))?;
-        let referenced_column: String = row
-            .get(4)
-            .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get to column: {}", e)))?;
-
+    let query = format!(
+        "PRAGMA foreign_key_list(\"{}\")",
+        table_name.replace('"', "\"\"")
+    );
+    for row in query_rows(conn, &query).await? {
+        let (Ok(referenced_table), Ok(from_column), Ok(referenced_column)) = (
+            row.get::<String>(2),
+            row.get::<String>(3),
+            row.get::<String>(4),
+        ) else {
+            continue;
+        };
         fk_map.insert(
             from_column,
             ForeignKeyInfo {
@@ -178,62 +238,25 @@ async fn get_foreign_keys(
     Ok(fk_map)
 }
 
-/// Get estimated row count for a table
-async fn get_row_count(
-    conn: &Arc<libsql::Connection>,
-    table_name: &str,
-) -> Result<Option<i64>, Error> {
-    let query = format!("SELECT COUNT(*) FROM \"{}\"", table_name);
-    let mut rows = conn
-        .query(&query, ())
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get row count: {}", e)))?;
-
-    if let Some(row) = rows
-        .next()
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to fetch count row: {}", e)))?
-    {
-        let count: i64 = row.get(0).unwrap_or(0);
-        Ok(Some(count))
-    } else {
-        Ok(None)
-    }
-}
-
 async fn get_table_indexes(
     conn: &Arc<libsql::Connection>,
     table_name: &str,
 ) -> Result<Vec<IndexInfo>, Error> {
     let mut indexes = Vec::new();
 
-    let query = format!("PRAGMA index_list(\"{}\")", table_name);
-    let mut rows = conn
-        .query(&query, ())
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get index list: {}", e)))?;
-
-    while let Some(row) = rows
-        .next()
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to fetch index row: {}", e)))?
-    {
+    let query = format!("PRAGMA index_list(\"{}\")", table_name.replace('"', "\"\""));
+    for row in query_rows(conn, &query).await? {
         let name: String = row.get(1).unwrap_or_default();
         let is_unique: i64 = row.get(2).unwrap_or(0);
 
-        let info_query = format!("PRAGMA index_info(\"{}\")", name);
-        let mut info_rows = conn
-            .query(&info_query, ())
+        let info_query = format!("PRAGMA index_info(\"{}\")", name.replace('"', "\"\""));
+        let column_names: Vec<String> = query_rows(conn, &info_query)
             .await
-            .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get index info: {}", e)))?;
-
-        let mut column_names = Vec::new();
-        while let Some(info_row) = info_rows.next().await.ok().flatten() {
-            let col_name: String = info_row.get(2).unwrap_or_default();
-            if !col_name.is_empty() {
-                column_names.push(col_name);
-            }
-        }
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|info_row| info_row.get::<String>(2).ok())
+            .filter(|col| !col.is_empty())
+            .collect();
 
         indexes.push(IndexInfo {
             name,

--- a/apps/desktop/src-tauri/src/database/mysql/schema.rs
+++ b/apps/desktop/src-tauri/src/database/mysql/schema.rs
@@ -23,32 +23,61 @@ pub async fn get_database_schema(
 ) -> Result<DatabaseSchema, Error> {
     let queries = dialect.introspection();
 
-    let mut conn = pool
-        .get_conn()
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("MySQL connect failed: {}", e)))?;
+    // The four catalog queries scope themselves to the connection's default
+    // schema via `DATABASE()` (see dialect.rs), so no `SELECT DATABASE()`
+    // round trip precedes them. mysql_async cannot multiplex one connection,
+    // so two pooled connections run two serial chains concurrently:
+    // columns → row counts on one, foreign keys → indexes on the other. The
+    // second handshake overlaps the first chain's queries.
+    let (columns_chain, fk_chain) =
+        tokio::join!(
+            async {
+                let mut conn = pool
+                    .get_conn()
+                    .await
+                    .map_err(|e| Error::Any(anyhow::anyhow!("MySQL connect failed: {}", e)))?;
+                let column_rows: Vec<Row> = conn
+                    .query(queries.columns)
+                    .await
+                    .map_err(|e| Error::Any(anyhow::anyhow!("Failed to query columns: {}", e)))?;
+                let count_rows: Vec<Row> = conn.query(queries.row_counts).await.map_err(|e| {
+                    Error::Any(anyhow::anyhow!("Failed to query row counts: {}", e))
+                })?;
+                Ok::<_, Error>((column_rows, count_rows))
+            },
+            async {
+                let mut conn = pool
+                    .get_conn()
+                    .await
+                    .map_err(|e| Error::Any(anyhow::anyhow!("MySQL connect failed: {}", e)))?;
+                let fk_rows: Vec<Row> = conn.query(queries.foreign_keys).await.map_err(|e| {
+                    Error::Any(anyhow::anyhow!("Failed to query foreign keys: {}", e))
+                })?;
+                let index_rows: Vec<Row> = conn
+                    .query(queries.indexes)
+                    .await
+                    .map_err(|e| Error::Any(anyhow::anyhow!("Failed to query indexes: {}", e)))?;
+                Ok::<_, Error>((fk_rows, index_rows))
+            },
+        );
+    let (column_rows, count_rows) = columns_chain?;
+    let (fk_rows, index_rows) = fk_chain?;
 
-    let current_db: String = conn
-        .query_first("SELECT DATABASE()")
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get current database: {}", e)))?
-        .unwrap_or_default();
-
-    if current_db.is_empty() {
-        return Err(Error::Any(anyhow::anyhow!("No database selected")));
+    // An empty catalog usually means no default schema was selected in the
+    // connection string; surface that instead of a silently empty sidebar.
+    if column_rows.is_empty() {
+        let mut conn = pool
+            .get_conn()
+            .await
+            .map_err(|e| Error::Any(anyhow::anyhow!("MySQL connect failed: {}", e)))?;
+        let current_db: Option<String> = conn
+            .query_first("SELECT DATABASE()")
+            .await
+            .map_err(|e| Error::Any(anyhow::anyhow!("Failed to get current database: {}", e)))?;
+        if current_db.unwrap_or_default().is_empty() {
+            return Err(Error::Any(anyhow::anyhow!("No database selected")));
+        }
     }
-
-    // -- columns + primary-key flag -----------------------------------------
-    let column_rows: Vec<Row> = conn
-        .exec(queries.columns, (&current_db,))
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to query columns: {}", e)))?;
-
-    // -- foreign keys -------------------------------------------------------
-    let fk_rows: Vec<Row> = conn
-        .exec(queries.foreign_keys, (&current_db,))
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to query foreign keys: {}", e)))?;
 
     let mut fk_map: HashMap<(String, String, String), ForeignKeyInfo> = HashMap::new();
     for row in &fk_rows {
@@ -68,12 +97,6 @@ pub async fn get_database_schema(
             },
         );
     }
-
-    // -- indexes ------------------------------------------------------------
-    let index_rows: Vec<Row> = conn
-        .exec(queries.indexes, (&current_db,))
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to query indexes: {}", e)))?;
 
     // Group columns per index
     let mut index_builder: HashMap<(String, String, String), (bool, Vec<String>)> = HashMap::new();
@@ -105,11 +128,6 @@ pub async fn get_database_schema(
     }
 
     // -- row count estimates ------------------------------------------------
-    let count_rows: Vec<Row> = conn
-        .exec(queries.row_counts, (&current_db,))
-        .await
-        .map_err(|e| Error::Any(anyhow::anyhow!("Failed to query row counts: {}", e)))?;
-
     let mut count_map: HashMap<(String, String), u64> = HashMap::new();
     for row in &count_rows {
         let schema: String = mysql_get_string(row, 0);

--- a/apps/desktop/src-tauri/src/database/postgres.rs
+++ b/apps/desktop/src-tauri/src/database/postgres.rs
@@ -2,6 +2,7 @@ pub mod connect;
 pub mod connection_string;
 pub mod execute;
 pub mod parser;
+pub(crate) mod row_counts;
 pub mod row_writer;
 pub mod schema;
 pub mod tls;

--- a/apps/desktop/src-tauri/src/database/postgres/row_counts.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/row_counts.rs
@@ -1,0 +1,92 @@
+use anyhow::Context;
+use tokio_postgres::Client;
+
+use crate::database::ident::quote_ansi as quote_identifier;
+use crate::Error;
+
+/// Batch size for the UNION ALL count query. Keeps a single statement from
+/// growing unbounded on schemas with hundreds of never-analyzed tables.
+const ROW_COUNT_BATCH_SIZE: usize = 50;
+
+/// Exact `COUNT(*)` for the given `(schema, table)` pairs, batched into as few
+/// round-trips as possible. Issuing one query per table serializes a network
+/// RTT per table, which costs seconds against a remote database (Neon,
+/// Supabase, RDS). Returns counts positionally, `None` where the count could
+/// not be read. Runs on the background row-count refresher, never on the
+/// introspection critical path.
+pub(crate) async fn exact_row_counts(
+    client: &Client,
+    tables: &[(String, String)],
+) -> Result<Vec<Option<u64>>, Error> {
+    let mut counts: Vec<Option<u64>> = Vec::with_capacity(tables.len());
+
+    for batch in tables.chunks(ROW_COUNT_BATCH_SIZE) {
+        let selects: Vec<String> = batch
+            .iter()
+            .enumerate()
+            .map(|(index, (schema, table))| {
+                format!(
+                    "SELECT {} AS idx, COUNT(*)::text AS count FROM {}.{}",
+                    index,
+                    quote_identifier(schema),
+                    quote_identifier(table)
+                )
+            })
+            .collect();
+
+        let query = selects.join(" UNION ALL ");
+        let messages = match client.simple_query(&query).await {
+            Ok(messages) => messages,
+            // One unreadable relation fails the whole batch, so fall back to
+            // counting this batch table-by-table and keep what we can get.
+            Err(err) => {
+                log::debug!("Batched row count failed, falling back per table: {}", err);
+                for (schema, table) in batch {
+                    counts.push(exact_row_count(client, schema, table).await.ok());
+                }
+                continue;
+            }
+        };
+
+        let mut batch_counts: Vec<Option<u64>> = vec![None; batch.len()];
+        for message in messages {
+            if let tokio_postgres::SimpleQueryMessage::Row(row) = message {
+                let index = match row.try_get("idx")?.and_then(|v| v.parse::<usize>().ok()) {
+                    Some(index) if index < batch_counts.len() => index,
+                    _ => continue,
+                };
+                batch_counts[index] = row.try_get("count")?.and_then(|v| v.parse::<u64>().ok());
+            }
+        }
+
+        counts.extend(batch_counts);
+    }
+
+    Ok(counts)
+}
+
+async fn exact_row_count(client: &Client, schema: &str, table: &str) -> Result<u64, Error> {
+    let query = format!(
+        "SELECT COUNT(*)::text AS count FROM {}.{}",
+        quote_identifier(schema),
+        quote_identifier(table)
+    );
+
+    let rows = client
+        .simple_query(&query)
+        .await
+        .context("Failed to query exact row count")?;
+
+    for message in rows {
+        if let tokio_postgres::SimpleQueryMessage::Row(row) = message {
+            let count = row
+                .try_get("count")?
+                .unwrap_or("0")
+                .parse::<u64>()
+                .context("Failed to parse exact row count")?;
+            return Ok(count);
+        }
+    }
+
+    Ok(0)
+}

--- a/apps/desktop/src-tauri/src/database/postgres/schema.rs
+++ b/apps/desktop/src-tauri/src/database/postgres/schema.rs
@@ -24,17 +24,20 @@ pub async fn get_database_schema(
 ) -> Result<DatabaseSchema, Error> {
     let queries = dialect.introspection();
 
-    // Main columns query with primary key detection
-    let rows = client
-        .query(queries.tables_columns, &[])
-        .await
-        .context("Failed to query database schema")?;
-
-    // Query for foreign keys
-    let fk_rows = client
-        .query(queries.foreign_keys, &[])
-        .await
-        .context("Failed to query foreign keys")?;
+    // All five catalog queries are dispatched concurrently: tokio-postgres
+    // pipelines statements on one connection when their futures are polled
+    // together, so a remote database pays roughly one round trip instead of
+    // five. `value_constraints` stays best-effort (restricted catalog access
+    // must not sink the whole introspection), so its error is captured rather
+    // than propagated.
+    let (rows, fk_rows, index_rows, count_rows, constraint_result) = tokio::try_join!(
+        client.query(queries.tables_columns, &[]),
+        client.query(queries.foreign_keys, &[]),
+        client.query(queries.indexes, &[]),
+        client.query(queries.row_counts, &[]),
+        async { Ok(client.query(queries.value_constraints, &[]).await) },
+    )
+    .context("Failed to query database schema")?;
 
     // Build foreign key lookup: (schema, table, column) -> ForeignKeyInfo
     let mut fk_map: HashMap<(String, String, String), ForeignKeyInfo> = HashMap::new();
@@ -55,12 +58,6 @@ pub async fn get_database_schema(
             },
         );
     }
-
-    // Query for indexes
-    let index_rows = client
-        .query(queries.indexes, &[])
-        .await
-        .context("Failed to query indexes")?;
 
     let mut index_map: HashMap<(String, String), Vec<IndexInfo>> = HashMap::new();
     for row in &index_rows {
@@ -104,27 +101,24 @@ pub async fn get_database_schema(
             .push(index_info);
     }
 
-    // Query for row count estimates (fast; vanilla uses pg_stat_user_tables,
-    // CockroachDB uses crdb_internal.table_row_statistics — see PgIntrospection).
-    let count_rows = client
-        .query(queries.row_counts, &[])
-        .await
-        .context("Failed to query row counts")?;
-
-    // Build row count lookup
+    // Build row count lookup. A negative estimate (`reltuples = -1`, never
+    // analyzed) means "unknown": leave the table out so it surfaces as `None`
+    // and the background exact count fills it in.
     let mut count_map: HashMap<(String, String), u64> = HashMap::new();
     for row in &count_rows {
         let schema: &str = row.get(0);
         let table: &str = row.get(1);
         let count: i64 = row.get(2);
-        count_map.insert((schema.to_owned(), table.to_owned()), count as u64);
+        if count >= 0 {
+            count_map.insert((schema.to_owned(), table.to_owned()), count as u64);
+        }
     }
 
     // Query for closed value sets (enum labels + single-column CHECK lists).
     // Best-effort: a failure here (e.g. restricted catalog access) must not sink
     // the whole introspection, so we log and continue with an empty map.
     let mut allowed_map: HashMap<(String, String, String), Vec<String>> = HashMap::new();
-    match client.query(queries.value_constraints, &[]).await {
+    match constraint_result {
         Ok(constraint_rows) => {
             for row in &constraint_rows {
                 let schema: &str = row.get(0);
@@ -231,26 +225,6 @@ pub async fn get_database_schema(
         });
     }
 
-    let mut pending_counts: Vec<&mut TableInfo> = tables_map
-        .values_mut()
-        .filter(|table| table.row_count_estimate.unwrap_or(0) == 0)
-        .collect();
-
-    if !pending_counts.is_empty() {
-        match exact_row_counts(client, &pending_counts).await {
-            Ok(counts) => {
-                for (table, count) in pending_counts.iter_mut().zip(counts) {
-                    if let Some(count) = count {
-                        table.row_count_estimate = Some(count);
-                    }
-                }
-            }
-            Err(err) => {
-                log::debug!("Failed to get exact row counts: {}", err);
-            }
-        }
-    }
-
     let tables = tables_map.into_values().collect();
     let schemas = schemas_set.into_iter().map(ToOwned::to_owned).collect();
     let unique_columns = unique_columns_set
@@ -264,93 +238,6 @@ pub async fn get_database_schema(
         unique_columns,
     })
 }
-
-/// Batch size for the UNION ALL count query. Keeps a single statement from
-/// growing unbounded on schemas with hundreds of never-analyzed tables.
-const ROW_COUNT_BATCH_SIZE: usize = 50;
-
-/// Exact `COUNT(*)` for every table, batched into as few round-trips as
-/// possible. Issuing one query per table serializes a network RTT per table,
-/// which costs seconds against a remote database (Neon, Supabase, RDS).
-/// Returns counts positionally, `None` where the count could not be read.
-async fn exact_row_counts(
-    client: &Client,
-    tables: &[&mut TableInfo],
-) -> Result<Vec<Option<u64>>, Error> {
-    let mut counts: Vec<Option<u64>> = Vec::with_capacity(tables.len());
-
-    for batch in tables.chunks(ROW_COUNT_BATCH_SIZE) {
-        let selects: Vec<String> = batch
-            .iter()
-            .enumerate()
-            .map(|(index, table)| {
-                format!(
-                    "SELECT {} AS idx, COUNT(*)::text AS count FROM {}.{}",
-                    index,
-                    quote_identifier(&table.schema),
-                    quote_identifier(&table.name)
-                )
-            })
-            .collect();
-
-        let query = selects.join(" UNION ALL ");
-        let messages = match client.simple_query(&query).await {
-            Ok(messages) => messages,
-            // One unreadable relation fails the whole batch, so fall back to
-            // counting this batch table-by-table and keep what we can get.
-            Err(err) => {
-                log::debug!("Batched row count failed, falling back per table: {}", err);
-                for table in batch {
-                    counts.push(exact_row_count(client, &table.schema, &table.name).await.ok());
-                }
-                continue;
-            }
-        };
-
-        let mut batch_counts: Vec<Option<u64>> = vec![None; batch.len()];
-        for message in messages {
-            if let tokio_postgres::SimpleQueryMessage::Row(row) = message {
-                let index = match row.try_get("idx")?.and_then(|v| v.parse::<usize>().ok()) {
-                    Some(index) if index < batch_counts.len() => index,
-                    _ => continue,
-                };
-                batch_counts[index] = row.try_get("count")?.and_then(|v| v.parse::<u64>().ok());
-            }
-        }
-
-        counts.extend(batch_counts);
-    }
-
-    Ok(counts)
-}
-
-async fn exact_row_count(client: &Client, schema: &str, table: &str) -> Result<u64, Error> {
-    let query = format!(
-        "SELECT COUNT(*)::text AS count FROM {}.{}",
-        quote_identifier(schema),
-        quote_identifier(table)
-    );
-
-    let rows = client
-        .simple_query(&query)
-        .await
-        .context("Failed to query exact row count")?;
-
-    for message in rows {
-        if let tokio_postgres::SimpleQueryMessage::Row(row) = message {
-            let count = row
-                .try_get("count")?
-                .unwrap_or("0")
-                .parse::<u64>()
-                .context("Failed to parse exact row count")?;
-            return Ok(count);
-        }
-    }
-
-    Ok(0)
-}
-
-use crate::database::ident::quote_ansi as quote_identifier;
 
 /// Extract the allowed-value list from a single-column `CHECK` constraint
 /// definition as returned by `pg_get_constraintdef`.
@@ -512,8 +399,11 @@ mod tests {
         assert_eq!(v.tables_columns, c.tables_columns);
         assert_eq!(v.foreign_keys, c.foreign_keys);
         assert_eq!(v.indexes, c.indexes);
-        // Only row counts diverge.
+        // Only row counts diverge: vanilla reads the restart-surviving
+        // pg_class.reltuples, CockroachDB its own statistics table.
         assert_ne!(v.row_counts, c.row_counts);
+        assert!(v.row_counts.contains("reltuples"));
+        assert!(!v.row_counts.contains("pg_stat_user_tables"));
         assert!(c.row_counts.contains("crdb_internal.table_row_statistics"));
     }
 }

--- a/apps/desktop/src-tauri/src/database/posthog/mod.rs
+++ b/apps/desktop/src-tauri/src/database/posthog/mod.rs
@@ -43,7 +43,7 @@ pub struct PosthogHttp {
 impl PosthogHttp {
     pub fn new(region: &str, project_id: String, api_key: String) -> Self {
         Self {
-            client: crate::http::query_client(),
+            client: crate::http::query_client().clone(),
             api_base: region_api_base(region).to_string(),
             project_id,
             api_key,
@@ -343,7 +343,10 @@ mod tests {
         }"#;
         let set = parse_result_set(body).expect("should decode");
         assert_eq!(set.columns, vec!["event", "count"]);
-        assert_eq!(set.types, vec![Some("String".into()), Some("UInt64".into())]);
+        assert_eq!(
+            set.types,
+            vec![Some("String".into()), Some("UInt64".into())]
+        );
         assert_eq!(set.rows.len(), 2);
         assert_eq!(set.rows[0][0], Value::from("$pageview"));
     }

--- a/apps/desktop/src-tauri/src/database/row_count_refresher.rs
+++ b/apps/desktop/src-tauri/src/database/row_count_refresher.rs
@@ -1,0 +1,539 @@
+//! Background exact row counts.
+//!
+//! Schema introspection returns immediately with whatever estimates the engine
+//! keeps (`pg_class.reltuples`, `information_schema.TABLES.TABLE_ROWS`,
+//! `duckdb_tables().estimated_size`) and leaves unknown or zero estimates as
+//! they are. This module owns the follow-up: a per-connection background task
+//! that runs batched exact `COUNT(*)` queries for those tables, patches the
+//! cached `Arc<DatabaseSchema>` in place and emits
+//! [`SCHEMA_ROW_COUNTS_EVENT`] so the frontend refetches the (now patched)
+//! cache. Keeping counts off the introspection critical path is what lets a
+//! cloud connection paint its sidebar in one round trip instead of counting
+//! every table first.
+//!
+//! Cancellation is a generation counter: every full schema invalidation or
+//! teardown calls [`RowCountRefresher::cancel`], which bumps the connection's
+//! generation and aborts the running task. A task compares its spawn-time
+//! generation before patching, so a stale result is discarded rather than
+//! resurrecting a dropped schema entry.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, EventTarget, Manager};
+use uuid::Uuid;
+
+use crate::database::ident::{qualified_ansi, qualified_mysql};
+use crate::database::types::{Database, DatabaseSchema};
+use crate::AppState;
+
+pub const SCHEMA_ROW_COUNTS_EVENT: &str = "schema-row-counts-updated";
+
+/// Tables per UNION ALL count statement for the server engines.
+const COUNT_BATCH_SIZE: usize = 50;
+/// Smaller batches for SQLite so the connection mutex is released between
+/// batches and interactive queries can interleave.
+const SQLITE_COUNT_BATCH_SIZE: usize = 25;
+/// Upper bound on one whole count run; a hung remote must not zombie the task.
+const COUNT_RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingCount {
+    pub schema: String,
+    pub table: String,
+}
+
+/// Tables whose estimate is unknown or zero. Zero is included because a stale
+/// stats source (Neon resets `pg_stat`; MySQL samples lazily) reports exactly
+/// zero, and counting a genuinely empty table is cheap.
+pub fn pending_counts(schema: &DatabaseSchema) -> Vec<PendingCount> {
+    schema
+        .tables
+        .iter()
+        .filter(|table| table.row_count_estimate.unwrap_or(0) == 0)
+        .map(|table| PendingCount {
+            schema: table.schema.clone(),
+            table: table.name.clone(),
+        })
+        .collect()
+}
+
+/// Applies positional counts onto a schema, returning the patched copy.
+/// `None` counts (unreadable tables) leave the existing estimate untouched.
+pub fn apply_counts(
+    schema: &DatabaseSchema,
+    pending: &[PendingCount],
+    counts: &[Option<u64>],
+) -> DatabaseSchema {
+    let mut patched = schema.clone();
+    for (entry, count) in pending.iter().zip(counts) {
+        let Some(count) = count else { continue };
+        if let Some(table) = patched
+            .tables
+            .iter_mut()
+            .find(|table| table.name == entry.table && table.schema == entry.schema)
+        {
+            table.row_count_estimate = Some(*count);
+        }
+    }
+    patched
+}
+
+#[derive(Clone, Serialize)]
+struct RowCountsUpdatedPayload {
+    #[serde(rename = "connectionId")]
+    connection_id: Uuid,
+}
+
+struct RunningTask {
+    generation: u64,
+    handle: tauri::async_runtime::JoinHandle<()>,
+}
+
+pub struct RowCountRefresher {
+    app: AppHandle,
+    generations: DashMap<Uuid, u64>,
+    tasks: DashMap<Uuid, RunningTask>,
+}
+
+impl RowCountRefresher {
+    pub fn new(app: AppHandle) -> Self {
+        Self {
+            app,
+            generations: DashMap::new(),
+            tasks: DashMap::new(),
+        }
+    }
+
+    fn generation(&self, connection_id: Uuid) -> u64 {
+        *self.generations.entry(connection_id).or_insert(0)
+    }
+
+    /// Bumps the generation and aborts any running count task. Call on every
+    /// full schema invalidation, disconnect, removal or config change so a
+    /// stale count run can neither patch the cache nor hold engine handles
+    /// alive past teardown.
+    pub fn cancel(&self, connection_id: Uuid) {
+        *self.generations.entry(connection_id).or_insert(0) += 1;
+        if let Some((_, task)) = self.tasks.remove(&connection_id) {
+            task.handle.abort();
+        }
+    }
+
+    /// Spawns a count run for the given pending tables unless one is already
+    /// running at the current generation. Safe to call on every schema read.
+    pub fn schedule(&self, connection_id: Uuid, pending: Vec<PendingCount>) {
+        if pending.is_empty() {
+            return;
+        }
+        let generation = self.generation(connection_id);
+        if let Some(task) = self.tasks.get(&connection_id) {
+            if task.generation == generation {
+                return;
+            }
+        }
+        if let Some((_, stale)) = self.tasks.remove(&connection_id) {
+            stale.handle.abort();
+        }
+
+        let app = self.app.clone();
+        let handle = tauri::async_runtime::spawn(async move {
+            run_count_task(app, connection_id, generation, pending).await;
+        });
+        self.tasks
+            .insert(connection_id, RunningTask { generation, handle });
+    }
+
+    fn finish(&self, connection_id: Uuid, generation: u64) {
+        self.tasks
+            .remove_if(&connection_id, |_, task| task.generation == generation);
+    }
+}
+
+async fn run_count_task(
+    app: AppHandle,
+    connection_id: Uuid,
+    generation: u64,
+    pending: Vec<PendingCount>,
+) {
+    let outcome =
+        tokio::time::timeout(COUNT_RUN_TIMEOUT, run_counts(&app, connection_id, &pending)).await;
+
+    let counts = match outcome {
+        Ok(Some(counts)) => counts,
+        Ok(None) => {
+            cleanup(&app, connection_id, generation);
+            return;
+        }
+        Err(_) => {
+            log::warn!("Row count refresh timed out for connection {connection_id}");
+            cleanup(&app, connection_id, generation);
+            return;
+        }
+    };
+
+    let Some(state) = app.try_state::<AppState>() else {
+        return;
+    };
+    let Some(refresher) = try_refresher(&app) else {
+        return;
+    };
+    if refresher.generation(connection_id) != generation {
+        refresher.finish(connection_id, generation);
+        return;
+    }
+
+    let mut patched_any = false;
+    state.schemas.alter(&connection_id, |_, old| {
+        let patched = apply_counts(&old, &pending, &counts);
+        patched_any = true;
+        Arc::new(patched)
+    });
+
+    if patched_any {
+        match app.emit_to(
+            EventTarget::App,
+            SCHEMA_ROW_COUNTS_EVENT,
+            RowCountsUpdatedPayload { connection_id },
+        ) {
+            Ok(()) => log::debug!("Row counts updated for connection {connection_id}"),
+            Err(e) => log::error!("Error emitting {SCHEMA_ROW_COUNTS_EVENT}: {e}"),
+        }
+    }
+
+    refresher.finish(connection_id, generation);
+}
+
+fn cleanup(app: &AppHandle, connection_id: Uuid, generation: u64) {
+    if let Some(refresher) = try_refresher(app) {
+        refresher.finish(connection_id, generation);
+    }
+}
+
+fn try_refresher(app: &AppHandle) -> Option<tauri::State<'_, RowCountRefresher>> {
+    app.try_state::<RowCountRefresher>()
+}
+
+/// A cloned engine handle: everything a count run needs, detached from the
+/// connections map so no `Ref` guard outlives this function's stack frame.
+enum CountTarget {
+    Postgres(Arc<tokio_postgres::Client>),
+    MySql(Arc<mysql_async::Pool>),
+    Sqlite(Arc<std::sync::Mutex<rusqlite::Connection>>),
+    LibSql(Arc<libsql::Connection>),
+    D1(Arc<crate::database::d1::D1Http>),
+}
+
+fn count_target(app: &AppHandle, connection_id: Uuid) -> Option<CountTarget> {
+    let state = app.try_state::<AppState>()?;
+    let entry = state.connections.get(&connection_id)?;
+    if !entry.connected {
+        return None;
+    }
+    match &entry.database {
+        Database::Postgres {
+            client: Some(client),
+            ..
+        } => Some(CountTarget::Postgres(Arc::clone(client))),
+        Database::MySQL {
+            pool: Some(pool), ..
+        } => Some(CountTarget::MySql(Arc::clone(pool))),
+        Database::SQLite {
+            connection: Some(conn),
+            ..
+        } => Some(CountTarget::Sqlite(Arc::clone(conn))),
+        Database::LibSQL {
+            connection: Some(conn),
+            ..
+        } => Some(CountTarget::LibSql(Arc::clone(conn))),
+        Database::D1 {
+            connection: Some(http),
+            ..
+        } => Some(CountTarget::D1(Arc::clone(http))),
+        _ => None,
+    }
+}
+
+async fn run_counts(
+    app: &AppHandle,
+    connection_id: Uuid,
+    pending: &[PendingCount],
+) -> Option<Vec<Option<u64>>> {
+    let target = count_target(app, connection_id)?;
+    let result = match target {
+        CountTarget::Postgres(client) => {
+            let pairs: Vec<(String, String)> = pending
+                .iter()
+                .map(|p| (p.schema.clone(), p.table.clone()))
+                .collect();
+            crate::database::postgres::row_counts::exact_row_counts(&client, &pairs).await
+        }
+        CountTarget::MySql(pool) => mysql_counts(&pool, pending).await,
+        CountTarget::Sqlite(conn) => sqlite_counts(conn, pending).await,
+        CountTarget::LibSql(conn) => libsql_counts(&conn, pending).await,
+        CountTarget::D1(http) => d1_counts(&http, pending).await,
+    };
+    match result {
+        Ok(counts) => Some(counts),
+        Err(err) => {
+            log::debug!("Row count refresh failed for connection {connection_id}: {err}");
+            None
+        }
+    }
+}
+
+fn union_all_counts(batch: &[PendingCount], quote: impl Fn(&PendingCount) -> String) -> String {
+    batch
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| {
+            format!(
+                "SELECT {} AS idx, COUNT(*) AS cnt FROM {}",
+                index,
+                quote(entry)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" UNION ALL ")
+}
+
+fn ansi_target(entry: &PendingCount) -> String {
+    let schema = if entry.schema.is_empty() {
+        None
+    } else {
+        Some(entry.schema.as_str())
+    };
+    qualified_ansi(schema, &entry.table)
+}
+
+async fn mysql_counts(
+    pool: &mysql_async::Pool,
+    pending: &[PendingCount],
+) -> Result<Vec<Option<u64>>, crate::Error> {
+    use mysql_async::prelude::Queryable;
+
+    let mut conn = pool
+        .get_conn()
+        .await
+        .map_err(|e| crate::Error::Any(anyhow::anyhow!("MySQL count connection failed: {e}")))?;
+
+    let mut counts: Vec<Option<u64>> = Vec::with_capacity(pending.len());
+    for batch in pending.chunks(COUNT_BATCH_SIZE) {
+        let sql = union_all_counts(batch, |entry| {
+            let schema = if entry.schema.is_empty() {
+                None
+            } else {
+                Some(entry.schema.as_str())
+            };
+            qualified_mysql(schema, &entry.table)
+        });
+        let mut batch_counts: Vec<Option<u64>> = vec![None; batch.len()];
+        match conn.query::<(u64, u64), _>(sql).await {
+            Ok(rows) => {
+                for (index, count) in rows {
+                    if let Some(slot) = batch_counts.get_mut(index as usize) {
+                        *slot = Some(count);
+                    }
+                }
+            }
+            Err(err) => {
+                log::debug!("MySQL batched count failed: {err}");
+            }
+        }
+        counts.extend(batch_counts);
+    }
+    Ok(counts)
+}
+
+async fn sqlite_counts(
+    conn: Arc<std::sync::Mutex<rusqlite::Connection>>,
+    pending: &[PendingCount],
+) -> Result<Vec<Option<u64>>, crate::Error> {
+    let mut counts: Vec<Option<u64>> = Vec::with_capacity(pending.len());
+    for batch in pending.chunks(SQLITE_COUNT_BATCH_SIZE) {
+        let sql = union_all_counts(batch, ansi_target);
+        let batch_len = batch.len();
+        let conn = Arc::clone(&conn);
+        let batch_counts = tokio::task::spawn_blocking(move || {
+            let mut batch_counts: Vec<Option<u64>> = vec![None; batch_len];
+            let guard = match conn.lock() {
+                Ok(guard) => guard,
+                Err(_) => return batch_counts,
+            };
+            let mut stmt = match guard.prepare(&sql) {
+                Ok(stmt) => stmt,
+                Err(err) => {
+                    log::debug!("SQLite batched count failed: {err}");
+                    return batch_counts;
+                }
+            };
+            let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)));
+            if let Ok(rows) = rows {
+                for row in rows.flatten() {
+                    let (index, count) = row;
+                    if count >= 0 {
+                        if let Some(slot) = batch_counts.get_mut(index as usize) {
+                            *slot = Some(count as u64);
+                        }
+                    }
+                }
+            }
+            batch_counts
+        })
+        .await
+        .map_err(|e| crate::Error::Any(anyhow::anyhow!("SQLite count task failed: {e}")))?;
+        counts.extend(batch_counts);
+    }
+    Ok(counts)
+}
+
+async fn libsql_counts(
+    conn: &libsql::Connection,
+    pending: &[PendingCount],
+) -> Result<Vec<Option<u64>>, crate::Error> {
+    let mut counts: Vec<Option<u64>> = Vec::with_capacity(pending.len());
+    for batch in pending.chunks(COUNT_BATCH_SIZE) {
+        let sql = union_all_counts(batch, ansi_target);
+        let mut batch_counts: Vec<Option<u64>> = vec![None; batch.len()];
+        match conn.query(&sql, ()).await {
+            Ok(mut rows) => {
+                while let Ok(Some(row)) = rows.next().await {
+                    let index = row.get::<i64>(0).unwrap_or(-1);
+                    let count = row.get::<i64>(1).unwrap_or(-1);
+                    if index >= 0 && count >= 0 {
+                        if let Some(slot) = batch_counts.get_mut(index as usize) {
+                            *slot = Some(count as u64);
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                log::debug!("libSQL batched count failed: {err}");
+            }
+        }
+        counts.extend(batch_counts);
+    }
+    Ok(counts)
+}
+
+async fn d1_counts(
+    http: &crate::database::d1::D1Http,
+    pending: &[PendingCount],
+) -> Result<Vec<Option<u64>>, crate::Error> {
+    let mut counts: Vec<Option<u64>> = Vec::with_capacity(pending.len());
+    for batch in pending.chunks(COUNT_BATCH_SIZE) {
+        let sql = union_all_counts(batch, ansi_target);
+        let mut batch_counts: Vec<Option<u64>> = vec![None; batch.len()];
+        match http.query(&sql, Vec::new()).await {
+            Ok(result_sets) => {
+                for set in result_sets {
+                    for row in &set.results {
+                        let index = row.get("idx").and_then(|v| v.as_i64()).unwrap_or(-1);
+                        let count = row.get("cnt").and_then(|v| v.as_i64()).unwrap_or(-1);
+                        if index >= 0 && count >= 0 {
+                            if let Some(slot) = batch_counts.get_mut(index as usize) {
+                                *slot = Some(count as u64);
+                            }
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                log::debug!("D1 batched count failed: {err}");
+            }
+        }
+        counts.extend(batch_counts);
+    }
+    Ok(counts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::types::TableInfo;
+
+    fn table(name: &str, schema: &str, estimate: Option<u64>) -> TableInfo {
+        TableInfo {
+            name: name.to_string(),
+            schema: schema.to_string(),
+            columns: Vec::new(),
+            primary_key_columns: Vec::new(),
+            row_count_estimate: estimate,
+            indexes: Vec::new(),
+        }
+    }
+
+    fn schema_of(tables: Vec<TableInfo>) -> DatabaseSchema {
+        DatabaseSchema {
+            tables,
+            schemas: Vec::new(),
+            unique_columns: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn pending_includes_none_and_zero_estimates_only() {
+        let schema = schema_of(vec![
+            table("a", "public", None),
+            table("b", "public", Some(0)),
+            table("c", "public", Some(42)),
+        ]);
+        let pending = pending_counts(&schema);
+        assert_eq!(
+            pending.iter().map(|p| p.table.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+    }
+
+    #[test]
+    fn apply_counts_patches_matching_tables_positionally() {
+        let schema = schema_of(vec![
+            table("a", "public", None),
+            table("b", "other", Some(0)),
+        ]);
+        let pending = vec![
+            PendingCount {
+                schema: "public".into(),
+                table: "a".into(),
+            },
+            PendingCount {
+                schema: "other".into(),
+                table: "b".into(),
+            },
+        ];
+        let patched = apply_counts(&schema, &pending, &[Some(7), None]);
+        assert_eq!(patched.tables[0].row_count_estimate, Some(7));
+        assert_eq!(patched.tables[1].row_count_estimate, Some(0));
+    }
+
+    #[test]
+    fn apply_counts_ignores_missing_tables() {
+        let schema = schema_of(vec![table("a", "public", None)]);
+        let pending = vec![PendingCount {
+            schema: "public".into(),
+            table: "dropped".into(),
+        }];
+        let patched = apply_counts(&schema, &pending, &[Some(9)]);
+        assert_eq!(patched.tables[0].row_count_estimate, None);
+    }
+
+    #[test]
+    fn union_all_counts_quotes_and_indexes() {
+        let batch = vec![
+            PendingCount {
+                schema: String::new(),
+                table: "users".into(),
+            },
+            PendingCount {
+                schema: String::new(),
+                table: "we\"ird".into(),
+            },
+        ];
+        let sql = union_all_counts(&batch, ansi_target);
+        assert_eq!(
+            sql,
+            "SELECT 0 AS idx, COUNT(*) AS cnt FROM \"users\" UNION ALL SELECT 1 AS idx, COUNT(*) AS cnt FROM \"we\"\"ird\""
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/database/schema_cache.rs
+++ b/apps/desktop/src-tauri/src/database/schema_cache.rs
@@ -1,0 +1,200 @@
+//! In-place patches for the cached `Arc<DatabaseSchema>`.
+//!
+//! Plain DML changes row counts, never structure, so mutation paths patch the
+//! affected table's `row_count_estimate` instead of dropping the whole schema
+//! entry — dropping it forces a full re-introspection (and, on the engines
+//! without cheap estimates, a background count storm) after every single cell
+//! edit.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use uuid::Uuid;
+
+use crate::database::types::DatabaseSchema;
+
+#[derive(Clone, Copy, Debug)]
+pub enum RowCountDelta {
+    Add(i64),
+    Zero,
+}
+
+/// Adjusts one table's row-count estimate in the cached schema. A `None`
+/// estimate stays `None` under `Add` (the true count is unknown; the background
+/// refresher owns filling it in), while `Zero` always pins it to `Some(0)`.
+/// Missing connection or table is a no-op.
+pub fn patch_row_count(
+    schemas: &DashMap<Uuid, Arc<DatabaseSchema>>,
+    connection_id: Uuid,
+    table_name: &str,
+    schema_name: Option<&str>,
+    delta: RowCountDelta,
+) {
+    schemas.alter(&connection_id, |_, old| {
+        let mut patched = (*old).clone();
+        let table = patched.tables.iter_mut().find(|table| {
+            table.name == table_name
+                && schema_name
+                    .map(|schema| table.schema == schema)
+                    .unwrap_or(true)
+        });
+        if let Some(table) = table {
+            table.row_count_estimate = match (delta, table.row_count_estimate) {
+                (RowCountDelta::Zero, _) => Some(0),
+                (RowCountDelta::Add(delta), Some(current)) => {
+                    Some((current as i64).saturating_add(delta).max(0) as u64)
+                }
+                (RowCountDelta::Add(_), None) => None,
+            };
+        }
+        Arc::new(patched)
+    });
+}
+
+/// Pins every table's estimate to zero — the truncate-database case, where
+/// structure is untouched but every table is now empty.
+pub fn zero_all_row_counts(schemas: &DashMap<Uuid, Arc<DatabaseSchema>>, connection_id: Uuid) {
+    schemas.alter(&connection_id, |_, old| {
+        let mut patched = (*old).clone();
+        for table in &mut patched.tables {
+            table.row_count_estimate = Some(0);
+        }
+        Arc::new(patched)
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::types::TableInfo;
+
+    fn schemas_with(
+        connection_id: Uuid,
+        tables: Vec<(&str, &str, Option<u64>)>,
+    ) -> DashMap<Uuid, Arc<DatabaseSchema>> {
+        let map = DashMap::new();
+        map.insert(
+            connection_id,
+            Arc::new(DatabaseSchema {
+                tables: tables
+                    .into_iter()
+                    .map(|(name, schema, estimate)| TableInfo {
+                        name: name.to_string(),
+                        schema: schema.to_string(),
+                        columns: Vec::new(),
+                        primary_key_columns: Vec::new(),
+                        row_count_estimate: estimate,
+                        indexes: Vec::new(),
+                    })
+                    .collect(),
+                schemas: Vec::new(),
+                unique_columns: Vec::new(),
+            }),
+        );
+        map
+    }
+
+    fn estimate(
+        schemas: &DashMap<Uuid, Arc<DatabaseSchema>>,
+        connection_id: Uuid,
+        table: &str,
+    ) -> Option<u64> {
+        schemas
+            .get(&connection_id)
+            .and_then(|schema| {
+                schema
+                    .tables
+                    .iter()
+                    .find(|t| t.name == table)
+                    .map(|t| t.row_count_estimate)
+            })
+            .flatten()
+    }
+
+    #[test]
+    fn add_and_subtract() {
+        let id = Uuid::new_v4();
+        let schemas = schemas_with(id, vec![("users", "public", Some(10))]);
+        patch_row_count(&schemas, id, "users", Some("public"), RowCountDelta::Add(1));
+        assert_eq!(estimate(&schemas, id, "users"), Some(11));
+        patch_row_count(
+            &schemas,
+            id,
+            "users",
+            Some("public"),
+            RowCountDelta::Add(-5),
+        );
+        assert_eq!(estimate(&schemas, id, "users"), Some(6));
+    }
+
+    #[test]
+    fn subtract_saturates_at_zero() {
+        let id = Uuid::new_v4();
+        let schemas = schemas_with(id, vec![("users", "public", Some(2))]);
+        patch_row_count(
+            &schemas,
+            id,
+            "users",
+            Some("public"),
+            RowCountDelta::Add(-10),
+        );
+        assert_eq!(estimate(&schemas, id, "users"), Some(0));
+    }
+
+    #[test]
+    fn add_on_unknown_estimate_stays_unknown() {
+        let id = Uuid::new_v4();
+        let schemas = schemas_with(id, vec![("users", "public", None)]);
+        patch_row_count(&schemas, id, "users", Some("public"), RowCountDelta::Add(1));
+        assert_eq!(estimate(&schemas, id, "users"), None);
+    }
+
+    #[test]
+    fn zero_pins_even_unknown() {
+        let id = Uuid::new_v4();
+        let schemas = schemas_with(id, vec![("users", "public", None)]);
+        patch_row_count(&schemas, id, "users", Some("public"), RowCountDelta::Zero);
+        assert_eq!(estimate(&schemas, id, "users"), Some(0));
+    }
+
+    #[test]
+    fn missing_table_and_connection_are_noops() {
+        let id = Uuid::new_v4();
+        let schemas = schemas_with(id, vec![("users", "public", Some(3))]);
+        patch_row_count(&schemas, id, "ghost", None, RowCountDelta::Add(1));
+        patch_row_count(
+            &schemas,
+            Uuid::new_v4(),
+            "users",
+            None,
+            RowCountDelta::Add(1),
+        );
+        assert_eq!(estimate(&schemas, id, "users"), Some(3));
+    }
+
+    #[test]
+    fn schema_qualifier_disambiguates() {
+        let id = Uuid::new_v4();
+        let schemas = schemas_with(id, vec![("users", "a", Some(1)), ("users", "b", Some(1))]);
+        patch_row_count(&schemas, id, "users", Some("b"), RowCountDelta::Add(4));
+        assert_eq!(
+            schemas
+                .get(&id)
+                .map(|s| (
+                    s.tables[0].row_count_estimate,
+                    s.tables[1].row_count_estimate
+                ))
+                .unwrap(),
+            (Some(1), Some(5))
+        );
+    }
+
+    #[test]
+    fn zero_all_covers_every_table() {
+        let id = Uuid::new_v4();
+        let schemas = schemas_with(id, vec![("a", "public", Some(9)), ("b", "public", None)]);
+        zero_all_row_counts(&schemas, id);
+        assert_eq!(estimate(&schemas, id, "a"), Some(0));
+        assert_eq!(estimate(&schemas, id, "b"), Some(0));
+    }
+}

--- a/apps/desktop/src-tauri/src/database/services/connection.rs
+++ b/apps/desktop/src-tauri/src/database/services/connection.rs
@@ -551,12 +551,14 @@ impl<'a> ConnectionService<'a> {
                         // failures are non-fatal and leave the existing (vanilla)
                         // dialect in place.
                         let detected_pg = match pg_client.query_one("SELECT version()", &[]).await {
-                            Ok(row) => row
-                                .try_get::<usize, String>(0)
-                                .ok()
-                                .map(|version| crate::database::dialect::detect_pg_dialect(&version)),
+                            Ok(row) => row.try_get::<usize, String>(0).ok().map(|version| {
+                                crate::database::dialect::detect_pg_dialect(&version)
+                            }),
                             Err(e) => {
-                                log::warn!("Failed to detect Postgres dialect via version(): {}", e);
+                                log::warn!(
+                                    "Failed to detect Postgres dialect via version(): {}",
+                                    e
+                                );
                                 None
                             }
                         };
@@ -641,7 +643,9 @@ impl<'a> ConnectionService<'a> {
 
                 match conn_attempt {
                     Ok(Ok(mut conn)) => {
-                        conn.ping().await?;
+                        // No ping: `get_conn` completed the handshake, and the
+                        // VERSION() probe below proves liveness — a ping would
+                        // just add one more round trip to every connect.
 
                         // Detect the real engine (MySQL vs MariaDB). The
                         // per-engine `dialect` field is the source of truth.
@@ -727,11 +731,9 @@ impl<'a> ConnectionService<'a> {
                 // File-source connections live entirely in memory; a real
                 // `.duckdb` file connection opens the file directly. Either path
                 // (in-process or helper) is selected inside `build_duckdb_backend`.
-                let built = crate::database::duckdb_backend::build_duckdb_backend(
-                    db_path,
-                    file_sources,
-                )
-                .await;
+                let built =
+                    crate::database::duckdb_backend::build_duckdb_backend(db_path, file_sources)
+                        .await;
 
                 match built {
                     Ok((conn_handle, registration)) => {
@@ -1027,9 +1029,7 @@ impl<'a> ConnectionService<'a> {
                     file_source_entries,
                     connection: Some(duckdb_conn),
                     ..
-                } if !file_sources.is_empty() => {
-                    (duckdb_conn.clone(), file_source_entries.clone())
-                }
+                } if !file_sources.is_empty() => (duckdb_conn.clone(), file_source_entries.clone()),
                 Database::DuckDB { file_sources, .. } if !file_sources.is_empty() => {
                     return Err(Error::InvalidInput(
                         "Connect the data-file session before saving".to_string(),
@@ -1108,7 +1108,8 @@ impl<'a> ConnectionService<'a> {
                 }
                 _ => {
                     return Err(Error::InvalidInput(
-                        "Import files is only available for DuckDB database connections".to_string(),
+                        "Import files is only available for DuckDB database connections"
+                            .to_string(),
                     ));
                 }
             }
@@ -1294,7 +1295,9 @@ impl<'a> ConnectionService<'a> {
                 .map_err(|e| Error::Any(anyhow::anyhow!("Failed to verify PIN: {}", e)))?;
 
             if !valid {
-                return Err(Error::PermissionDenied("Invalid connection PIN".to_string()));
+                return Err(Error::PermissionDenied(
+                    "Invalid connection PIN".to_string(),
+                ));
             }
 
             // PIN matches, retrieve password

--- a/apps/desktop/src-tauri/src/database/services/metadata.rs
+++ b/apps/desktop/src-tauri/src/database/services/metadata.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 use crate::{
     database::{
+        dialect::{MySqlDialect, PgDialect},
         metadata::{self, DatabaseMetadata},
         postgres, sqlite,
         types::{Database, DatabaseConnection, DatabaseSchema},
@@ -15,25 +16,36 @@ use crate::{
 pub struct MetadataService<'a> {
     pub connections: &'a DashMap<Uuid, DatabaseConnection>,
     pub schemas: &'a DashMap<Uuid, Arc<DatabaseSchema>>,
+    pub schema_locks: &'a DashMap<Uuid, Arc<tokio::sync::Mutex<()>>>,
+}
+
+/// A cloned engine handle for one introspection run. Cloning out of the
+/// connections map lets the `DashMap` `Ref` drop before any await, so a slow
+/// introspection can never block writers to the connections map.
+enum IntrospectTarget {
+    Postgres {
+        client: Arc<tokio_postgres::Client>,
+        dialect: PgDialect,
+    },
+    Sqlite(Arc<std::sync::Mutex<rusqlite::Connection>>),
+    DuckDb(Arc<dyn crate::database::duckdb_backend::DuckDbConn>),
+    LibSql(Arc<libsql::Connection>),
+    D1(Arc<crate::database::d1::D1Http>),
+    Posthog(Arc<crate::database::posthog::PosthogHttp>),
+    MySql {
+        pool: Arc<mysql_async::Pool>,
+        dialect: MySqlDialect,
+    },
 }
 
 impl<'a> MetadataService<'a> {
-    pub async fn get_database_schema(
-        &self,
-        connection_id: Uuid,
-    ) -> Result<Arc<DatabaseSchema>, Error> {
-        if let Some(schema) = self.schemas.get(&connection_id) {
-            return Ok(schema.clone());
-        }
-
+    fn introspect_target(&self, connection_id: Uuid) -> Result<IntrospectTarget, Error> {
         let connection_entry = self
             .connections
             .get(&connection_id)
             .with_context(|| format!("Connection not found: {}", connection_id))?;
 
-        let connection = connection_entry.value();
-
-        let schema = match &connection.database {
+        match &connection_entry.value().database {
             // TODO(dialect-parity, #89): CockroachDB shares the Postgres
             // introspection path. Some Postgres catalog queries differ on
             // CockroachDB; the `dialect` field is now threaded into
@@ -43,45 +55,48 @@ impl<'a> MetadataService<'a> {
                 client: Some(client),
                 dialect,
                 ..
-            } => postgres::schema::get_database_schema(client, *dialect).await?,
+            } => Ok(IntrospectTarget::Postgres {
+                client: Arc::clone(client),
+                dialect: *dialect,
+            }),
             Database::Postgres { client: None, .. } => {
-                return Err(Error::Any(anyhow!("Postgres connection not active")))
+                Err(Error::Any(anyhow!("Postgres connection not active")))
             }
             Database::SQLite {
                 connection: Some(conn),
                 ..
-            } => sqlite::schema::get_database_schema(Arc::clone(conn)).await?,
+            } => Ok(IntrospectTarget::Sqlite(Arc::clone(conn))),
             Database::SQLite {
                 connection: None, ..
-            } => return Err(Error::Any(anyhow!("SQLite connection not active"))),
+            } => Err(Error::Any(anyhow!("SQLite connection not active"))),
             Database::DuckDB {
                 connection: Some(conn),
                 ..
-            } => conn.get_schema().await?,
+            } => Ok(IntrospectTarget::DuckDb(Arc::clone(conn))),
             Database::DuckDB {
                 connection: None, ..
-            } => return Err(Error::Any(anyhow!("DuckDB connection not active"))),
+            } => Err(Error::Any(anyhow!("DuckDB connection not active"))),
             Database::LibSQL {
                 connection: Some(conn),
                 ..
-            } => crate::database::libsql::schema::get_database_schema(Arc::clone(conn)).await?,
+            } => Ok(IntrospectTarget::LibSql(Arc::clone(conn))),
             Database::LibSQL {
                 connection: None, ..
-            } => return Err(Error::Any(anyhow!("LibSQL connection not active"))),
+            } => Err(Error::Any(anyhow!("LibSQL connection not active"))),
             Database::D1 {
                 connection: Some(http),
                 ..
-            } => crate::database::d1::schema::get_database_schema(http).await?,
+            } => Ok(IntrospectTarget::D1(Arc::clone(http))),
             Database::D1 {
                 connection: None, ..
-            } => return Err(Error::Any(anyhow!("Cloudflare D1 connection not active"))),
+            } => Err(Error::Any(anyhow!("Cloudflare D1 connection not active"))),
             Database::Posthog {
                 connection: Some(http),
                 ..
-            } => crate::database::posthog::schema::get_database_schema(http).await?,
+            } => Ok(IntrospectTarget::Posthog(Arc::clone(http))),
             Database::Posthog {
                 connection: None, ..
-            } => return Err(Error::Any(anyhow!("PostHog connection not active"))),
+            } => Err(Error::Any(anyhow!("PostHog connection not active"))),
             // TODO(dialect-parity, #88): MariaDB shares the MySQL introspection
             // path. MariaDB-specific types (UUID, INET4/INET6) and some
             // information_schema differences need a dialect branch; the
@@ -92,9 +107,53 @@ impl<'a> MetadataService<'a> {
                 pool: Some(pool),
                 dialect,
                 ..
-            } => crate::database::mysql::schema::get_database_schema(pool.clone(), *dialect).await?,
+            } => Ok(IntrospectTarget::MySql {
+                pool: Arc::clone(pool),
+                dialect: *dialect,
+            }),
             Database::MySQL { pool: None, .. } => {
-                return Err(Error::Any(anyhow!("MySQL connection not active")))
+                Err(Error::Any(anyhow!("MySQL connection not active")))
+            }
+        }
+    }
+
+    pub async fn get_database_schema(
+        &self,
+        connection_id: Uuid,
+    ) -> Result<Arc<DatabaseSchema>, Error> {
+        if let Some(schema) = self.schemas.get(&connection_id) {
+            return Ok(schema.clone());
+        }
+
+        // Serialize introspections per connection: the loser of a concurrent
+        // race waits here and then returns the winner's cached schema instead
+        // of running the whole introspection a second time.
+        let lock = self.schema_locks.entry(connection_id).or_default().clone();
+        let _guard = lock.lock().await;
+
+        if let Some(schema) = self.schemas.get(&connection_id) {
+            return Ok(schema.clone());
+        }
+
+        let target = self.introspect_target(connection_id)?;
+
+        let schema = match target {
+            IntrospectTarget::Postgres { client, dialect } => {
+                postgres::schema::get_database_schema(&client, dialect).await?
+            }
+            IntrospectTarget::Sqlite(conn) => sqlite::schema::get_database_schema(conn).await?,
+            IntrospectTarget::DuckDb(conn) => conn.get_schema().await?,
+            IntrospectTarget::LibSql(conn) => {
+                crate::database::libsql::schema::get_database_schema(conn).await?
+            }
+            IntrospectTarget::D1(http) => {
+                crate::database::d1::schema::get_database_schema(&http).await?
+            }
+            IntrospectTarget::Posthog(http) => {
+                crate::database::posthog::schema::get_database_schema(&http).await?
+            }
+            IntrospectTarget::MySql { pool, dialect } => {
+                crate::database::mysql::schema::get_database_schema(pool, dialect).await?
             }
         };
 

--- a/apps/desktop/src-tauri/src/database/services/mutation.rs
+++ b/apps/desktop/src-tauri/src/database/services/mutation.rs
@@ -62,7 +62,7 @@ impl<'a> MutationService<'a> {
         column_name: String,
         new_value: serde_json::Value,
     ) -> Result<MutationResult, Error> {
-        let (adapter, cid) = self.write_adapter(connection_id)?;
+        let (adapter, _) = self.write_adapter(connection_id)?;
         let result = adapter
             .update_cell(
                 table_name,
@@ -73,7 +73,6 @@ impl<'a> MutationService<'a> {
                 new_value,
             )
             .await?;
-        self.schemas.remove(&cid);
         Ok(result)
     }
 
@@ -114,13 +113,19 @@ impl<'a> MutationService<'a> {
         let (adapter, cid) = self.write_adapter(connection_id)?;
         let result = adapter
             .delete_rows(
-                table_name,
-                schema_name,
+                table_name.clone(),
+                schema_name.clone(),
                 primary_key_column,
                 primary_key_values,
             )
             .await?;
-        self.schemas.remove(&cid);
+        crate::database::schema_cache::patch_row_count(
+            self.schemas,
+            cid,
+            &table_name,
+            schema_name.as_deref(),
+            crate::database::schema_cache::RowCountDelta::Add(-(result.affected_rows as i64)),
+        );
         Ok(result)
     }
 
@@ -134,9 +139,15 @@ impl<'a> MutationService<'a> {
     ) -> Result<MutationResult, Error> {
         let (adapter, cid) = self.write_adapter(connection_id)?;
         let result = adapter
-            .insert_row(table_name, schema_name, row_data)
+            .insert_row(table_name.clone(), schema_name.clone(), row_data)
             .await?;
-        self.schemas.remove(&cid);
+        crate::database::schema_cache::patch_row_count(
+            self.schemas,
+            cid,
+            &table_name,
+            schema_name.as_deref(),
+            crate::database::schema_cache::RowCountDelta::Add(1),
+        );
         Ok(result)
     }
 
@@ -151,13 +162,19 @@ impl<'a> MutationService<'a> {
         let (adapter, cid) = self.write_adapter(connection_id)?;
         let result = adapter
             .duplicate_row(
-                table_name,
-                schema_name,
+                table_name.clone(),
+                schema_name.clone(),
                 primary_key_column,
                 primary_key_value,
             )
             .await?;
-        self.schemas.remove(&cid);
+        crate::database::schema_cache::patch_row_count(
+            self.schemas,
+            cid,
+            &table_name,
+            schema_name.as_deref(),
+            crate::database::schema_cache::RowCountDelta::Add(1),
+        );
         Ok(result)
     }
 
@@ -458,9 +475,15 @@ impl<'a> MutationService<'a> {
     ) -> Result<TruncateResult, Error> {
         let (adapter, cid) = self.write_adapter(connection_id)?;
         let result = adapter
-            .truncate_table(table_name, schema_name, cascade)
+            .truncate_table(table_name.clone(), schema_name.clone(), cascade)
             .await?;
-        self.schemas.remove(&cid);
+        crate::database::schema_cache::patch_row_count(
+            self.schemas,
+            cid,
+            &table_name,
+            schema_name.as_deref(),
+            crate::database::schema_cache::RowCountDelta::Zero,
+        );
         Ok(result)
     }
 
@@ -477,7 +500,7 @@ impl<'a> MutationService<'a> {
         }
         let (adapter, cid) = self.write_adapter(connection_id)?;
         let result = adapter.truncate_database(schema_name, confirm).await?;
-        self.schemas.remove(&cid);
+        crate::database::schema_cache::zero_all_row_counts(self.schemas, cid);
         Ok(result)
     }
 

--- a/apps/desktop/src-tauri/src/database/services/tests.rs
+++ b/apps/desktop/src-tauri/src/database/services/tests.rs
@@ -43,11 +43,13 @@ mod tests {
         // Create minimal dependencies - no Tauri, no AppState
         let connections: DashMap<Uuid, DatabaseConnection> = DashMap::new();
         let schemas: DashMap<Uuid, Arc<DatabaseSchema>> = DashMap::new();
+        let schema_locks: DashMap<Uuid, Arc<tokio::sync::Mutex<()>>> = DashMap::new();
 
         // Construct the service with explicit dependencies
         let _svc = MetadataService {
             connections: &connections,
             schemas: &schemas,
+            schema_locks: &schema_locks,
         };
 
         // Service constructed successfully without Tauri runtime

--- a/apps/desktop/src-tauri/src/database/sqlite/schema.rs
+++ b/apps/desktop/src-tauri/src/database/sqlite/schema.rs
@@ -1,176 +1,163 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
-use anyhow::Context;
 use rusqlite::Connection;
 
 use crate::{
-    database::types::{ColumnInfo, DatabaseSchema, ForeignKeyInfo, IndexInfo, TableInfo},
+    database::sqlite_introspection::{
+        assemble, CollapsedQueries, RawColumn, RawForeignKey, RawIndexColumn, RawTable,
+    },
+    database::types::DatabaseSchema,
     Error,
 };
 
+/// Introspects the schema in four constant queries via the pragma table-valued
+/// functions, instead of a 5-queries-per-table PRAGMA loop. Row counts are
+/// filled in by the background row-count refresher, so a large file never
+/// blocks the first paint behind full-table `COUNT(*)` scans. The whole read
+/// runs in one `spawn_blocking` holding the connection mutex once.
 pub async fn get_database_schema(conn: Arc<Mutex<Connection>>) -> Result<DatabaseSchema, Error> {
     tauri::async_runtime::spawn_blocking(move || {
         let conn = conn
             .lock()
             .map_err(|_| Error::Internal("SQLite connection mutex poisoned".into()))?;
-
-        // Get all table names
-        let mut tables_stmt = conn.prepare(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
-        )?;
-        let table_names: Vec<String> = tables_stmt
-            .query_map([], |row| row.get::<_, String>(0))?
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let mut tables = Vec::new();
-        let mut unique_columns_set = HashSet::new();
-
-        for table_name in table_names {
-            // Get column info including primary key status
-            // PRAGMA table_info returns: cid, name, type, notnull, dflt_value, pk
-            let pragma_query = format!("PRAGMA table_info('{}')", table_name);
-            let mut col_stmt = conn
-                .prepare(&pragma_query)
-                .context("Failed to prepare PRAGMA table_info query")?;
-
-            let col_rows = col_stmt.query_map([], |row| {
-                let column_name: String = row.get(1)?;
-                let data_type: String = row.get(2)?;
-                let not_null: bool = row.get::<_, i32>(3)? != 0;
-                let default_value: Option<String> = row.get(4)?;
-                let pk: i32 = row.get(5)?; // pk > 0 means it's part of the primary key
-
-                Ok((column_name, data_type, !not_null, default_value, pk > 0))
-            })?;
-
-            // Get foreign keys for this table
-            let fk_query = format!("PRAGMA foreign_key_list('{}')", table_name);
-            let mut fk_stmt = conn
-                .prepare(&fk_query)
-                .context("Failed to prepare PRAGMA foreign_key_list query")?;
-
-            // foreign_key_list returns: id, seq, table, from, to, on_update, on_delete, match
-            let fk_map: HashMap<String, ForeignKeyInfo> = fk_stmt
-                .query_map([], |row| {
-                    let from_column: String = row.get(3)?;
-                    let ref_table: String = row.get(2)?;
-                    let ref_column: String = row.get(4)?;
-                    Ok((from_column, ref_table, ref_column))
-                })?
-                .filter_map(|r| r.ok())
-                .map(|(from, ref_table, ref_column)| {
-                    (
-                        from,
-                        ForeignKeyInfo {
-                            referenced_table: ref_table,
-                            referenced_column: ref_column,
-                            referenced_schema: String::new(), // SQLite doesn't have schemas
-                        },
-                    )
-                })
-                .collect();
-
-            // Get row count estimate
-            let count_query = format!("SELECT COUNT(*) FROM \"{}\"", table_name);
-            let row_count: Option<u64> = conn
-                .query_row(&count_query, [], |row| row.get::<_, i64>(0))
-                .ok()
-                .map(|c| c as u64);
-
-            // Get Indexes
-            let index_list_query = format!("PRAGMA index_list('{}')", table_name);
-            let mut index_stmt = conn.prepare(&index_list_query)?;
-
-            // index_list returns: seq, name, unique, origin, partial
-            let mut indexes = Vec::new();
-            let index_info_rows = index_stmt.query_map([], |row| {
-                let name: String = row.get(1)?;
-                let is_unique: bool = row.get::<_, i32>(2)? != 0;
-                Ok((name, is_unique))
-            })?;
-
-            for idx in index_info_rows {
-                if let Ok((name, is_unique)) = idx {
-                    // Get columns for this index
-                    let index_info_query = format!("PRAGMA index_info('{}')", name);
-                    let mut info_stmt = conn.prepare(&index_info_query)?;
-
-                    let column_names: Vec<String> = info_stmt
-                        .query_map([], |row| row.get(2))?
-                        .collect::<Result<Vec<_>, _>>()?;
-
-                    indexes.push(IndexInfo {
-                        name,
-                        column_names,
-                        is_unique,
-                        is_primary: false, // SQLite PKs are handled separately usually, but explicit indexes are listed here
-                    });
-                }
-            }
-
-            // Check if this table has AUTOINCREMENT by examining sqlite_master
-            // AUTOINCREMENT only works with INTEGER PRIMARY KEY
-            let autoincrement_query = format!(
-                "SELECT sql FROM sqlite_master WHERE type='table' AND name='{}'",
-                table_name
-            );
-            let table_sql: String = conn
-                .query_row(&autoincrement_query, [], |row| row.get(0))
-                .unwrap_or_default();
-            let has_autoincrement = table_sql.to_uppercase().contains("AUTOINCREMENT");
-
-            let mut columns = Vec::new();
-            let mut primary_key_columns = Vec::new();
-
-            for col_result in col_rows {
-                let (column_name, data_type, is_nullable, default_value, is_primary_key) =
-                    col_result?;
-
-                unique_columns_set.insert(column_name.clone());
-
-                if is_primary_key {
-                    primary_key_columns.push(column_name.clone());
-                }
-
-                // Detect auto-increment: INTEGER PRIMARY KEY with AUTOINCREMENT or ROWID alias
-                let is_auto_increment = is_primary_key
-                    && data_type.to_uppercase() == "INTEGER"
-                    && (has_autoincrement || primary_key_columns.len() == 1);
-
-                let foreign_key = fk_map.get(&column_name).cloned();
-
-                columns.push(ColumnInfo {
-                    name: column_name,
-                    data_type,
-                    is_nullable,
-                    default_value,
-                    is_primary_key,
-                    is_auto_increment,
-                    foreign_key,
-                    allowed_values: None,
-                });
-            }
-
-            tables.push(TableInfo {
-                name: table_name,
-                schema: String::new(), // SQLite doesn't have schemas
-                columns,
-                primary_key_columns,
-                row_count_estimate: row_count,
-                indexes,
-            });
-        }
-
-        let unique_columns = unique_columns_set.into_iter().collect();
-
-        Ok(DatabaseSchema {
-            tables,
-            schemas: vec![],
-            unique_columns,
-        }) as Result<_, Error>
+        introspect(&conn)
     })
     .await?
+}
+
+fn introspect(conn: &Connection) -> Result<DatabaseSchema, Error> {
+    let mut tables_stmt = conn.prepare(CollapsedQueries::TABLES)?;
+    let raw_tables: Vec<RawTable> = tables_stmt
+        .query_map([], |row| {
+            Ok(RawTable {
+                name: row.get(0)?,
+                create_sql: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut columns_stmt = conn.prepare(CollapsedQueries::COLUMNS)?;
+    let raw_columns: Vec<RawColumn> = columns_stmt
+        .query_map([], |row| {
+            Ok(RawColumn {
+                table: row.get(0)?,
+                name: row.get(1)?,
+                data_type: row.get(2)?,
+                not_null: row.get::<_, i32>(3)? != 0,
+                default_value: row.get(4)?,
+                is_primary_key: row.get::<_, i32>(5)? > 0,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut fk_stmt = conn.prepare(CollapsedQueries::FOREIGN_KEYS)?;
+    let raw_foreign_keys: Vec<RawForeignKey> = fk_stmt
+        .query_map([], |row| {
+            Ok(RawForeignKey {
+                table: row.get(0)?,
+                referenced_table: row.get(1)?,
+                from_column: row.get(2)?,
+                referenced_column: row.get(3)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut index_stmt = conn.prepare(CollapsedQueries::INDEXES)?;
+    let raw_index_columns: Vec<RawIndexColumn> = index_stmt
+        .query_map([], |row| {
+            Ok(RawIndexColumn {
+                table: row.get(0)?,
+                index: row.get(1)?,
+                is_unique: row.get::<_, i32>(2)? != 0,
+                column: row.get(3)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(assemble(
+        raw_tables,
+        raw_columns,
+        raw_foreign_keys,
+        raw_index_columns,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory sqlite");
+        conn.execute_batch(
+            "CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL DEFAULT 'x@y.z',
+                nickname TEXT
+            );
+            CREATE UNIQUE INDEX users_email ON users (email);
+            CREATE TABLE posts (
+                id INTEGER PRIMARY KEY,
+                user_id INTEGER REFERENCES users(id),
+                title TEXT
+            );
+            CREATE INDEX posts_user_title ON posts (user_id, title);
+            INSERT INTO users (email) VALUES ('a@b.c');",
+        )
+        .expect("fixture schema");
+        conn
+    }
+
+    #[test]
+    fn introspects_fixture_in_constant_queries() {
+        let conn = fixture();
+        let schema = introspect(&conn).expect("introspection");
+
+        assert_eq!(schema.tables.len(), 2);
+        let users = schema.tables.iter().find(|t| t.name == "users").unwrap();
+        assert_eq!(users.primary_key_columns, vec!["id"]);
+        assert!(users.columns[0].is_auto_increment);
+        let email = users.columns.iter().find(|c| c.name == "email").unwrap();
+        assert!(!email.is_nullable);
+        assert_eq!(email.default_value.as_deref(), Some("'x@y.z'"));
+        let email_index = users
+            .indexes
+            .iter()
+            .find(|i| i.name == "users_email")
+            .unwrap();
+        assert!(email_index.is_unique);
+        assert_eq!(email_index.column_names, vec!["email"]);
+
+        let posts = schema.tables.iter().find(|t| t.name == "posts").unwrap();
+        let user_id = posts.columns.iter().find(|c| c.name == "user_id").unwrap();
+        let fk = user_id.foreign_key.as_ref().expect("fk detected");
+        assert_eq!(fk.referenced_table, "users");
+        assert_eq!(fk.referenced_column, "id");
+        let composite = posts
+            .indexes
+            .iter()
+            .find(|i| i.name == "posts_user_title")
+            .unwrap();
+        assert_eq!(composite.column_names, vec!["user_id", "title"]);
+
+        // Counts are deferred to the background refresher.
+        assert!(schema.tables.iter().all(|t| t.row_count_estimate.is_none()));
+    }
+
+    #[test]
+    fn empty_database_yields_empty_schema() {
+        let conn = Connection::open_in_memory().expect("in-memory sqlite");
+        let schema = introspect(&conn).expect("introspection");
+        assert!(schema.tables.is_empty());
+        assert!(schema.unique_columns.is_empty());
+    }
+
+    #[test]
+    fn weird_table_names_survive() {
+        let conn = Connection::open_in_memory().expect("in-memory sqlite");
+        conn.execute_batch("CREATE TABLE \"we ird\" (id INTEGER PRIMARY KEY, note TEXT);")
+            .expect("weird table");
+        let schema = introspect(&conn).expect("introspection");
+        assert_eq!(schema.tables[0].name, "we ird");
+        assert_eq!(schema.tables[0].columns.len(), 2);
+    }
 }

--- a/apps/desktop/src-tauri/src/database/sqlite_introspection.rs
+++ b/apps/desktop/src-tauri/src/database/sqlite_introspection.rs
@@ -1,0 +1,360 @@
+//! Shared schema assembly for the SQLite family (SQLite, libSQL, D1).
+//!
+//! All three engines expose the same catalog surface (`sqlite_master` plus the
+//! `table_info` / `foreign_key_list` / `index_list` / `index_info` PRAGMAs);
+//! only the transport differs. Each engine fetches raw rows its own way —
+//! ideally in a constant number of round trips — and hands them here, so the
+//! grouping, primary-key, auto-increment and index logic exists once.
+//!
+//! Row counts are deliberately absent: the introspection path returns
+//! `row_count_estimate: None` and the background row-count refresher fills
+//! counts in afterwards.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::database::types::{ColumnInfo, DatabaseSchema, ForeignKeyInfo, IndexInfo, TableInfo};
+
+pub struct RawTable {
+    pub name: String,
+    /// The table's CREATE statement from `sqlite_master.sql`, used for
+    /// AUTOINCREMENT detection.
+    pub create_sql: String,
+}
+
+/// One `PRAGMA table_info` row; must arrive in `cid` order per table.
+pub struct RawColumn {
+    pub table: String,
+    pub name: String,
+    pub data_type: String,
+    pub not_null: bool,
+    pub default_value: Option<String>,
+    pub is_primary_key: bool,
+}
+
+/// One `PRAGMA foreign_key_list` row.
+pub struct RawForeignKey {
+    pub table: String,
+    pub from_column: String,
+    pub referenced_table: String,
+    pub referenced_column: String,
+}
+
+/// One `PRAGMA index_list` × `index_info` row; must arrive in `seqno` order
+/// per index. `column` is `None` for expression index members.
+pub struct RawIndexColumn {
+    pub table: String,
+    pub index: String,
+    pub is_unique: bool,
+    pub column: Option<String>,
+}
+
+pub fn assemble(
+    raw_tables: Vec<RawTable>,
+    raw_columns: Vec<RawColumn>,
+    raw_foreign_keys: Vec<RawForeignKey>,
+    raw_index_columns: Vec<RawIndexColumn>,
+) -> DatabaseSchema {
+    let mut columns_by_table: HashMap<String, Vec<RawColumn>> = HashMap::new();
+    for column in raw_columns {
+        columns_by_table
+            .entry(column.table.clone())
+            .or_default()
+            .push(column);
+    }
+
+    let mut fks_by_table: HashMap<(String, String), ForeignKeyInfo> = HashMap::new();
+    for fk in raw_foreign_keys {
+        fks_by_table.insert(
+            (fk.table, fk.from_column),
+            ForeignKeyInfo {
+                referenced_table: fk.referenced_table,
+                referenced_column: fk.referenced_column,
+                referenced_schema: String::new(),
+            },
+        );
+    }
+
+    let mut indexes_by_table: HashMap<String, Vec<IndexInfo>> = HashMap::new();
+    for index_column in raw_index_columns {
+        let indexes = indexes_by_table.entry(index_column.table).or_default();
+        let index = match indexes.iter_mut().find(|i| i.name == index_column.index) {
+            Some(index) => index,
+            None => {
+                indexes.push(IndexInfo {
+                    name: index_column.index,
+                    column_names: Vec::new(),
+                    is_unique: index_column.is_unique,
+                    is_primary: false,
+                });
+                indexes.last_mut().expect("just pushed")
+            }
+        };
+        if let Some(column) = index_column.column {
+            index.column_names.push(column);
+        }
+    }
+
+    let mut tables = Vec::new();
+    let mut unique_columns_set = HashSet::new();
+
+    for raw_table in raw_tables {
+        let has_autoincrement = raw_table
+            .create_sql
+            .to_uppercase()
+            .contains("AUTOINCREMENT");
+        let table_columns = columns_by_table.remove(&raw_table.name).unwrap_or_default();
+
+        let mut columns = Vec::new();
+        let mut primary_key_columns = Vec::new();
+
+        for raw_column in table_columns {
+            unique_columns_set.insert(raw_column.name.clone());
+
+            if raw_column.is_primary_key {
+                primary_key_columns.push(raw_column.name.clone());
+            }
+
+            // AUTOINCREMENT requires INTEGER PRIMARY KEY; a single INTEGER pk
+            // is a rowid alias and auto-increments even without the keyword.
+            let is_auto_increment = raw_column.is_primary_key
+                && raw_column.data_type.to_uppercase() == "INTEGER"
+                && (has_autoincrement || primary_key_columns.len() == 1);
+
+            let foreign_key = fks_by_table
+                .get(&(raw_table.name.clone(), raw_column.name.clone()))
+                .cloned();
+
+            columns.push(ColumnInfo {
+                name: raw_column.name,
+                data_type: raw_column.data_type,
+                is_nullable: !raw_column.not_null,
+                default_value: raw_column.default_value,
+                is_primary_key: raw_column.is_primary_key,
+                is_auto_increment,
+                foreign_key,
+                allowed_values: None,
+            });
+        }
+
+        tables.push(TableInfo {
+            name: raw_table.name.clone(),
+            schema: String::new(),
+            columns,
+            primary_key_columns,
+            row_count_estimate: None,
+            indexes: indexes_by_table.remove(&raw_table.name).unwrap_or_default(),
+        });
+    }
+
+    DatabaseSchema {
+        tables,
+        schemas: vec![],
+        unique_columns: unique_columns_set.into_iter().collect(),
+    }
+}
+
+/// The four constant introspection queries every SQLite-family engine can run
+/// instead of per-table PRAGMA loops. The pragma table-valued functions
+/// (`pragma_table_info(...)`) are plain SELECT sources, available since SQLite
+/// 3.16 and supported by libSQL/sqld.
+pub struct CollapsedQueries;
+
+impl CollapsedQueries {
+    pub const TABLES: &'static str = "SELECT name, sql FROM sqlite_master \
+         WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name";
+
+    pub const COLUMNS: &'static str =
+        "SELECT m.name AS tbl, p.name AS col, p.\"type\" AS col_type, \
+                p.\"notnull\" AS not_null, p.dflt_value AS dflt_value, p.pk AS pk \
+         FROM sqlite_master m JOIN pragma_table_info(m.name) p \
+         WHERE m.type='table' AND m.name NOT LIKE 'sqlite_%' \
+         ORDER BY m.name, p.cid";
+
+    pub const FOREIGN_KEYS: &'static str = "SELECT m.name AS tbl, f.\"table\" AS ref_table, f.\"from\" AS from_col, f.\"to\" AS to_col \
+         FROM sqlite_master m JOIN pragma_foreign_key_list(m.name) f \
+         WHERE m.type='table' AND m.name NOT LIKE 'sqlite_%'";
+
+    pub const INDEXES: &'static str =
+        "SELECT m.name AS tbl, il.name AS idx, il.\"unique\" AS is_unique, ii.name AS col \
+         FROM sqlite_master m \
+         JOIN pragma_index_list(m.name) il \
+         LEFT JOIN pragma_index_info(il.name) ii \
+         WHERE m.type='table' AND m.name NOT LIKE 'sqlite_%' \
+         ORDER BY m.name, il.seq, ii.seqno";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn users_table() -> RawTable {
+        RawTable {
+            name: "users".into(),
+            create_sql: "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT)".into(),
+        }
+    }
+
+    #[test]
+    fn assembles_columns_pks_and_rowid_autoincrement() {
+        let schema = assemble(
+            vec![users_table()],
+            vec![
+                RawColumn {
+                    table: "users".into(),
+                    name: "id".into(),
+                    data_type: "INTEGER".into(),
+                    not_null: true,
+                    default_value: None,
+                    is_primary_key: true,
+                },
+                RawColumn {
+                    table: "users".into(),
+                    name: "email".into(),
+                    data_type: "TEXT".into(),
+                    not_null: false,
+                    default_value: None,
+                    is_primary_key: false,
+                },
+            ],
+            vec![],
+            vec![],
+        );
+        let table = &schema.tables[0];
+        assert_eq!(table.primary_key_columns, vec!["id"]);
+        assert!(table.columns[0].is_auto_increment);
+        assert!(!table.columns[1].is_auto_increment);
+        assert!(table.columns[1].is_nullable);
+        assert_eq!(table.row_count_estimate, None);
+    }
+
+    #[test]
+    fn composite_integer_pk_is_not_auto_increment_without_keyword() {
+        let schema = assemble(
+            vec![RawTable {
+                name: "pairs".into(),
+                create_sql: "CREATE TABLE pairs (a INTEGER, b INTEGER, PRIMARY KEY (a, b))".into(),
+            }],
+            vec![
+                RawColumn {
+                    table: "pairs".into(),
+                    name: "a".into(),
+                    data_type: "INTEGER".into(),
+                    not_null: true,
+                    default_value: None,
+                    is_primary_key: true,
+                },
+                RawColumn {
+                    table: "pairs".into(),
+                    name: "b".into(),
+                    data_type: "INTEGER".into(),
+                    not_null: true,
+                    default_value: None,
+                    is_primary_key: true,
+                },
+            ],
+            vec![],
+            vec![],
+        );
+        let table = &schema.tables[0];
+        // First pk column keeps the legacy single-pk heuristic; the second is
+        // provably composite and never auto-increments.
+        assert!(!table.columns[1].is_auto_increment);
+        assert_eq!(table.primary_key_columns, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn attaches_foreign_keys_to_their_column() {
+        let schema = assemble(
+            vec![
+                users_table(),
+                RawTable {
+                    name: "posts".into(),
+                    create_sql: String::new(),
+                },
+            ],
+            vec![RawColumn {
+                table: "posts".into(),
+                name: "user_id".into(),
+                data_type: "INTEGER".into(),
+                not_null: false,
+                default_value: None,
+                is_primary_key: false,
+            }],
+            vec![RawForeignKey {
+                table: "posts".into(),
+                from_column: "user_id".into(),
+                referenced_table: "users".into(),
+                referenced_column: "id".into(),
+            }],
+            vec![],
+        );
+        let posts = schema.tables.iter().find(|t| t.name == "posts").unwrap();
+        let fk = posts.columns[0].foreign_key.as_ref().unwrap();
+        assert_eq!(fk.referenced_table, "users");
+        assert_eq!(fk.referenced_column, "id");
+    }
+
+    #[test]
+    fn groups_index_columns_in_order_and_skips_expression_members() {
+        let schema = assemble(
+            vec![users_table()],
+            vec![],
+            vec![],
+            vec![
+                RawIndexColumn {
+                    table: "users".into(),
+                    index: "users_email_name".into(),
+                    is_unique: true,
+                    column: Some("email".into()),
+                },
+                RawIndexColumn {
+                    table: "users".into(),
+                    index: "users_email_name".into(),
+                    is_unique: true,
+                    column: Some("name".into()),
+                },
+                RawIndexColumn {
+                    table: "users".into(),
+                    index: "users_expr".into(),
+                    is_unique: false,
+                    column: None,
+                },
+            ],
+        );
+        let indexes = &schema.tables[0].indexes;
+        assert_eq!(indexes.len(), 2);
+        assert_eq!(indexes[0].column_names, vec!["email", "name"]);
+        assert!(indexes[0].is_unique);
+        assert!(indexes[1].column_names.is_empty());
+    }
+
+    #[test]
+    fn unique_columns_collects_every_column_name() {
+        let schema = assemble(
+            vec![users_table()],
+            vec![
+                RawColumn {
+                    table: "users".into(),
+                    name: "id".into(),
+                    data_type: "INTEGER".into(),
+                    not_null: true,
+                    default_value: None,
+                    is_primary_key: true,
+                },
+                RawColumn {
+                    table: "users".into(),
+                    name: "email".into(),
+                    data_type: "TEXT".into(),
+                    not_null: false,
+                    default_value: None,
+                    is_primary_key: false,
+                },
+            ],
+            vec![],
+            vec![],
+        );
+        let mut unique: Vec<_> = schema.unique_columns.clone();
+        unique.sort();
+        assert_eq!(unique, vec!["email", "id"]);
+    }
+}

--- a/apps/desktop/src-tauri/src/http.rs
+++ b/apps/desktop/src-tauri/src/http.rs
@@ -28,12 +28,17 @@ pub fn client() -> &'static reqwest::Client {
     })
 }
 
-/// Client for HTTP query engines (D1, PostHog): same connect timeout, longer
-/// request budget.
-pub fn query_client() -> reqwest::Client {
-    reqwest::Client::builder()
-        .connect_timeout(CONNECT_TIMEOUT)
-        .timeout(QUERY_TIMEOUT)
-        .build()
-        .expect("default reqwest client with timeouts")
+/// Shared client for HTTP query engines (D1, PostHog): same connect timeout,
+/// longer request budget. One process-wide client means TLS sessions and
+/// keep-alives are reused across connect, introspection and queries; cloning a
+/// `reqwest::Client` shares its pool.
+pub fn query_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(QUERY_TIMEOUT)
+            .build()
+            .expect("default reqwest client with timeouts")
+    })
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -43,6 +43,9 @@ pub use error::{Error, Result};
 pub struct AppState {
     pub connections: DashMap<Uuid, DatabaseConnection>,
     pub schemas: DashMap<Uuid, Arc<DatabaseSchema>>,
+    /// Per-connection introspection locks: two concurrent schema reads for the
+    /// same connection must run one introspection, not two.
+    pub schema_locks: DashMap<Uuid, Arc<tokio::sync::Mutex<()>>>,
     /// SQLite database for application data
     pub storage: Storage,
     pub stmt_manager: StatementManager,
@@ -72,6 +75,7 @@ impl AppState {
         let state = Self {
             connections: DashMap::new(),
             schemas: DashMap::new(),
+            schema_locks: DashMap::new(),
             storage,
             stmt_manager: StatementManager::new(),
             command_registry: RwLock::new(command_registry),
@@ -158,8 +162,10 @@ pub fn run() {
             let handle = app.handle();
             let monitor = ConnectionMonitor::new(handle.clone());
             let live_monitor = crate::database::LiveMonitorManager::new(handle.clone());
+            let row_count_refresher = crate::database::RowCountRefresher::new(handle.clone());
             handle.manage(monitor);
             handle.manage(live_monitor);
+            handle.manage(row_count_refresher);
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/apps/desktop/src-tauri/tests/live_db_tests.rs
+++ b/apps/desktop/src-tauri/tests/live_db_tests.rs
@@ -125,3 +125,323 @@ async fn mariadb_full_mutation_lifecycle() {
         .unwrap_or_else(|_| "mysql://root:rootpass@127.0.0.1:3306/dora".into());
     mysql_family_lifecycle(&url, MySqlDialect::MariaDb).await;
 }
+
+// ---------------------------------------------------------------------------
+// Introspection: the collapsed/parallelized schema readers against real
+// servers. These pin the connection-open overhaul: Postgres pipelined catalog
+// queries + reltuples estimates, MySQL/MariaDB DATABASE()-scoped queries over
+// two pooled connections, and libSQL's collapsed pragma-function queries
+// against sqld (the one path that cannot be proven offline).
+// ---------------------------------------------------------------------------
+
+async fn pg_client(url: &str) -> tokio_postgres::Client {
+    let (client, conn) = tokio_postgres::connect(url, tokio_postgres::NoTls)
+        .await
+        .expect("failed to connect to postgres");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    client
+}
+
+async fn pg_introspection_roundtrip(url: &str, dialect: app_lib::database::dialect::PgDialect) {
+    let client = pg_client(url).await;
+
+    client
+        .batch_execute(
+            "DROP TABLE IF EXISTS live_intro_child; DROP TABLE IF EXISTS live_intro_parent;
+             CREATE TABLE live_intro_parent (id SERIAL PRIMARY KEY, label TEXT NOT NULL);
+             CREATE TABLE live_intro_child (
+                 id SERIAL PRIMARY KEY,
+                 parent_id INT REFERENCES live_intro_parent(id),
+                 note TEXT
+             );
+             CREATE INDEX live_intro_child_note ON live_intro_child (note);
+             INSERT INTO live_intro_parent (label) VALUES ('a'), ('b');",
+        )
+        .await
+        .expect("fixture setup failed");
+
+    let schema = app_lib::database::postgres::schema::get_database_schema(&client, dialect)
+        .await
+        .expect("introspection failed");
+
+    let parent = schema
+        .tables
+        .iter()
+        .find(|t| t.name == "live_intro_parent")
+        .expect("parent table introspected");
+    assert_eq!(parent.primary_key_columns, vec!["id"]);
+    assert!(parent
+        .columns
+        .iter()
+        .any(|c| c.name == "label" && !c.is_nullable));
+
+    let child = schema
+        .tables
+        .iter()
+        .find(|t| t.name == "live_intro_child")
+        .expect("child table introspected");
+    let parent_fk = child
+        .columns
+        .iter()
+        .find(|c| c.name == "parent_id")
+        .and_then(|c| c.foreign_key.as_ref())
+        .expect("FK detected");
+    assert_eq!(parent_fk.referenced_table, "live_intro_parent");
+    assert!(child
+        .indexes
+        .iter()
+        .any(|i| i.name == "live_intro_child_note"));
+
+    client
+        .batch_execute("DROP TABLE live_intro_child; DROP TABLE live_intro_parent;")
+        .await
+        .expect("fixture teardown failed");
+}
+
+#[tokio::test]
+async fn postgres_introspection_roundtrip() {
+    if !live_enabled() {
+        eprintln!("skipping postgres_introspection_roundtrip: DORA_LIVE_DB_TESTS != 1");
+        return;
+    }
+    let url = std::env::var("DORA_POSTGRES_URL")
+        .unwrap_or_else(|_| "postgres://postgres:rootpass@127.0.0.1:5432/dora".into());
+    pg_introspection_roundtrip(&url, app_lib::database::dialect::PgDialect::Postgres).await;
+}
+
+#[tokio::test]
+async fn postgres_reltuples_estimates_after_analyze() {
+    if !live_enabled() {
+        eprintln!("skipping postgres_reltuples_estimates_after_analyze: DORA_LIVE_DB_TESTS != 1");
+        return;
+    }
+    let url = std::env::var("DORA_POSTGRES_URL")
+        .unwrap_or_else(|_| "postgres://postgres:rootpass@127.0.0.1:5432/dora".into());
+    let client = pg_client(&url).await;
+
+    client
+        .batch_execute(
+            "DROP TABLE IF EXISTS live_estimates;
+             CREATE TABLE live_estimates (id INT PRIMARY KEY);
+             INSERT INTO live_estimates SELECT generate_series(1, 500);
+             ANALYZE live_estimates;",
+        )
+        .await
+        .expect("fixture setup failed");
+
+    let schema = app_lib::database::postgres::schema::get_database_schema(
+        &client,
+        app_lib::database::dialect::PgDialect::Postgres,
+    )
+    .await
+    .expect("introspection failed");
+
+    let table = schema
+        .tables
+        .iter()
+        .find(|t| t.name == "live_estimates")
+        .expect("table introspected");
+    // reltuples comes from the catalog, so a just-ANALYZEd table reports its
+    // real cardinality without any COUNT(*) on the introspection path.
+    assert_eq!(table.row_count_estimate, Some(500));
+
+    client
+        .batch_execute("DROP TABLE live_estimates;")
+        .await
+        .expect("fixture teardown failed");
+}
+
+#[tokio::test]
+async fn cockroach_introspection_roundtrip() {
+    if !live_enabled() {
+        eprintln!("skipping cockroach_introspection_roundtrip: DORA_LIVE_DB_TESTS != 1");
+        return;
+    }
+    let url = std::env::var("DORA_COCKROACH_URL")
+        .unwrap_or_else(|_| "postgres://root@127.0.0.1:26257/defaultdb?sslmode=disable".into());
+    pg_introspection_roundtrip(&url, app_lib::database::dialect::PgDialect::CockroachDb).await;
+}
+
+async fn mysql_introspection_roundtrip(url: &str, dialect: MySqlDialect) {
+    let opts = mysql_async::Opts::from_url(url).expect("invalid database URL");
+    let pool = mysql_async::Pool::new(opts);
+
+    {
+        let mut conn = pool.get_conn().await.expect("failed to connect");
+        conn.query_drop("DROP TABLE IF EXISTS live_intro_child")
+            .await
+            .unwrap();
+        conn.query_drop("DROP TABLE IF EXISTS live_intro_parent")
+            .await
+            .unwrap();
+        conn.query_drop(
+            "CREATE TABLE live_intro_parent (id INT AUTO_INCREMENT PRIMARY KEY, label VARCHAR(32) NOT NULL)",
+        )
+        .await
+        .unwrap();
+        conn.query_drop(
+            "CREATE TABLE live_intro_child (
+                 id INT AUTO_INCREMENT PRIMARY KEY,
+                 parent_id INT,
+                 note VARCHAR(64),
+                 INDEX live_intro_child_note (note),
+                 FOREIGN KEY (parent_id) REFERENCES live_intro_parent(id)
+             )",
+        )
+        .await
+        .unwrap();
+    }
+
+    let schema =
+        app_lib::database::mysql::schema::get_database_schema(Arc::new(pool.clone()), dialect)
+            .await
+            .expect("introspection failed");
+
+    let parent = schema
+        .tables
+        .iter()
+        .find(|t| t.name == "live_intro_parent")
+        .expect("parent table introspected");
+    assert_eq!(parent.primary_key_columns, vec!["id"]);
+    assert!(parent
+        .columns
+        .iter()
+        .any(|c| c.name == "id" && c.is_auto_increment));
+
+    let child = schema
+        .tables
+        .iter()
+        .find(|t| t.name == "live_intro_child")
+        .expect("child table introspected");
+    let parent_fk = child
+        .columns
+        .iter()
+        .find(|c| c.name == "parent_id")
+        .and_then(|c| c.foreign_key.as_ref())
+        .expect("FK detected");
+    assert_eq!(parent_fk.referenced_table, "live_intro_parent");
+    assert!(child
+        .indexes
+        .iter()
+        .any(|i| i.name == "live_intro_child_note"));
+
+    {
+        let mut conn = pool.get_conn().await.unwrap();
+        conn.query_drop("DROP TABLE live_intro_child")
+            .await
+            .unwrap();
+        conn.query_drop("DROP TABLE live_intro_parent")
+            .await
+            .unwrap();
+    }
+    pool.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn mysql_introspection_roundtrip_live() {
+    if !live_enabled() {
+        eprintln!("skipping mysql_introspection_roundtrip_live: DORA_LIVE_DB_TESTS != 1");
+        return;
+    }
+    let url = std::env::var("DORA_MYSQL_URL")
+        .unwrap_or_else(|_| "mysql://root:rootpass@127.0.0.1:3307/dora".into());
+    mysql_introspection_roundtrip(&url, MySqlDialect::MySql).await;
+}
+
+#[tokio::test]
+async fn mariadb_introspection_roundtrip_live() {
+    if !live_enabled() {
+        eprintln!("skipping mariadb_introspection_roundtrip_live: DORA_LIVE_DB_TESTS != 1");
+        return;
+    }
+    let url = std::env::var("DORA_MARIADB_URL")
+        .unwrap_or_else(|_| "mysql://root:rootpass@127.0.0.1:3306/dora".into());
+    mysql_introspection_roundtrip(&url, MySqlDialect::MariaDb).await;
+}
+
+/// The decisive sqld test: the collapsed pragma-function introspection must be
+/// accepted by a real sqld server, not just by local SQLite. Calls the
+/// collapsed path directly so a sqld parser rejection fails the test instead
+/// of silently taking the per-table fallback.
+#[tokio::test]
+async fn libsql_collapsed_introspection_against_sqld() {
+    if !live_enabled() {
+        eprintln!("skipping libsql_collapsed_introspection_against_sqld: DORA_LIVE_DB_TESTS != 1");
+        return;
+    }
+    let url = std::env::var("DORA_LIBSQL_URL").unwrap_or_else(|_| "http://127.0.0.1:8081".into());
+
+    let db = libsql::Builder::new_remote(url, String::new())
+        .build()
+        .await
+        .expect("failed to build sqld client");
+    let conn = db.connect().expect("failed to connect to sqld");
+
+    conn.execute("DROP TABLE IF EXISTS live_intro_child", ())
+        .await
+        .unwrap();
+    conn.execute("DROP TABLE IF EXISTS live_intro_parent", ())
+        .await
+        .unwrap();
+    conn.execute(
+        "CREATE TABLE live_intro_parent (id INTEGER PRIMARY KEY, label TEXT NOT NULL)",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "CREATE TABLE live_intro_child (
+             id INTEGER PRIMARY KEY,
+             parent_id INTEGER REFERENCES live_intro_parent(id),
+             note TEXT
+         )",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "CREATE INDEX live_intro_child_note ON live_intro_child (note)",
+        (),
+    )
+    .await
+    .unwrap();
+
+    let schema = app_lib::database::libsql::schema::collapsed_introspect(&conn)
+        .await
+        .expect("sqld rejected the collapsed pragma-function introspection");
+
+    let parent = schema
+        .tables
+        .iter()
+        .find(|t| t.name == "live_intro_parent")
+        .expect("parent table introspected");
+    assert_eq!(parent.primary_key_columns, vec!["id"]);
+
+    let child = schema
+        .tables
+        .iter()
+        .find(|t| t.name == "live_intro_child")
+        .expect("child table introspected");
+    let parent_fk = child
+        .columns
+        .iter()
+        .find(|c| c.name == "parent_id")
+        .and_then(|c| c.foreign_key.as_ref())
+        .expect("FK detected");
+    assert_eq!(parent_fk.referenced_table, "live_intro_parent");
+    assert!(child
+        .indexes
+        .iter()
+        .any(|i| i.name == "live_intro_child_note"));
+    // Counts are deferred to the background refresher on every engine.
+    assert!(schema.tables.iter().all(|t| t.row_count_estimate.is_none()));
+
+    conn.execute("DROP TABLE live_intro_child", ())
+        .await
+        .unwrap();
+    conn.execute("DROP TABLE live_intro_parent", ())
+        .await
+        .unwrap();
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,7 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import { getAppearanceSettings, applyAppearanceToDOM } from '@studio/shared/lib/appearance-store'
 import { loadFontPair } from '@studio/shared/lib/font-loader'
-import { hydrateWorkspaceFromBootstrap } from '@studio/core/workspace-store'
+import {
+	hydrateWorkspaceFromBootstrap,
+	initTableSnapshotPersistence
+} from '@studio/core/workspace-store'
 import { dismissBootScreen, preloadBootAssets, revealMainWindow } from './boot-screen'
 import App from './App.tsx'
 import '@studio/styles.css'
@@ -21,6 +24,10 @@ async function boot() {
 	// The workspace store is filled before the first render, so the shell paints
 	// from normalized state instead of a chain of requests.
 	await Promise.all([fontPromise, preloadBootAssets(), hydrateWorkspaceFromBootstrap()])
+
+	// After bootstrap so the gating settings document is available; before
+	// render so restored tables paint from the persisted snapshot immediately.
+	initTableSnapshotPersistence()
 
 	createRoot(document.getElementById('root')!).render(<App />)
 

--- a/packages/studio/src/core/data-provider/adapters/tauri.ts
+++ b/packages/studio/src/core/data-provider/adapters/tauri.ts
@@ -7,6 +7,7 @@ import type {
 	ColumnDefinition
 } from '@studio/features/database-studio/types'
 import { buildWhereClauseFrom } from '../filter-sql'
+import { nextPollDelay, QUERY_POLL_INITIAL_MS } from '../poll-delay'
 import type {
 	ConnectionInfo,
 	DatabaseSchema,
@@ -95,7 +96,6 @@ const formatError = formatBackendError
  * tables, and the timeout fell through to a misleading "Failed to get columns".
  */
 const QUERY_POLL_TIMEOUT_MS = 30_000
-const QUERY_POLL_INTERVAL_MS = 100
 const QUERY_STREAMING_ENABLED =
 	(
 		import.meta as unknown as {
@@ -132,6 +132,7 @@ const STREAM_PAGE_CACHE_LIMIT = 8
  */
 async function pollQueryToCompletion(queryId: number): Promise<QueryPollResult> {
 	const deadline = performance.now() + QUERY_POLL_TIMEOUT_MS
+	let interval = QUERY_POLL_INITIAL_MS
 
 	while (performance.now() < deadline) {
 		const fetchResult = await commands.fetchQuery(queryId)
@@ -150,7 +151,8 @@ async function pollQueryToCompletion(queryId: number): Promise<QueryPollResult> 
 		if (pageInfo.status === 'Error') {
 			return { kind: 'error', message: pageInfo.error || 'Query failed' }
 		}
-		await delay(QUERY_POLL_INTERVAL_MS)
+		await delay(interval)
+		interval = nextPollDelay(interval)
 	}
 	return { kind: 'timeout' }
 }

--- a/packages/studio/src/core/data-provider/connection-phase.ts
+++ b/packages/studio/src/core/data-provider/connection-phase.ts
@@ -1,0 +1,37 @@
+import { useSyncExternalStore } from 'react'
+
+export type ConnectionPhase = 'connecting' | 'introspecting'
+
+const phases = new Map<string, ConnectionPhase>()
+const listeners = new Set<() => void>()
+
+/**
+ * Ephemeral per-connection open progress, written by the schema queryFn and
+ * read by loading surfaces so a long connect (e.g. a suspended Neon compute
+ * waking up) shows a stage instead of an unexplained skeleton. Deliberately
+ * not workspace-store state: it exists only while one fetch is in flight and
+ * must be writable from plain async code.
+ */
+export function setConnectionPhase(connectionId: string, phase: ConnectionPhase | null): void {
+	if (phase === null) {
+		phases.delete(connectionId)
+	} else {
+		phases.set(connectionId, phase)
+	}
+	for (const listener of listeners) {
+		listener()
+	}
+}
+
+function subscribe(listener: () => void): () => void {
+	listeners.add(listener)
+	return () => {
+		listeners.delete(listener)
+	}
+}
+
+export function useConnectionPhase(connectionId: string | undefined): ConnectionPhase | null {
+	return useSyncExternalStore(subscribe, () =>
+		connectionId ? (phases.get(connectionId) ?? null) : null
+	)
+}

--- a/packages/studio/src/core/data-provider/hooks.ts
+++ b/packages/studio/src/core/data-provider/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useMutation, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type {
 	SortDescriptor,
 	FilterDescriptor,
@@ -7,19 +7,18 @@ import type {
 } from '@studio/features/database-studio/types'
 import type { Connection } from '@studio/features/connections/types'
 import type { DatabaseInfo, JsonValue } from '@studio/lib/bindings'
-import {
-	applyConnectResult,
-	dataFileSourcesQueryKey
-} from '@studio/features/database-studio/hooks/use-data-file-sources'
+import { dataFileSourcesQueryKey } from '@studio/features/database-studio/hooks/use-data-file-sources'
 import {
 	dropTableSnapshot,
 	patchTableSnapshotRows,
+	readSchemaEntry,
 	readTableSnapshot,
 	setConnections,
 	setConnectionsError,
 	setConnectionsLoading
 } from '@studio/core/workspace-store'
-import { useAdapter } from './context'
+import { useAdapter, useIsTauri } from './context'
+import { schemaQueryOptions } from './schema-query'
 import { getAdapterError } from './types'
 
 const schemaRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
@@ -206,35 +205,72 @@ export function useSchema(connectionId: string | undefined) {
 	)
 
 	return useQuery({
-		queryKey: ['schema', connectionId],
-		queryFn: async function () {
-			if (!connectionId) throw new Error('No connection ID')
-
-			const connectResult = await adapter.connectToDatabase(connectionId)
-			if (!connectResult.ok) {
-				throw new Error(getAdapterError(connectResult))
-			}
-			applyConnectResult(queryClient, connectionId, connectResult.data)
-
-			if (!connectResult.data.connected) {
-				throw new Error('Could not connect to this database')
-			}
-
-			const res = await adapter.getSchema(connectionId)
-			if (!res.ok) throw new Error(getAdapterError(res))
-			return res.data
-		},
+		...schemaQueryOptions(adapter, queryClient, connectionId ?? ''),
 		enabled: !!connectionId,
-		retry: false,
+		// Seed from the workspace-store mirror: a bootstrap entry carries
+		// `fetchedAt: 0`, so the sidebar paints synchronously after a webview
+		// reload while react-query still refetches in the background; an
+		// in-session mirror carries a real timestamp and skips the refetch
+		// within staleTime.
+		initialData: function () {
+			return connectionId ? readSchemaEntry(connectionId)?.schema : undefined
+		},
+		initialDataUpdatedAt: function () {
+			return connectionId ? readSchemaEntry(connectionId)?.fetchedAt : undefined
+		},
 		// Schema freshness is driven explicitly by `dora-schema-refresh` events
 		// (DDL, imports, data mutations), so we don't auto-refetch on focus or
 		// reconnect. Without this, closing a focus-trapping modal like the
 		// connection dialog re-runs connect + getSchema and reloads everything,
 		// even when nothing was edited.
-		staleTime: 5 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		refetchOnReconnect: false
 	})
+}
+
+/**
+ * Invalidates the schema query when the backend's background exact-count task
+ * patches its cached schema. Mounted exactly once (workspace startup); the
+ * refetch this triggers hits the already-patched backend cache, so it is one
+ * cheap IPC, not a re-introspection. Deliberately not a `dora-schema-refresh`
+ * dispatch — that event's other listeners treat it as "structure changed".
+ */
+export function useSchemaRowCountListener() {
+	const isTauri = useIsTauri()
+	const queryClient = useQueryClient()
+
+	useEffect(
+		function listenForRowCountUpdates() {
+			if (!isTauri) return
+			let disposed = false
+			let unlisten: (() => void) | undefined
+
+			void import('@tauri-apps/api/event')
+				.then(function ({ listen }) {
+					return listen<{ connectionId: string }>(
+						'schema-row-counts-updated',
+						function (event) {
+							void queryClient.invalidateQueries({
+								queryKey: ['schema', event.payload.connectionId]
+							})
+						}
+					)
+				})
+				.then(function (cleanup) {
+					if (disposed) cleanup()
+					else unlisten = cleanup
+				})
+				.catch(function (error) {
+					console.warn('Failed to listen for row count updates:', error)
+				})
+
+			return function cleanup() {
+				disposed = true
+				unlisten?.()
+			}
+		},
+		[isTauri, queryClient]
+	)
 }
 
 export function useExecuteQuery() {

--- a/packages/studio/src/core/data-provider/poll-delay.ts
+++ b/packages/studio/src/core/data-provider/poll-delay.ts
@@ -1,0 +1,11 @@
+export const QUERY_POLL_INTERVAL_MS = 100
+export const QUERY_POLL_INITIAL_MS = 20
+
+/**
+ * Poll delay backoff: 20 → 40 → 80 → 100 → 100… A fixed 100ms start added up
+ * to ~100ms of pure waiting on every fast local query; backing off keeps the
+ * fast path fast without hammering the backend on slow queries.
+ */
+export function nextPollDelay(previous: number): number {
+	return Math.min(previous * 2, QUERY_POLL_INTERVAL_MS)
+}

--- a/packages/studio/src/core/data-provider/schema-query.ts
+++ b/packages/studio/src/core/data-provider/schema-query.ts
@@ -1,0 +1,54 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { applyConnectResult } from '@studio/features/database-studio/hooks/use-data-file-sources'
+import { setSchema } from '@studio/core/workspace-store'
+import type { DatabaseSchema } from '@studio/lib/bindings'
+import { setConnectionPhase } from './connection-phase'
+import type { DataAdapter } from './types'
+import { getAdapterError } from './types'
+
+export const SCHEMA_STALE_TIME_MS = 5 * 60 * 1000
+
+/**
+ * The one schema query. `useSchema` consumes it, and every imperative caller
+ * goes through `queryClient.fetchQuery(schemaQueryOptions(...))` so concurrent
+ * schema needs collapse into a single connect + introspection instead of
+ * racing their own adapter calls. `staleTime` lives here because `fetchQuery`
+ * without it would silently refetch on every call.
+ *
+ * On success the schema is mirrored into the workspace store with a real
+ * `fetchedAt`, which is what lets the next webview reload seed instantly from
+ * the bootstrap payload.
+ */
+export function schemaQueryOptions(
+	adapter: DataAdapter,
+	queryClient: QueryClient,
+	connectionId: string
+) {
+	return {
+		queryKey: ['schema', connectionId] as const,
+		staleTime: SCHEMA_STALE_TIME_MS,
+		retry: false as const,
+		queryFn: async function (): Promise<DatabaseSchema> {
+			setConnectionPhase(connectionId, 'connecting')
+			try {
+				const connectResult = await adapter.connectToDatabase(connectionId)
+				if (!connectResult.ok) {
+					throw new Error(getAdapterError(connectResult))
+				}
+				applyConnectResult(queryClient, connectionId, connectResult.data)
+
+				if (!connectResult.data.connected) {
+					throw new Error('Could not connect to this database')
+				}
+
+				setConnectionPhase(connectionId, 'introspecting')
+				const res = await adapter.getSchema(connectionId)
+				if (!res.ok) throw new Error(getAdapterError(res))
+				setSchema(connectionId, res.data, Date.now())
+				return res.data
+			} finally {
+				setConnectionPhase(connectionId, null)
+			}
+		}
+	}
+}

--- a/packages/studio/src/core/settings/settings-store.tsx
+++ b/packages/studio/src/core/settings/settings-store.tsx
@@ -9,7 +9,10 @@ import {
 	useRef
 } from 'react'
 import { commands } from '@studio/lib/bindings'
-import { readBootstrappedSettings } from '@studio/core/workspace-store'
+import {
+	configureTableSnapshotPersistence,
+	readBootstrappedSettings
+} from '@studio/core/workspace-store'
 import { MonacoTheme } from './editor-themes'
 
 export type EditorTheme = 'auto' | MonacoTheme
@@ -20,6 +23,7 @@ export type SettingsState = {
 	editorTheme: EditorTheme
 	enableVimMode: boolean
 	hideAi: boolean
+	persistTableSnapshots: boolean
 	privacyMaskData: boolean
 	restoreLastConnection: boolean
 	restoreTabsOnLaunch: boolean
@@ -38,6 +42,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
 	editorTheme: 'auto',
 	enableVimMode: false,
 	hideAi: false,
+	persistTableSnapshots: true,
 	privacyMaskData: false,
 	restoreLastConnection: true,
 	restoreTabsOnLaunch: true,
@@ -121,6 +126,10 @@ export function sanitizeSettings(value: unknown): SettingsState {
 				? value.enableVimMode
 				: DEFAULT_SETTINGS.enableVimMode,
 		hideAi: typeof value.hideAi === 'boolean' ? value.hideAi : DEFAULT_SETTINGS.hideAi,
+		persistTableSnapshots:
+			typeof value.persistTableSnapshots === 'boolean'
+				? value.persistTableSnapshots
+				: DEFAULT_SETTINGS.persistTableSnapshots,
 		privacyMaskData:
 			typeof value.privacyMaskData === 'boolean'
 				? value.privacyMaskData
@@ -281,6 +290,15 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
 			}
 		}
 	}, [settings, scheduleSave])
+
+	useEffect(
+		function syncSnapshotPersistence() {
+			configureTableSnapshotPersistence(
+				settings.persistTableSnapshots && !settings.privacyMaskData
+			)
+		},
+		[settings.persistTableSnapshots, settings.privacyMaskData]
+	)
 
 	useEffect(function flushSettingsBeforeExit() {
 		function flush() {

--- a/packages/studio/src/core/workspace-store/actions.ts
+++ b/packages/studio/src/core/workspace-store/actions.ts
@@ -3,7 +3,13 @@ import type { SettingsSectionId } from '@studio/features/sidebar/components/sett
 import type { DatabaseSchema, SavedQuery, SnippetFolder } from '@studio/lib/bindings'
 import type { HydrateSessionArgs } from './slices/tabs'
 import { workspaceStore } from './store'
-import { tableSnapshotKey, type Tab, type TableSnapshot, type TabsSlice } from './types'
+import {
+	tableSnapshotKey,
+	type SchemaEntry,
+	type Tab,
+	type TableSnapshot,
+	type TabsSlice
+} from './types'
 
 /**
  * Module-level action functions rather than hook-returned closures: every one
@@ -132,6 +138,16 @@ export function openSettingsView(
 
 export function setSchema(connectionId: string, schema: DatabaseSchema, fetchedAt = 0): void {
 	workspaceStore.dispatch({ type: 'schemas/set', connectionId, schema, fetchedAt })
+}
+
+/**
+ * The last schema this session (or the bootstrap payload) saw for a
+ * connection, read synchronously. Bootstrap entries carry `fetchedAt: 0`, so
+ * consumers can seed instantly while still treating the data as stale.
+ */
+export function readSchemaEntry(connectionId: string | undefined): SchemaEntry | undefined {
+	if (!connectionId) return undefined
+	return workspaceStore.getState().schemas.byConnectionId[connectionId]
 }
 
 export function invalidateSchema(connectionId: string): void {

--- a/packages/studio/src/core/workspace-store/index.ts
+++ b/packages/studio/src/core/workspace-store/index.ts
@@ -7,6 +7,10 @@ export {
 	resetBootstrapForTests
 } from './bootstrap'
 export {
+	configureTableSnapshotPersistence,
+	initTableSnapshotPersistence
+} from './snapshot-persistence'
+export {
 	createWorkspaceStore,
 	dispatchWorkspace,
 	readWorkspace,

--- a/packages/studio/src/core/workspace-store/snapshot-persistence.ts
+++ b/packages/studio/src/core/workspace-store/snapshot-persistence.ts
@@ -1,0 +1,180 @@
+import {
+	DEFAULT_QUERY_SIGNATURE,
+	snapshotQuerySignature
+} from '@studio/features/database-studio/utils/table-snapshot'
+import { noop } from '@studio/shared/utils/noop'
+import { putTableSnapshot } from './actions'
+import { workspaceStore } from './store'
+import { readBootstrappedSettings } from './bootstrap'
+import type { TableSnapshot } from './types'
+
+/**
+ * Disk mirror for default-page table snapshots.
+ *
+ * The in-memory snapshot slice is what makes a table switch paint instantly;
+ * this module extends that across app restarts by mirroring the default-page
+ * snapshots (first page, no sort, no filters) to localStorage and hydrating
+ * them back at boot. Because it mirrors the store, every existing
+ * `dropTableSnapshot` / `clearTableSnapshots` propagates to disk for free.
+ *
+ * Privacy: row values land on disk in plaintext, so the mirror is a settings
+ * toggle (`persistTableSnapshots`, default on) and is force-disabled — with
+ * the stored key cleared — whenever `privacyMaskData` is on.
+ */
+const STORAGE_KEY = 'dora.table-snapshots.v1'
+const MAX_ENTRIES = 20
+const MAX_BYTES = 2_000_000
+const WRITE_DEBOUNCE_MS = 500
+
+let enabled = false
+let unsubscribe: (() => void) | null = null
+let writeTimer: ReturnType<typeof setTimeout> | null = null
+let lastWritten: string | null = null
+
+function storage(): Storage | null {
+	try {
+		return typeof window === 'undefined' ? null : window.localStorage
+	} catch {
+		return null
+	}
+}
+
+function isDefaultPageSnapshot(snapshot: TableSnapshot): boolean {
+	return snapshotQuerySignature(snapshot) === DEFAULT_QUERY_SIGNATURE
+}
+
+function serializeSnapshots(): string | null {
+	const byKey = workspaceStore.getState().tableSnapshots.byKey
+	const entries = Object.values(byKey)
+		.filter(isDefaultPageSnapshot)
+		.sort((a, b) => b.fetchedAt - a.fetchedAt)
+		.slice(0, MAX_ENTRIES)
+
+	let serialized = JSON.stringify(entries)
+	let kept = entries.length
+	while (serialized.length > MAX_BYTES && kept > 0) {
+		kept -= 1
+		serialized = JSON.stringify(entries.slice(0, kept))
+	}
+	return serialized.length > MAX_BYTES ? null : serialized
+}
+
+function writeNow(): void {
+	const store = storage()
+	if (!store) return
+	const serialized = serializeSnapshots()
+	if (serialized === null || serialized === lastWritten) return
+	try {
+		store.setItem(STORAGE_KEY, serialized)
+		lastWritten = serialized
+	} catch {
+		noop()
+	}
+}
+
+function scheduleWrite(): void {
+	if (writeTimer) clearTimeout(writeTimer)
+	writeTimer = setTimeout(function flushSnapshotMirror() {
+		writeTimer = null
+		writeNow()
+	}, WRITE_DEBOUNCE_MS)
+}
+
+function isPersistedSnapshot(value: unknown): value is TableSnapshot {
+	if (typeof value !== 'object' || value === null) return false
+	const snapshot = value as Record<string, unknown>
+	return (
+		typeof snapshot.connectionId === 'string' &&
+		typeof snapshot.tableId === 'string' &&
+		Array.isArray(snapshot.columns) &&
+		Array.isArray(snapshot.rows) &&
+		typeof snapshot.totalCount === 'number' &&
+		Array.isArray(snapshot.visibleColumns) &&
+		typeof snapshot.offset === 'number' &&
+		typeof snapshot.limit === 'number' &&
+		typeof snapshot.fetchedAt === 'number'
+	)
+}
+
+function hydrate(): void {
+	const store = storage()
+	if (!store) return
+	try {
+		const raw = store.getItem(STORAGE_KEY)
+		if (!raw) return
+		const parsed: unknown = JSON.parse(raw)
+		if (!Array.isArray(parsed)) return
+		for (const entry of parsed) {
+			if (isPersistedSnapshot(entry) && isDefaultPageSnapshot(entry)) {
+				putTableSnapshot(entry)
+			}
+		}
+		lastWritten = raw
+	} catch {
+		noop()
+	}
+}
+
+function clearStored(): void {
+	const store = storage()
+	if (!store) return
+	try {
+		store.removeItem(STORAGE_KEY)
+	} catch {
+		noop()
+	}
+	lastWritten = null
+}
+
+/**
+ * Turns the mirror on or off. Idempotent; safe to call from a settings effect
+ * on every change. Turning it off removes the stored data.
+ */
+export function configureTableSnapshotPersistence(nextEnabled: boolean): void {
+	if (nextEnabled === enabled) return
+	enabled = nextEnabled
+
+	if (!enabled) {
+		unsubscribe?.()
+		unsubscribe = null
+		if (writeTimer) {
+			clearTimeout(writeTimer)
+			writeTimer = null
+		}
+		clearStored()
+		return
+	}
+
+	// Hydrate before subscribing so the initial (possibly empty) store state
+	// cannot clobber what the last session persisted.
+	hydrate()
+	unsubscribe = workspaceStore.subscribe(scheduleWrite)
+}
+
+/**
+ * Boot-path entry: resolves the two gating settings from the bootstrapped
+ * settings document (or the browser-mode localStorage fallback) without
+ * waiting for React. The settings provider re-configures on live toggles.
+ */
+export function initTableSnapshotPersistence(): void {
+	let persist = true
+	let mask = false
+	try {
+		const doc = readBootstrappedSettings() ?? storage()?.getItem('ui_settings') ?? null
+		if (doc) {
+			const parsed: unknown = JSON.parse(doc)
+			if (typeof parsed === 'object' && parsed !== null) {
+				const settings = parsed as Record<string, unknown>
+				if (typeof settings.persistTableSnapshots === 'boolean') {
+					persist = settings.persistTableSnapshots
+				}
+				if (typeof settings.privacyMaskData === 'boolean') {
+					mask = settings.privacyMaskData
+				}
+			}
+		}
+	} catch {
+		noop()
+	}
+	configureTableSnapshotPersistence(persist && !mask)
+}

--- a/packages/studio/src/features/database-studio/components/database-studio-empty-states.tsx
+++ b/packages/studio/src/features/database-studio/components/database-studio-empty-states.tsx
@@ -35,14 +35,15 @@ export function DatabaseStudioNoConnection({ onAddConnection }: NoConnectionProp
 
 type ConnectionLoadingProps = {
 	connectionName?: string
+	phase?: 'connecting' | 'introspecting' | null
 }
 
-export function DatabaseStudioConnectionLoading({ connectionName }: ConnectionLoadingProps) {
+export function DatabaseStudioConnectionLoading({ connectionName, phase }: ConnectionLoadingProps) {
 	return (
 		<div className='flex flex-1 flex-col items-center justify-center p-6 text-center'>
 			<Spinner className='h-8 w-8 text-muted-foreground/70 mb-4' />
 			<h2 className='text-lg font-semibold text-foreground mb-1 tracking-tight'>
-				Connecting…
+				{phase === 'introspecting' ? 'Reading schema…' : 'Connecting…'}
 			</h2>
 			<p className='text-muted-foreground text-sm max-w-sm'>
 				{connectionName

--- a/packages/studio/src/features/database-studio/database-studio.tsx
+++ b/packages/studio/src/features/database-studio/database-studio.tsx
@@ -1,6 +1,7 @@
 import { TableSkeleton } from '@studio/shared/ui/skeleton'
 import { useToast } from '@studio/shared/ui/use-toast'
 import { useAdapter, useDataMutation, useConnections, useSchema } from '@studio/core/data-provider'
+import { useConnectionPhase } from '@studio/core/data-provider/connection-phase'
 import { usePendingEdits } from '@studio/core/pending-edits'
 import { openTab } from '@studio/core/workspace-store'
 import { useSettings } from '@studio/core/settings'
@@ -129,6 +130,7 @@ export function DatabaseStudio({
 	const { toast } = useToast()
 	const { data: connections = [] } = useConnections()
 	const schemaQuery = useSchema(activeConnectionId)
+	const connectionPhase = useConnectionPhase(activeConnectionId)
 	const activeConnection = useMemo(
 		function () {
 			return connections.find(function (connection) {
@@ -903,7 +905,10 @@ export function DatabaseStudio({
 	if (!tableId) {
 		if (schemaQuery.isLoading && !schemaQuery.data) {
 			return withDataFileChrome(
-				<DatabaseStudioConnectionLoading connectionName={activeConnection?.name} />
+				<DatabaseStudioConnectionLoading
+					connectionName={activeConnection?.name}
+					phase={connectionPhase}
+				/>
 			)
 		}
 

--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
@@ -1,16 +1,20 @@
 import { useCallback, useEffect, useMemo, useRef, type Dispatch, type SetStateAction } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useLiveMonitor } from '@studio/core/live-monitor'
 import { overlayPendingEditsOnRows, type PendingEdit } from '@studio/core/pending-edits'
 import { useNuqsState } from '@studio/core/url-state/use-nuqs-state'
 import {
+	dropTableSnapshot,
 	putTableSnapshot,
 	readTableSnapshot,
 	type TableSnapshot
 } from '@studio/core/workspace-store'
 import { getAdapterError } from '@studio/core/data-provider/types'
+import { schemaQueryOptions } from '@studio/core/data-provider/schema-query'
 import { isConnectionUnavailableError } from '@studio/shared/utils/error-messages'
+import { noop } from '@studio/shared/utils/noop'
 import { toast } from '@studio/shared/ui/notifier'
-import type { AdapterResult, DataAdapter } from '@studio/core/data-provider/types'
+import type { DataAdapter } from '@studio/core/data-provider/types'
 import type { DatabaseSchema } from '@studio/lib/bindings'
 import { enrichColumnsWithFKs } from '../utils/fk-enrichment'
 import {
@@ -112,6 +116,7 @@ export function useDatabaseStudioSync(args: Args) {
 	} = args
 
 	const liveMonitor = useLiveMonitor()
+	const queryClient = useQueryClient()
 	const {
 		urlState,
 		setSelectedRow,
@@ -178,7 +183,6 @@ export function useDatabaseStudioSync(args: Args) {
 
 		setIsLoading(true)
 
-		let schemaForTable: AdapterResult<DatabaseSchema> | null = null
 		const currentView = `${activeConnectionId}::${tableId}::${currentQuerySignature}`
 		const snapshot = readTableSnapshot(activeConnectionId, tableRefName)
 		const cached =
@@ -204,31 +208,31 @@ export function useDatabaseStudioSync(args: Args) {
 			displayedViewRef.current = currentView
 		}
 
-		try {
-			schemaForTable = await adapter.getSchema(activeConnectionId)
-			if (!isCurrentRequest()) return
-			if (schemaForTable.ok && !schemaHasTable(schemaForTable.data, tableRefName)) {
-				console.warn('[DatabaseStudio] Skipping stale table selection:', {
-					connectionId: activeConnectionId,
-					tableRefName
-				})
-				setTableData(null)
-				setIsTableTransitioning(false)
-				setIsLoading(false)
-				return
-			}
-		} catch (error) {
-			if (!isCurrentRequest()) return
-			console.error('[DatabaseStudio] Failed to validate selected table:', error)
-			if (!isConnectionUnavailableError(error)) {
-				toast.error('Failed to validate selected table', {
-					description: error instanceof Error ? error.message : String(error)
-				})
-			}
+		// The schema fetch races the row fetch instead of gating it: it goes
+		// through the shared react-query entry (single-flight with useSchema)
+		// and is only needed for the stale-table guard and FK enrichment, both
+		// of which can apply after rows are on screen.
+		let resolvedSchema: DatabaseSchema | null = null
+		const schemaPromise = queryClient
+			.fetchQuery(schemaQueryOptions(adapter, queryClient, activeConnectionId))
+			.then(function (schema: DatabaseSchema) {
+				resolvedSchema = schema
+				return schema
+			})
+		schemaPromise.catch(noop)
+
+		const handleStaleTable = function () {
+			console.warn('[DatabaseStudio] Skipping stale table selection:', {
+				connectionId: activeConnectionId,
+				tableRefName
+			})
+			setTableData(null)
+			dropTableSnapshot(activeConnectionId, tableRefName)
+			setIsTableTransitioning(false)
 		}
 
-		try {
-			const result = await adapter.fetchTableData(
+		const fetchRows = function () {
+			return adapter.fetchTableData(
 				activeConnectionId,
 				tableRefName,
 				Math.floor(pagination.offset / pagination.limit),
@@ -238,19 +242,40 @@ export function useDatabaseStudioSync(args: Args) {
 				filterConjunction,
 				filterGroup
 			)
+		}
+
+		try {
+			let result = await fetchRows()
 			if (!isCurrentRequest()) return
+
+			// Cold boot: the connection opens inside the schema queryFn, so a
+			// connection-unavailable fetch means it raced ahead of connect.
+			// Wait for the schema query to settle and retry exactly once.
+			if (!result.ok && isConnectionUnavailableError(getAdapterError(result))) {
+				try {
+					await schemaPromise
+				} catch {
+					noop()
+				}
+				if (!isCurrentRequest()) return
+				result = await fetchRows()
+				if (!isCurrentRequest()) return
+			}
 
 			if (result.ok) {
 				const data = result.data
-				const schemaResult = schemaForTable ?? (await adapter.getSchema(activeConnectionId))
-				if (!isCurrentRequest()) return
-				if (schemaResult.ok) {
-					const { tableName: tableNamePart, schemaName } = getTableRefParts(
-						tableRefName ?? ''
-					)
+				const { tableName: tableNamePart, schemaName } = getTableRefParts(tableRefName)
+
+				if (resolvedSchema) {
+					// Warm path (cached schema): guard and enrich before the
+					// single paint, exactly like the old serial ordering.
+					if (!schemaHasTable(resolvedSchema, tableRefName)) {
+						handleStaleTable()
+						return
+					}
 					data.columns = enrichColumnsWithFKs(
 						data.columns,
-						schemaResult.data,
+						resolvedSchema,
 						tableNamePart,
 						schemaName ?? undefined
 					)
@@ -270,23 +295,69 @@ export function useDatabaseStudioSync(args: Args) {
 					})
 				}
 
-				putTableSnapshot({
-					connectionId: activeConnectionId,
-					tableId: tableRefName,
-					columns: data.columns,
-					rows: data.rows,
-					totalCount: data.totalCount,
-					visibleColumns: nextVisibleColumns,
-					offset: pagination.offset,
-					limit: pagination.limit,
-					sort,
-					filters,
-					conjunction: filterConjunction,
-					filterGroup,
-					fetchedAt: Date.now()
-				})
+				const snapshotOf = function (columns: TableData['columns']) {
+					return {
+						connectionId: activeConnectionId,
+						tableId: tableRefName,
+						columns,
+						rows: data.rows,
+						totalCount: data.totalCount,
+						visibleColumns: nextVisibleColumns,
+						offset: pagination.offset,
+						limit: pagination.limit,
+						sort,
+						filters,
+						conjunction: filterConjunction,
+						filterGroup,
+						fetchedAt: Date.now()
+					}
+				}
+				putTableSnapshot(snapshotOf(data.columns))
+
+				if (!resolvedSchema) {
+					// Cold path: rows are painted; apply the schema verdict and
+					// enrichment when it lands. A schema failure surfaces via
+					// the shared ['schema', id] query state, not a toast here.
+					setIsLoading(false)
+					let schema: DatabaseSchema | null = null
+					try {
+						schema = await schemaPromise
+					} catch (error) {
+						console.error('[DatabaseStudio] Failed to validate selected table:', error)
+					}
+					if (!isCurrentRequest() || !schema) return
+					if (!schemaHasTable(schema, tableRefName)) {
+						handleStaleTable()
+						return
+					}
+					const enriched = enrichColumnsWithFKs(
+						data.columns,
+						schema,
+						tableNamePart,
+						schemaName ?? undefined
+					)
+					if (enriched !== data.columns) {
+						setTableData(withPendingEdits({ ...data, columns: enriched }, tableId))
+						putTableSnapshot(snapshotOf(enriched))
+					}
+				}
 			} else {
+				// Buffer the error until the schema verdict: a dropped table's
+				// failing fetch should resolve to the silent stale-table clear,
+				// not an error toast for a table that no longer exists.
 				const errorMessage = getAdapterError(result)
+				let tableMissing = false
+				try {
+					const schema = await schemaPromise
+					tableMissing = !schemaHasTable(schema, tableRefName)
+				} catch {
+					noop()
+				}
+				if (!isCurrentRequest()) return
+				if (tableMissing) {
+					handleStaleTable()
+					return
+				}
 				console.error('[DatabaseStudio] Failed to load table data:', errorMessage)
 				if (!isConnectionUnavailableError(errorMessage)) {
 					toast.error('Failed to load table data', {
@@ -324,6 +395,7 @@ export function useDatabaseStudioSync(args: Args) {
 		filterGroup,
 		pagination.limit,
 		pagination.offset,
+		queryClient,
 		setIsLoading,
 		setIsTableTransitioning,
 		setTableData,

--- a/packages/studio/src/features/sidebar/components/settings-panel.tsx
+++ b/packages/studio/src/features/sidebar/components/settings-panel.tsx
@@ -1531,6 +1531,32 @@ export function SettingsView({ windowControls, initialSection, highlightSection 
 										<div
 											className='flex items-start justify-between gap-4'
 											tabIndex={-1}
+											data-settings-focus='safety-persist-snapshots'
+										>
+											<div className='flex-1'>
+												<div className='text-sm text-sidebar-foreground'>
+													Remember table contents
+												</div>
+												<div className='text-xs leading-tight text-muted-foreground'>
+													Cache the last viewed page of each table on this device
+													so tables reappear instantly after a restart. Row values
+													are stored in plain text; turning this off (or enabling
+													Privacy mode) removes the cache.
+												</div>
+											</div>
+											<div className='flex-shrink-0 pt-0.5'>
+												<Switch
+													checked={settings.persistTableSnapshots}
+													onCheckedChange={function (checked) {
+														updateSetting('persistTableSnapshots', checked)
+													}}
+												/>
+											</div>
+										</div>
+
+										<div
+											className='flex items-start justify-between gap-4'
+											tabIndex={-1}
 											data-settings-focus='safety-hide-ai'
 										>
 											<div className='flex-1'>

--- a/packages/studio/src/features/sidebar/database-sidebar.tsx
+++ b/packages/studio/src/features/sidebar/database-sidebar.tsx
@@ -4,6 +4,7 @@ import { SidebarTableSkeleton } from '@studio/shared/ui/skeleton'
 import { useToast } from '@studio/shared/ui/use-toast'
 import { toast as appToast } from '@studio/shared/ui/notifier'
 import { useAdapter, useSchema } from '@studio/core/data-provider'
+import { useConnectionPhase } from '@studio/core/data-provider/connection-phase'
 import { useIsTauri } from '@studio/core/data-provider/context'
 import { getAdapterError } from '@studio/core/data-provider/types'
 import type { DatabaseSchema, TableInfo } from '@studio/lib/bindings'
@@ -116,6 +117,7 @@ export function DatabaseSidebar({
 	// Shares the ['schema', connectionId] query with DatabaseStudio — a private
 	// fetch here meant every connect ran connect + introspection twice.
 	const schemaQuery = useSchema(activeConnectionId)
+	const connectionPhase = useConnectionPhase(activeConnectionId)
 	const schema: DatabaseSchema | null = schemaQuery.data ?? null
 	const isLoadingSchema = schemaQuery.isFetching
 	const schemaError = schemaQuery.isError
@@ -817,7 +819,16 @@ export function DatabaseSidebar({
 			<div className='flex min-h-0 flex-1 flex-col'>
 				<ScrollArea className='min-h-0 flex-1' style={{ flex: 1 }}>
 					{isLoadingSchema && !schema ? (
-						<SidebarTableSkeleton rows={8} />
+						<div>
+							{connectionPhase && (
+								<p className='px-4 pt-3 text-xs text-muted-foreground'>
+									{connectionPhase === 'introspecting'
+										? 'Reading schema…'
+										: 'Connecting…'}
+								</p>
+							)}
+							<SidebarTableSkeleton rows={8} />
+						</div>
 					) : schemaError ? (
 						<div className='flex flex-col items-center justify-center h-40 px-4 py-6 gap-3'>
 							<div className='flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10'>

--- a/packages/studio/src/features/sql-console/sql-console.tsx
+++ b/packages/studio/src/features/sql-console/sql-console.tsx
@@ -3,6 +3,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import { useAdapter, useIsTauri } from '@studio/core/data-provider/context'
 import { useSettings } from '@studio/core/settings'
 import { useConnections } from '@studio/core/data-provider'
+import { useSchema } from '@studio/core/data-provider/hooks'
 import { askAi, buildExplainQueryPrompt } from '@studio/features/ai-assistant/ai-actions'
 import { getAdapterError } from '@studio/core/data-provider/types'
 import type { QueryResult } from '@studio/core/data-provider/types'
@@ -173,7 +174,34 @@ function SqlConsoleInner({ isActive = true, activeConnectionId, getConnectionNam
 	const [showFilter, setShowFilter] = useState(false)
 	const [showHistory, setShowHistory] = useState(false)
 	const [showAiCmdK, setShowAiCmdK] = useState(false)
-	const [tables, setTables] = useState<TableInfo[]>([])
+
+	// The shared schema query (single-flight with the sidebar and the grid);
+	// 'dora-schema-refresh' invalidations flow through it, so the console no
+	// longer runs its own connect + introspection.
+	const schemaQuery = useSchema(activeConnectionId || undefined)
+	const tables = useMemo(
+		function mapSchemaTables(): TableInfo[] {
+			const schemaTables = schemaQuery.data?.tables
+			if (!schemaTables) return []
+			return schemaTables.map(function (t) {
+				return {
+					name: t.name,
+					schema: t.schema,
+					type: 'table' as const,
+					rowCount: t.row_count_estimate ?? 0,
+					columns: t.columns.map(function (c) {
+						return {
+							name: c.name,
+							type: c.data_type,
+							nullable: c.is_nullable,
+							primaryKey: c.is_primary_key
+						}
+					})
+				}
+			})
+		},
+		[schemaQuery.data]
+	)
 
 	const { addToHistory, updateChartConfig } = useQueryHistory()
 
@@ -207,40 +235,6 @@ function SqlConsoleInner({ isActive = true, activeConnectionId, getConnectionNam
 		},
 		[mode, currentSqlQuery, currentDrizzleQuery]
 	)
-
-	const refreshSchema = useCallback(async () => {
-		if (!activeConnectionId) {
-			setTables([])
-			return
-		}
-
-		try {
-			await adapter.connectToDatabase(activeConnectionId)
-			const res = await adapter.getSchema(activeConnectionId)
-			if (res.ok && res.data.tables) {
-				const mapped: TableInfo[] = res.data.tables.map(function (t) {
-					return {
-						name: t.name,
-						schema: t.schema,
-						type: 'table' as const,
-						rowCount: t.row_count_estimate ?? 0,
-						columns: t.columns.map(function (c) {
-							return {
-								name: c.name,
-								type: c.data_type,
-								nullable: c.is_nullable,
-								primaryKey: c.is_primary_key
-							}
-						})
-					}
-				})
-				setTables(mapped)
-			}
-		} catch (error) {
-			console.error('Failed to fetch schema:', error)
-			notifyBackgroundFailure('Failed to fetch schema', error)
-		}
-	}, [activeConnectionId, adapter])
 
 	const loadSnippets = useCallback(async () => {
 		const [scriptsRes, foldersRes] = await Promise.all([
@@ -293,91 +287,42 @@ function SqlConsoleInner({ isActive = true, activeConnectionId, getConnectionNam
 		[activeConnectionId, loadSnippets]
 	)
 
+	// One-shot per connection: seed the editors with a sensible default query
+	// once the schema first arrives. The ref guard keeps later schema
+	// invalidations (DDL, count updates) from clobbering the user's edits.
+	const defaultQueryConnectionRef = useRef<string | null>(null)
 	useEffect(
-		function () {
+		function seedDefaultQueryForConnection() {
 			if (!activeConnectionId) {
-				setTables([])
+				defaultQueryConnectionRef.current = null
 				setCurrentSqlQuery(DEFAULT_SQL)
 				setCurrentDrizzleQuery(DEFAULT_QUERY)
 				return
 			}
+			if (defaultQueryConnectionRef.current === activeConnectionId) return
+			if (!schemaQuery.data) return
+			defaultQueryConnectionRef.current = activeConnectionId
 
-			let cancelled = false
-
-			async function fetchSchema() {
-				try {
-					await adapter.connectToDatabase(activeConnectionId!)
-					const res = await adapter.getSchema(activeConnectionId!)
-					if (cancelled) return
-					if (res.ok && res.data.tables) {
-						const mapped: TableInfo[] = res.data.tables.map(function (t) {
-							return {
-								name: t.name,
-								schema: t.schema,
-								type: 'table' as const,
-								rowCount: t.row_count_estimate ?? 0,
-								columns: t.columns.map(function (c) {
-									return {
-										name: c.name,
-										type: c.data_type,
-										nullable: c.is_nullable,
-										primaryKey: c.is_primary_key
-									}
-								})
-							}
-						})
-						setTables(mapped)
-
-						if (mapped.length > 0) {
-							const defaultTable = pickDefaultQueryTable(mapped)
-							if (defaultTable) {
-								setCurrentSqlQuery(buildDefaultSqlQuery(defaultTable.name))
-								setCurrentDrizzleQuery(buildDefaultDrizzleQuery(defaultTable.name))
-							} else {
-								setCurrentSqlQuery(DEFAULT_SQL)
-								setCurrentDrizzleQuery(DEFAULT_QUERY)
-							}
-						} else {
-							setCurrentSqlQuery(DEFAULT_SQL)
-							setCurrentDrizzleQuery(DEFAULT_QUERY)
-						}
-					}
-				} catch (error) {
-					if (!cancelled) {
-						console.error('Failed to fetch schema:', error)
-						notifyBackgroundFailure('Failed to fetch schema', error)
-					}
-				}
-			}
-
-			fetchSchema()
-
-			return function () {
-				cancelled = true
+			const defaultTable = pickDefaultQueryTable(tables)
+			if (defaultTable) {
+				setCurrentSqlQuery(buildDefaultSqlQuery(defaultTable.name))
+				setCurrentDrizzleQuery(buildDefaultDrizzleQuery(defaultTable.name))
+			} else {
+				setCurrentSqlQuery(DEFAULT_SQL)
+				setCurrentDrizzleQuery(DEFAULT_QUERY)
 			}
 		},
-		[activeConnectionId, adapter]
+		[activeConnectionId, schemaQuery.data, tables]
 	)
 
 	useEffect(
-		function listenForSchemaRefresh() {
-			function onSchemaRefresh(event: Event) {
-				const customEvent = event as CustomEvent<{ connectionId?: string }>
-				const targetConnectionId = customEvent.detail?.connectionId
-				if (!targetConnectionId || targetConnectionId === activeConnectionId) {
-					refreshSchema().catch(function (error) {
-						console.error('Failed to refresh schema:', error)
-						notifyBackgroundFailure('Failed to refresh schema', error)
-					})
-				}
-			}
-
-			window.addEventListener('dora-schema-refresh', onSchemaRefresh as EventListener)
-			return function () {
-				window.removeEventListener('dora-schema-refresh', onSchemaRefresh as EventListener)
+		function reportSchemaFailure() {
+			if (schemaQuery.error) {
+				console.error('Failed to fetch schema:', schemaQuery.error)
+				notifyBackgroundFailure('Failed to fetch schema', schemaQuery.error)
 			}
 		},
-		[activeConnectionId, refreshSchema]
+		[schemaQuery.error]
 	)
 
 	useEffect(

--- a/packages/studio/src/pages/workspace/use-workspace-startup.ts
+++ b/packages/studio/src/pages/workspace/use-workspace-startup.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useIsTauri } from '@studio/core/data-provider'
-import { useConnections } from '@studio/core/data-provider/hooks'
+import { useConnections, useSchemaRowCountListener } from '@studio/core/data-provider/hooks'
 import { ENV_MODE, getEnv } from '@studio/core/env'
 import { useSettings } from '@studio/core/settings'
 import {
@@ -35,6 +35,8 @@ export function useWorkspaceStartup({ onFileDrop }: Args) {
 	const activeConnectionId = useActiveConnectionId()
 
 	const isLoading = isSettingsLoading || isConnectionsLoading
+
+	useSchemaRowCountListener()
 
 	useEffect(
 		function listenForServerSideDisconnects() {


### PR DESCRIPTION
## Summary

Opening a connection — especially cloud databases (Neon, Turso, Cloudflare D1, remote MySQL) — showed skeletons for many seconds while the app ran serial round trips and synchronous full-table counts. This reworks the whole open path.

### Backend
- **Counts off the critical path**: introspection returns engine estimates immediately; a new `RowCountRefresher` runs batched exact `COUNT(*)` in the background, patches the cached schema and emits `schema-row-counts-updated`. Cancellation via per-connection generation counter on every invalidation/teardown.
- **Postgres**: estimates from `pg_class.reltuples` (survives Neon scale-to-zero restarts; `pg_stat_user_tables` resets on wake and triggered a COUNT storm of every table); the five catalog queries run pipelined via `try_join!` (~1 RTT).
- **libSQL/SQLite**: per-table PRAGMA loops collapsed to 4 constant queries via pragma table-valued functions (shared assembler; legacy loop kept as sqld fallback). **Verified live against sqld.**
- **D1**: from `1 + tables×(5+idx)` HTTPS requests to 2–3 multi-statement requests.
- **MySQL/MariaDB**: connect ping dropped; catalog queries self-scope via `DATABASE()` and run concurrently on two pooled connections.
- **Cache hygiene**: DML patches the cached row count instead of dropping the whole schema (which forced full re-introspection after every cell edit); in-flight introspection dedup; config changes invalidate properly; shared HTTP client for D1/PostHog.

### Frontend
- One shared schema query — sidebar, grid and SQL console single-flight through react-query (SQL console's duplicate connect+introspect removed).
- First page of rows fetches in parallel with introspection; stale-table guard and FK enrichment apply post-hoc.
- Sidebar seeds instantly from the bootstrap schema cache after a reload; `schema-row-counts-updated` listener refreshes counts.
- Row snapshots persist to localStorage (20-entry LRU, 2MB cap, new **Remember table contents** setting, force-disabled and cleared under Privacy mode) — relaunch paints rows instantly.
- Query polling backs off 20→100ms; staged "Connecting… / Reading schema…" indicator during cloud cold starts.

## Verification
- `cargo test` 278 green incl. new units (count patching, refresher scheduling, D1 positional mapping, SQLite fixture introspection, dialect assertions)
- Live DB suite 8/8 (`DORA_LIVE_DB_TESTS=1`): new introspection round-trips for Postgres 17 (reltuples after ANALYZE), CockroachDB, MySQL, MariaDB, and the decisive collapsed-pragma test against real sqld
- `bun run test:desktop` 1089 green incl. new tests (schema-query single-flight, snapshot persistence LRU/privacy, poll backoff); typecheck + lint clean

## Notes
- libSQL previously returned *table* names in `unique_columns` (bug) — now column names, matching SQLite/D1; its `schemas` list is now `[]` instead of `[""]`.
- D1's batched path has no live fixture; covered by unit tests + arity-mismatch fallback to the legacy loop.