### PR TITLE
fix(studio): self-host Inter and JetBrains Mono and rework the view loading shell

### DIFF
--- a/apps/marketing/src/app/(app)/app/page.tsx
+++ b/apps/marketing/src/app/(app)/app/page.tsx
@@ -4,6 +4,7 @@ import { getRoute } from '@/core/config/routes'
 import { createMetadata } from '@/core/config/seo'
 
 import AppMount from './app-mount'
+import '@dora/studio/fonts'
 import '@dora/studio/styles'
 
 export const metadata: Metadata = createMetadata(getRoute('/app'))

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -6,6 +6,7 @@
 	"exports": {
 		".": "./src/index.ts",
 		"./styles": "./src/styles.css",
+		"./fonts": "./src/fonts.ts",
 		"./*": "./src/*"
 	},
 	"scripts": {

--- a/packages/studio/src/features/orm-cockpit/components/migration-status-view.tsx
+++ b/packages/studio/src/features/orm-cockpit/components/migration-status-view.tsx
@@ -5,19 +5,14 @@
  */
 
 import { CheckCircle2, Clock, Info } from 'lucide-react'
-import { Spinner } from '@studio/shared/ui/spinner'
 import { cn } from '@studio/shared/utils/cn'
 import { EmptyState } from '@studio/shared/ui/empty-state'
+import { SchemaDiffMigrationsSkeleton } from '@studio/shared/ui/view-loading-shell'
 import type { MigrationStatusState } from '@studio/features/orm-cockpit/components/use-migration-status'
 
 export function MigrationStatusView({ state }: { state: MigrationStatusState }) {
 	if (state.loading && !state.status) {
-		return (
-			<div className='flex h-full items-center justify-center gap-2 text-muted-foreground'>
-				<Spinner className='h-5 w-5' />
-				<span className='text-sm'>Reading migrations…</span>
-			</div>
-		)
+		return <SchemaDiffMigrationsSkeleton />
 	}
 
 	if (!state.status) {

--- a/packages/studio/src/features/orm-cockpit/components/orm-cockpit-panel.tsx
+++ b/packages/studio/src/features/orm-cockpit/components/orm-cockpit-panel.tsx
@@ -35,6 +35,7 @@ import {
 	DropdownMenuTrigger
 } from '@studio/shared/ui/dropdown-menu'
 import { EmptyState } from '@studio/shared/ui/empty-state'
+import { SchemaDiffBodySkeleton } from '@studio/shared/ui/view-loading-shell'
 import { CockpitEmptySkeleton } from './cockpit-empty-skeleton'
 import { cn } from '@studio/shared/utils/cn'
 import { useConnections } from '@studio/core/data-provider'
@@ -369,16 +370,7 @@ export function OrmCockpitPanel({ activeConnectionId, onOpenInSqlConsole, window
 		}
 
 		if (busy && !cockpit.diff) {
-			return (
-				<div className='flex h-full flex-col items-center justify-center gap-3 text-muted-foreground'>
-					<Spinner className='h-6 w-6' />
-					<span className='text-sm'>
-						{cockpit.phase === 'linking'
-							? 'Detecting project…'
-							: 'Comparing your code to the database…'}
-					</span>
-				</div>
-			)
+			return <SchemaDiffBodySkeleton />
 		}
 
 		if (cockpit.phase === 'choice' && cockpit.choices) {

--- a/packages/studio/src/fonts.ts
+++ b/packages/studio/src/fonts.ts
@@ -1,0 +1,12 @@
+/*
+ * Imported as individual CSS modules instead of @import lines in styles.css:
+ * Tailwind's postcss plugin inlines @imports without rebasing url(./files/…),
+ * which drops the woff2 assets from the build. As JS imports, each file is
+ * processed by the bundler on its own and the font assets are emitted.
+ */
+import '@fontsource/inter/400.css'
+import '@fontsource/inter/500.css'
+import '@fontsource/inter/600.css'
+import '@fontsource/jetbrains-mono/400.css'
+import '@fontsource/jetbrains-mono/500.css'
+import '@fontsource/jetbrains-mono/600.css'

--- a/packages/studio/src/pages/workspace/workspace-views-host.tsx
+++ b/packages/studio/src/pages/workspace/workspace-views-host.tsx
@@ -101,7 +101,8 @@ export function WorkspaceViewsHost({ actions, isLoading, isTauri }: Props) {
 					view={
 						activeNavId === 'sql-console' ||
 						activeNavId === 'schema-visualizer' ||
-						activeNavId === 'docker'
+						activeNavId === 'docker' ||
+						activeNavId === 'orm-cockpit'
 							? activeNavId
 							: 'database-studio'
 					}

--- a/packages/studio/src/shared/ui/view-loading-shell.tsx
+++ b/packages/studio/src/shared/ui/view-loading-shell.tsx
@@ -1,9 +1,26 @@
 import type { ReactNode } from 'react'
-import { Database, Network, PanelLeft, Search, SquareTerminal, Table2 } from 'lucide-react'
+import {
+	ArrowLeftRight,
+	ChevronRight,
+	Database,
+	GitCompareArrows,
+	ListChecks,
+	Network,
+	PanelLeft,
+	Search,
+	SquareTerminal,
+	Table2,
+	Wand2
+} from 'lucide-react'
 import { Skeleton, TableSkeleton } from '@studio/shared/ui/skeleton'
 import { cn } from '@studio/shared/utils/cn'
 
-type ViewId = 'database-studio' | 'sql-console' | 'schema-visualizer' | 'docker'
+type ViewId =
+	| 'database-studio'
+	| 'sql-console'
+	| 'schema-visualizer'
+	| 'docker'
+	| 'orm-cockpit'
 
 function LoadingFrame({
 	children,
@@ -324,9 +341,165 @@ export function DockerLoadingShell() {
 	)
 }
 
+/** One collapsed table card in the drift list — mirrors `TableCard` in drift-view. */
+function DriftTableCardSkeleton({ nameWidth }: { nameWidth: string }) {
+	return (
+		<div className='overflow-hidden rounded-md border border-border/60 bg-card/40'>
+			<div className='flex w-full items-center gap-2 px-3 py-2'>
+				<ChevronRight className='h-4 w-4 shrink-0 text-muted-foreground/40' />
+				<Skeleton className='h-3.5 w-3.5 rounded-sm' />
+				<Skeleton className={cn('h-4', nameWidth)} />
+				<Skeleton className='h-3 w-20' />
+				<Skeleton className='ml-auto h-5 w-14 rounded-full' />
+			</div>
+		</div>
+	)
+}
+
+/** A labelled group of table diffs — mirrors `DriftGroup` in drift-view. */
+function DriftGroupSkeleton({
+	titleWidth,
+	hintWidth,
+	cardWidths
+}: {
+	titleWidth: string
+	hintWidth: string
+	cardWidths: string[]
+}) {
+	return (
+		<div className='space-y-2'>
+			<div className='flex items-baseline gap-2'>
+				<Skeleton className={cn('h-3.5', titleWidth)} />
+				<Skeleton className={cn('h-3', hintWidth)} />
+				<Skeleton className='ml-auto h-3 w-4' />
+			</div>
+			<div className='space-y-2'>
+				{cardWidths.map(function (width, index) {
+					return <DriftTableCardSkeleton key={index} nameWidth={width} />
+				})}
+			</div>
+		</div>
+	)
+}
+
+/**
+ * The Differences tab body while the code schema is parsed, the live schema is
+ * introspected and the two are diffed. Deliberately 1:1 with the split the panel
+ * renders on `ready` — same two resizable halves, same left toolbar, same drift
+ * list — so nothing shifts when the real diff lands. Shown for exactly as long
+ * as the work takes; nothing here is on a timer.
+ */
+export function SchemaDiffBodySkeleton() {
+	return (
+		<div className='flex h-full min-h-0 flex-1' aria-hidden='true'>
+			<div className='flex min-w-0 flex-1 flex-col'>
+				<div className='flex items-center justify-between border-b border-border/60 px-3 py-2'>
+					<Skeleton className='h-3.5 w-28' />
+					<Skeleton className='h-7 w-40 rounded-md' />
+				</div>
+				<div className='min-h-0 flex-1 overflow-hidden p-3'>
+					<div className='space-y-4'>
+						<div className='flex items-center gap-2'>
+							<Skeleton className='h-3.5 w-28' />
+						</div>
+						<DriftGroupSkeleton
+							titleWidth='w-56'
+							hintWidth='w-44'
+							cardWidths={['w-28', 'w-20', 'w-32']}
+						/>
+						<DriftGroupSkeleton
+							titleWidth='w-48'
+							hintWidth='w-40'
+							cardWidths={['w-24']}
+						/>
+					</div>
+				</div>
+			</div>
+			<div className='w-1 shrink-0 bg-sidebar-border' />
+			<div className='flex min-w-0 flex-1 flex-col items-center justify-center p-8 text-center'>
+				<div className='mb-4 text-muted-foreground opacity-50'>
+					<Wand2 className='h-8 w-8' />
+				</div>
+				<Skeleton className='h-5 w-52' />
+				<Skeleton className='mt-2 h-3.5 w-72' />
+			</div>
+		</div>
+	)
+}
+
+/** The Migrations tab body while the journal and the applied set are read. */
+export function SchemaDiffMigrationsSkeleton() {
+	return (
+		<div className='flex h-full flex-col' aria-hidden='true'>
+			<div className='flex items-center gap-3 border-b border-border/60 px-3 py-2'>
+				<Skeleton className='h-3.5 w-20' />
+				<Skeleton className='h-3.5 w-20' />
+				<Skeleton className='ml-auto h-3.5 w-14' />
+			</div>
+			<div className='min-h-0 flex-1 overflow-hidden'>
+				{['w-48', 'w-56', 'w-40', 'w-52', 'w-44', 'w-36'].map(function (width, index) {
+					return (
+						<div
+							key={index}
+							className='flex items-center gap-2 border-b border-border/40 px-3 py-2'
+						>
+							<Skeleton className='h-3.5 w-3.5 rounded-full' />
+							<Skeleton className={cn('h-4', width)} />
+							<Skeleton className='ml-auto h-3 w-16' />
+						</div>
+					)
+				})}
+			</div>
+		</div>
+	)
+}
+
+/**
+ * Suspense fallback for the lazily-loaded Schema Diff view. Reproduces the
+ * panel's own chrome (header, tab bar) so the chunk landing is invisible.
+ */
+export function SchemaDiffLoadingShell() {
+	return (
+		<LoadingFrame>
+			<div className='flex h-10 shrink-0 items-center justify-between border-b border-sidebar-border bg-sidebar px-2'>
+				<div className='flex items-center gap-2 px-2'>
+					<GitCompareArrows className='h-4 w-4 text-muted-foreground' />
+					<Skeleton className='h-4 w-24' />
+				</div>
+				<div className='flex items-center gap-1'>
+					<Skeleton className='h-7 w-36 rounded-md' />
+					<Skeleton className='h-7 w-28 rounded-md' />
+				</div>
+			</div>
+
+			<div className='flex shrink-0 items-center gap-1 border-b border-border/60 px-2 py-1'>
+				<div className='flex items-center gap-1.5 rounded px-2.5 py-1'>
+					<GitCompareArrows className='h-3.5 w-3.5 text-muted-foreground/50' />
+					<Skeleton className='h-3 w-16' />
+				</div>
+				<div className='flex items-center gap-1.5 rounded px-2.5 py-1'>
+					<ListChecks className='h-3.5 w-3.5 text-muted-foreground/50' />
+					<Skeleton className='h-3 w-16' />
+				</div>
+				<div className='flex items-center gap-1.5 rounded px-2.5 py-1'>
+					<ArrowLeftRight className='h-3.5 w-3.5 text-muted-foreground/50' />
+					<Skeleton className='h-3 w-14' />
+				</div>
+			</div>
+
+			<div className='min-h-0 flex-1'>
+				<SchemaDiffBodySkeleton />
+			</div>
+		</LoadingFrame>
+	)
+}
+
 export function ViewLoadingShell({ view }: { view: ViewId }) {
 	if (view === 'sql-console') {
 		return <SqlConsoleLoadingShell />
+	}
+	if (view === 'orm-cockpit') {
+		return <SchemaDiffLoadingShell />
 	}
 	if (view === 'schema-visualizer') {
 		return <SchemaVisualizerLoadingShell />

--- a/packages/studio/src/styles.css
+++ b/packages/studio/src/styles.css
@@ -1,10 +1,10 @@
-@import '@fontsource/inter/400.css';
-@import '@fontsource/inter/500.css';
-@import '@fontsource/inter/600.css';
-@import '@fontsource/jetbrains-mono/400.css';
-@import '@fontsource/jetbrains-mono/500.css';
-@import '@fontsource/jetbrains-mono/600.css';
-
+/*
+ * Font CSS is imported from JS entry points (apps/desktop/src/main.tsx,
+ * apps/marketing app/page.tsx), not here: Tailwind v4's postcss inlines any
+ * @import into this file without rebasing url(./files/…), so the woff2 assets
+ * are never emitted and every font request 404s — which wedges the boot
+ * screen's document.fonts.load() on WebKitGTK.
+ */
 @import 'tailwindcss';
 @import 'tw-animate-css';
 


### PR DESCRIPTION
## Summary

- **Fonts**: Inter and JetBrains Mono move from CSS `@import` lines to bundled `@fontsource` modules imported as JS (`packages/studio/src/fonts.ts`, exported as `@dora/studio/fonts`). Tailwind's postcss plugin inlines `@import`s without rebasing `url()` assets, which dropped the woff2 files from the build and broke font rendering under the desktop content-security policy.
- **Loading shell**: the lazy-view `ViewLoadingShell` gets per-view icons and structure, so switching to a not-yet-mounted view no longer flashes a generic spinner.
- Small orm-cockpit panel/migration-status polish; the marketing in-browser app page imports the shared fonts module.

## Verification

- `bun run --cwd packages/studio typecheck` and `bun run test:desktop` (1089) green on this branch

## Summary by Sourcery

Self-host studio fonts reliably and replace generic lazy-view loading feedback with view-specific shells.

New Features:
- Bundle Inter and JetBrains Mono fonts through a shared studio font entry point for reliable self-hosted rendering.
- Provide view-specific loading shells for the ORM cockpit and schema-diff workflows to prevent generic loading flashes.

Bug Fixes:
- Fix missing bundled font assets that caused font rendering failures under the desktop content-security policy.

Enhancements:
- Polish ORM cockpit loading states and include the ORM cockpit in workspace view loading behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Inter and JetBrains Mono font support across the application.
  - Added tailored loading placeholders for the Schema Diff view, including migration and content sections.
  - Improved loading labels so the Schema Diff view is identified correctly.

- **Bug Fixes**
  - Replaced generic spinners with contextual skeleton loading states during schema analysis, linking, and migration loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->