### PR TITLE
fix(grid): commit the snapshot paint before issuing the refresh fetch

### DIFF
--- a/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
+++ b/packages/studio/src/features/database-studio/hooks/use-database-studio-sync.ts
@@ -194,7 +194,9 @@ export function useDatabaseStudioSync(args: Args) {
 		// screen — e.g. after a delete/insert/column change. The snapshot is stale
 		// relative to the mutation, so painting it here is the "flash back to the
 		// old state". Keep the current rows visible and swap in fresh data.
+		let paintedFromSnapshot = false
 		if (cached && currentView !== displayedViewRef.current) {
+			paintedFromSnapshot = true
 			const next = withPendingEdits(snapshotToTableData(cached), tableId)
 			if (!isSameTableData(queryStateRef.current.tableData, next)) setTableData(next)
 			if (cached.visibleColumns.length > 0) {
@@ -245,6 +247,17 @@ export function useDatabaseStudioSync(args: Args) {
 		}
 
 		try {
+			// A snapshot paint must reach the screen before the refresh fetch is
+			// issued (the cached-switch render invariant): yield one macrotask so
+			// React commits the painted rows, then fire the fetch. Non-cached
+			// loads fetch immediately — there is nothing on screen to protect.
+			if (paintedFromSnapshot) {
+				await new Promise(function (resolve) {
+					setTimeout(resolve, 0)
+				})
+				if (!isCurrentRequest()) return
+			}
+
 			let result = await fetchRows()
 			if (!isCurrentRequest()) return
 


### PR DESCRIPTION
Follow-up to #237. The parallel `loadTableData` issued `fetchTableData` synchronously in the same tick as the snapshot paint, tripping the `@invariant` "a cached table switch paints without touching the adapter" (1 fetch before first paint). After a snapshot paint we now yield one macrotask so React commits the painted rows before the refresh fetch fires; non-cached loads are unchanged.

Verified: `bun run perf:invariants` 6/6 locally, `bun run test:desktop` 1089 green, typecheck clean.

## Summary by Sourcery

Bug Fixes:
- Ensure cached table snapshots are painted before refresh requests are issued, preventing the cached table switch invariant from being violated.